### PR TITLE
refactor: build statements from `GoExpressionNode`

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -3,10 +3,9 @@ use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
 use crate::Planner;
-use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
 use crate::names::go_name;
-use crate::plan::bodies::{LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign};
 use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::GoExpression;
 
@@ -149,18 +148,15 @@ impl CoercionPlan {
                 let type_name = planner.use_go_type(&ty);
                 GoExpression::conversion(type_name, value)
             }
-            Self::Layout(bridge) => {
-                let bridged = planner.plan_layout_bridge(&mut statements, value.as_str(), &bridge);
-                GoExpression::opaque(bridged)
-            }
+            Self::Layout(bridge) => planner.plan_layout_bridge(&mut statements, value, &bridge),
             Self::RebuildArray {
                 array_type,
                 element,
-            } => planner.plan_array_rebuild(&mut statements, value.as_str(), &array_type, *element),
+            } => planner.plan_array_rebuild(&mut statements, value, &array_type, *element),
             Self::RebuildTuple {
                 slot_types,
                 elements,
-            } => planner.plan_tuple_rebuild(&mut statements, value.as_str(), &slot_types, elements),
+            } => planner.plan_tuple_rebuild(&mut statements, value, &slot_types, elements),
         };
         (statements, value)
     }
@@ -169,7 +165,7 @@ impl CoercionPlan {
 impl Planner<'_> {
     pub(crate) fn apply_type_coercion(
         &mut self,
-        output: &mut String,
+        statements: &mut Vec<LoweredStatement>,
         target_ty: Option<&Type>,
         expression: &Expression,
         emitted: GoExpression,
@@ -179,14 +175,14 @@ impl Planner<'_> {
         };
         let coercion = self.value_slot_coercion(expression, target);
         let (setup, value) = coercion.lower(self, emitted);
-        output.push_str(&Renderer.render_setup(&setup));
+        statements.extend(setup);
         value
     }
 
     fn plan_array_rebuild(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: &str,
+        value: GoExpression,
         array_type: &Type,
         element: CoercionPlan,
     ) -> GoExpression {
@@ -202,18 +198,23 @@ impl Planner<'_> {
 
         let index = self.fresh_var(Some("i"));
         self.declare(&index);
-        let element_read = GoExpression::index(
-            GoExpression::name(source.clone()),
-            GoExpression::name(index.clone()),
-        );
+        let element_read = GoExpression::index(source.clone(), GoExpression::name(index.clone()));
         let (mut body, coerced) = element.lower(self, element_read);
-        body.push(LoweredStatement::RawGo(format!(
-            "{output}[{index}] = {coerced}\n"
-        )));
+        body.push(assign(
+            GoExpression::index(
+                GoExpression::name(output.clone()),
+                GoExpression::name(index.clone()),
+            ),
+            coerced,
+        ));
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
             kind: LoopKind::Generated { label: None },
-            header: format!("for {index} := range {source} {{\n"),
+            header: LoopHeader::Range {
+                key: Some(index),
+                value: None,
+                iterable: source,
+            },
             body: LoweredBlock { statements: body },
         }));
         GoExpression::name(output)
@@ -222,7 +223,7 @@ impl Planner<'_> {
     fn plan_tuple_rebuild(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: &str,
+        value: GoExpression,
         slot_types: &[Type],
         elements: Vec<CoercionPlan>,
     ) -> GoExpression {
@@ -231,8 +232,7 @@ impl Planner<'_> {
         let mut arguments = Vec::with_capacity(elements.len());
         for (index, element) in elements.into_iter().enumerate() {
             let field = TUPLE_FIELDS.get(index).expect("oversize tuple arity");
-            let slot_read =
-                GoExpression::selector(GoExpression::name(source.clone()), field.to_string());
+            let slot_read = GoExpression::selector(source.clone(), field.to_string());
             let (element_setup, coerced) = element.lower(self, slot_read);
             statements.extend(element_setup);
             arguments.push(coerced);

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -1,7 +1,6 @@
 use syntax::types::Type;
 
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::tuple_element_types;
 use crate::calls::go_interop::WrapperTarget;
@@ -10,53 +9,55 @@ use crate::control_flow::fallible::{
     OPTION_SOME_TAG, PARTIAL_ERR_TAG, PARTIAL_OK_TAG, RESULT_OK_TAG,
 };
 use crate::control_flow::propagation::plain_return;
-use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, ReturnForm};
+use crate::plan::bodies::{
+    Definition, ElseArm, IfPlan, LoweredBlock, LoweredStatement, ReturnForm, define, define_many,
+};
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
-use crate::write_line;
 use syntax::ast::Expression;
 use syntax::parse::TUPLE_FIELDS;
 
 /// A bare `return v0, v1, ...` statement leaf.
-pub(crate) fn multi_value_return(values: Vec<String>) -> LoweredStatement {
+pub(crate) fn multi_value_return(values: Vec<GoExpression>) -> LoweredStatement {
     LoweredStatement::Return(ReturnForm::Multi { values })
 }
 
 /// An `if <condition> { <setup...> return <then_values...> }` tag-check leaf (no else).
 pub(crate) fn tag_check(
-    condition: String,
+    condition: GoExpression,
     setup: Vec<LoweredStatement>,
-    then_values: Vec<String>,
+    then_values: Vec<GoExpression>,
+) -> LoweredStatement {
+    tag_check_with_initializer(None, condition, setup, then_values)
+}
+
+pub(crate) fn tag_check_with_initializer(
+    initializer: Option<Definition>,
+    condition: GoExpression,
+    setup: Vec<LoweredStatement>,
+    then_values: Vec<GoExpression>,
 ) -> LoweredStatement {
     let mut statements = setup;
     statements.push(multi_value_return(then_values));
     LoweredStatement::If(IfPlan {
         condition_setup: Vec::new(),
+        initializer,
         condition,
         then_body: LoweredBlock { statements },
         else_arm: ElseArm::None,
     })
 }
 
-/// Render a lowered tagged-return destructure as Go text, for closure/value
-/// contexts (adapters) that embed it in a string body rather than a statement
-/// block.
-pub(crate) fn render_lowered_result_return(
-    planner: &mut Planner,
-    output: &mut String,
-    result_value: &str,
-    return_ty: &Type,
-    shape: &CallableReturnAbi,
-) {
-    let statements = emit_lowered_result_return(planner, result_value, return_ty, shape);
-    let block = LoweredBlock { statements };
-    Renderer.render_lowered_block(output, &block);
+fn has_tag(value: &GoExpression, tag: &str) -> GoExpression {
+    GoExpression::binary(
+        GoExpression::selector(value.clone(), "Tag".to_string()),
+        "==",
+        GoExpression::name(tag.to_string()),
+    )
 }
 
-/// Idiomatic Go zero (`0`, `""`, `nil`, ...) for a lowered failure slot.
-fn lowered_zero(planner: &mut Planner, ok_ty: &Type) -> String {
-    let (zero, packages) = planner.zero_value(ok_ty);
-    planner.require_packages(&packages);
-    zero
+fn field(value: &GoExpression, field: &str) -> GoExpression {
+    GoExpression::selector(value.clone(), field.to_string())
 }
 
 /// The lowered Go-return values for an `Err`-with-payload failure, in the
@@ -65,14 +66,14 @@ pub(crate) fn lowered_err_values(
     planner: &mut Planner,
     shape: &CallableReturnAbi,
     return_ty: &Type,
-    err_expr: &str,
-) -> Vec<String> {
+    err_expr: GoExpression,
+) -> Vec<GoExpression> {
     match shape {
-        CallableReturnAbi::BareError => vec![err_expr.to_string()],
+        CallableReturnAbi::BareError => vec![err_expr],
         CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
             let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
             let mut values = lowered_payload_zeros(planner, shape, &ok_ty);
-            values.push(err_expr.to_string());
+            values.push(err_expr);
             values
         }
         CallableReturnAbi::Tuple { .. } => {
@@ -85,20 +86,20 @@ pub(crate) fn lowered_err_values(
 }
 
 /// The lowered Go-return values for a success-constructor payload, in the
-/// enclosing function's lowered shape (e.g. `[ok, "nil"]`). `payload` holds
+/// enclosing function's lowered shape (e.g. `[ok, nil]`). `payload` holds
 /// the already-lowered payload slots.
 pub(crate) fn lowered_ok_values(
     shape: &CallableReturnAbi,
-    mut payload: Vec<String>,
-) -> Vec<String> {
+    mut payload: Vec<GoExpression>,
+) -> Vec<GoExpression> {
     match shape {
-        CallableReturnAbi::BareError => vec!["nil".to_string()],
+        CallableReturnAbi::BareError => vec![GoExpression::nil()],
         CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
-            payload.push("nil".to_string());
+            payload.push(GoExpression::nil());
             payload
         }
         CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
-            payload.push("true".to_string());
+            payload.push(GoExpression::literal("true".to_string()));
             payload
         }
         CallableReturnAbi::Option(OptionReturnAbi::Nullable) => payload,
@@ -114,20 +115,20 @@ pub(crate) fn lowered_ok_values(
 }
 
 /// The lowered Go-return values for a bare `None`, in an Option-shaped fn's
-/// lowered shape (e.g. `[zero, "false"]`).
+/// lowered shape (e.g. `[zero, false]`).
 pub(crate) fn lowered_none_values(
     planner: &mut Planner,
     shape: &CallableReturnAbi,
     return_ty: &Type,
-) -> Vec<String> {
+) -> Vec<GoExpression> {
     match shape {
         CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
             let inner = planner.facts.peel_alias(return_ty).ok_type();
             let mut values = lowered_payload_zeros(planner, shape, &inner);
-            values.push("false".to_string());
+            values.push(GoExpression::literal("false".to_string()));
             values
         }
-        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec!["nil".to_string()],
+        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec![GoExpression::nil()],
         _ => unreachable!("only Option's `None` lacks a payload"),
     }
 }
@@ -136,8 +137,8 @@ pub(crate) fn lowered_payload_values(
     planner: &mut Planner,
     shape: &CallableReturnAbi,
     payload_ty: &Type,
-    payload_expr: &str,
-) -> (Vec<LoweredStatement>, Vec<String>) {
+    payload_expr: GoExpression,
+) -> (Vec<LoweredStatement>, Vec<GoExpression>) {
     if shape.has_flattened_payload() {
         let mut statements = Vec::new();
         let tuple = planner.stable_source(&mut statements, "tup", payload_expr);
@@ -145,7 +146,7 @@ pub(crate) fn lowered_payload_values(
         statements.extend(projection);
         (statements, values)
     } else {
-        (Vec::new(), vec![payload_expr.to_string()])
+        (Vec::new(), vec![payload_expr])
     }
 }
 
@@ -153,20 +154,20 @@ fn lowered_payload_zeros(
     planner: &mut Planner,
     shape: &CallableReturnAbi,
     payload_ty: &Type,
-) -> Vec<String> {
+) -> Vec<GoExpression> {
     if shape.has_flattened_payload() {
         tuple_element_types(&planner.facts.peel_alias(payload_ty))
             .iter()
             .map(|slot_ty| {
                 if planner.facts.is_nullable_option(slot_ty) {
-                    "nil".to_string()
+                    GoExpression::nil()
                 } else {
-                    lowered_zero(planner, slot_ty)
+                    planner.zero_value_expression(slot_ty)
                 }
             })
             .collect()
     } else {
-        vec![lowered_zero(planner, payload_ty)]
+        vec![planner.zero_value_expression(payload_ty)]
     }
 }
 
@@ -174,7 +175,7 @@ fn lowered_payload_zeros(
 /// as structured tag-check `IfPlan`s and `Return` leaves.
 pub(crate) fn emit_lowered_result_return(
     planner: &mut Planner,
-    result_value: &str,
+    result_value: &GoExpression,
     return_ty: &Type,
     shape: &CallableReturnAbi,
 ) -> Vec<LoweredStatement> {
@@ -184,10 +185,10 @@ pub(crate) fn emit_lowered_result_return(
     match shape {
         CallableReturnAbi::BareError | CallableReturnAbi::Result { .. } => {
             let (ok_setup, ok_payload) =
-                lowered_payload_values(planner, shape, &ok_ty(), &format!("{p}.OkVal"));
+                lowered_payload_values(planner, shape, &ok_ty(), field(p, "OkVal"));
             vec![
                 tag_check(
-                    format!("{p}.Tag == {RESULT_OK_TAG}"),
+                    has_tag(p, RESULT_OK_TAG),
                     ok_setup,
                     lowered_ok_values(shape, ok_payload),
                 ),
@@ -195,27 +196,27 @@ pub(crate) fn emit_lowered_result_return(
                     planner,
                     shape,
                     return_ty,
-                    &format!("{p}.ErrVal"),
+                    field(p, "ErrVal"),
                 )),
             ]
         }
         CallableReturnAbi::Partial { .. } => {
             let ok_ty = ok_ty();
-            let ok_access = format!("{p}.OkVal");
-            let (ok_setup, ok_payload) = lowered_payload_values(planner, shape, &ok_ty, &ok_access);
+            let (ok_setup, ok_payload) =
+                lowered_payload_values(planner, shape, &ok_ty, field(p, "OkVal"));
             let (both_setup, mut both_values) =
-                lowered_payload_values(planner, shape, &ok_ty, &ok_access);
-            both_values.push(format!("{p}.ErrVal"));
+                lowered_payload_values(planner, shape, &ok_ty, field(p, "OkVal"));
+            both_values.push(field(p, "ErrVal"));
             let mut statements = vec![
                 tag_check(
-                    format!("{p}.Tag == {PARTIAL_OK_TAG}"),
+                    has_tag(p, PARTIAL_OK_TAG),
                     ok_setup,
                     lowered_ok_values(shape, ok_payload),
                 ),
                 tag_check(
-                    format!("{p}.Tag == {PARTIAL_ERR_TAG}"),
+                    has_tag(p, PARTIAL_ERR_TAG),
                     Vec::new(),
-                    lowered_err_values(planner, shape, return_ty, &format!("{p}.ErrVal")),
+                    lowered_err_values(planner, shape, return_ty, field(p, "ErrVal")),
                 ),
             ];
             statements.extend(both_setup);
@@ -224,10 +225,10 @@ pub(crate) fn emit_lowered_result_return(
         }
         CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. } | OptionReturnAbi::Nullable) => {
             let (some_setup, some_payload) =
-                lowered_payload_values(planner, shape, &ok_ty(), &format!("{p}.SomeVal"));
+                lowered_payload_values(planner, shape, &ok_ty(), field(p, "SomeVal"));
             vec![
                 tag_check(
-                    format!("{p}.Tag == {OPTION_SOME_TAG}"),
+                    has_tag(p, OPTION_SOME_TAG),
                     some_setup,
                     lowered_ok_values(shape, some_payload),
                 ),
@@ -247,7 +248,7 @@ pub(crate) fn emit_lowered_result_return(
 
 fn emit_lowered_tuple_return(
     planner: &mut Planner,
-    result_value: &str,
+    result_value: &GoExpression,
     return_ty: &Type,
 ) -> Vec<LoweredStatement> {
     let (mut statements, fields) = lowered_tuple_values(planner, result_value, return_ty);
@@ -259,19 +260,19 @@ fn emit_lowered_tuple_return(
 /// nullable-Option slot to its bare Go nilable.
 fn lowered_tuple_values(
     planner: &mut Planner,
-    tuple_value: &str,
+    tuple_value: &GoExpression,
     tuple_ty: &Type,
-) -> (Vec<LoweredStatement>, Vec<String>) {
+) -> (Vec<LoweredStatement>, Vec<GoExpression>) {
     let slot_tys = tuple_element_types(&planner.facts.peel_alias(tuple_ty));
     let mut statements = Vec::new();
     let fields = slot_tys
         .iter()
         .enumerate()
         .map(|(i, slot_ty)| {
-            let raw = format!("{}.{}", tuple_value, TUPLE_FIELDS[i]);
+            let raw = field(tuple_value, TUPLE_FIELDS[i]);
             if planner.facts.is_nullable_option(slot_ty) {
                 let inner = planner.use_go_type(&slot_ty.ok_type());
-                planner.plan_option_projection(&mut statements, &raw, "unwrap", &inner, false)
+                planner.plan_option_projection(&mut statements, raw, "unwrap", &inner, false)
             } else {
                 raw
             }
@@ -285,7 +286,7 @@ pub(crate) fn lowered_tuple_literal_values(
     planner: &mut Planner,
     elements: &[Expression],
     tuple_ty: &Type,
-) -> (Vec<LoweredStatement>, Vec<String>) {
+) -> (Vec<LoweredStatement>, Vec<GoExpression>) {
     let slot_tys = tuple_element_types(&planner.facts.peel_alias(tuple_ty));
     let stages: Vec<ValuePlan> = elements
         .iter()
@@ -301,58 +302,57 @@ pub(crate) fn lowered_tuple_literal_values(
     let mut statements = sequenced.setup;
     let parts =
         planner.coerce_elements_to_slots(&mut statements, elements, sequenced.values, &slot_tys);
-    (
-        statements,
-        parts.iter().map(GoExpression::rendered).collect(),
-    )
+    (statements, parts)
 }
 
 impl Planner<'_> {
     /// Wrap a callable's physical Go result into the Lisette-visible value.
     pub(crate) fn lower_abi_to_tagged(
         &mut self,
-        raw_value: &str,
+        raw_value: GoExpression,
         abi: &CallableReturnAbi,
         result_ty: &Type,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         if abi.is_passthrough() {
-            return (Vec::new(), raw_value.to_string());
+            return (Vec::new(), raw_value);
         }
         if let CallableReturnAbi::Tuple { arity } = abi {
             let mut statements = Vec::new();
             let temps = self.create_temp_vars("ret", *arity);
-            statements.push(LoweredStatement::RawGo(format!(
-                "{} := {}\n",
-                temps.join(", "),
-                raw_value
-            )));
+            statements.push(define_many(temps.clone(), raw_value));
             let slot_tys = tuple_element_types(&self.facts.peel_alias(result_ty));
-            let values: Vec<String> = temps
-                .iter()
+            let values: Vec<GoExpression> = temps
+                .into_iter()
                 .enumerate()
                 .map(|(index, value)| {
-                    slot_tys
+                    let value = GoExpression::name(value);
+                    match slot_tys
                         .get(index)
                         .filter(|slot_ty| self.facts.is_nullable_option(slot_ty))
-                        .map(|slot_ty| {
+                    {
+                        Some(slot_ty) => {
                             self.plan_nil_check_option_wrap(&mut statements, value, slot_ty)
-                        })
-                        .unwrap_or_else(|| value.clone())
+                        }
+                        None => value,
+                    }
                 })
                 .collect();
-            let tuple = self.plan_tuple_from_vars(&mut statements, &values, result_ty);
+            let tuple = self.plan_tuple_from_vars(&mut statements, values);
             return (statements, tuple);
         }
 
         let (wrap, outcome) =
             self.lower_abi_wrapping(raw_value, abi, result_ty, WrapperTarget::FreshSlot);
-        (wrap, outcome.expect("wrapper produced no slot"))
+        (
+            wrap,
+            GoExpression::name(outcome.expect("wrapper produced no slot")),
+        )
     }
 
     /// Wrap a callable's physical Go result and return it in each wrapper branch.
     pub(crate) fn lower_abi_to_tagged_return(
         &mut self,
-        raw_value: &str,
+        raw_value: GoExpression,
         abi: &CallableReturnAbi,
         result_ty: &Type,
     ) -> Vec<LoweredStatement> {
@@ -372,9 +372,9 @@ impl Planner<'_> {
 /// return shape. Returns `(go_return_type, body)`.
 fn emit_return_adapter(
     planner: &mut Planner,
-    inner_call: &str,
+    inner_call: GoExpression,
     lisette_return_type: &Type,
-) -> Option<(String, String)> {
+) -> Option<(String, Vec<LoweredStatement>)> {
     let return_type = lisette_return_type;
 
     if return_type.is_result() {
@@ -435,16 +435,21 @@ fn emit_return_adapter(
 /// Returns `(go_return_type, body)` for a tagged result destructured into `shape`.
 fn emit_shape_return_adapter(
     planner: &mut Planner,
-    inner_call: &str,
+    inner_call: GoExpression,
     return_type: &Type,
     shape: &CallableReturnAbi,
     prefix: &str,
-) -> (String, String) {
+) -> (String, Vec<LoweredStatement>) {
     let go_return = planner.render_lowered_return_ty(shape, return_type);
     let result = planner.fresh_var(Some(prefix));
     planner.declare(&result);
-    let mut body = format!("{result} := {inner_call}\n");
-    render_lowered_result_return(planner, &mut body, &result, return_type, shape);
+    let mut body = vec![define(result.clone(), inner_call)];
+    body.extend(emit_lowered_result_return(
+        planner,
+        &GoExpression::name(result),
+        return_type,
+        shape,
+    ));
     (go_return, body)
 }
 
@@ -453,9 +458,9 @@ fn emit_shape_return_adapter(
 /// adapter-style unwrapping.
 fn emit_tuple_return_adapter(
     planner: &mut Planner,
-    inner_call: &str,
+    inner_call: GoExpression,
     return_type: &Type,
-) -> Option<(String, String)> {
+) -> Option<(String, Vec<LoweredStatement>)> {
     let tuple_params: Vec<Type> = match return_type {
         Type::Tuple(elements) => elements.clone(),
         Type::Nominal { params, .. } => params.clone(),
@@ -465,20 +470,28 @@ fn emit_tuple_return_adapter(
     let tup = planner.fresh_var(Some("tup"));
     planner.declare(&tup);
 
-    let mut body = format!("{tup} := {inner_call}\n");
+    let mut body = vec![define(tup.clone(), inner_call)];
+    let tup = GoExpression::name(tup);
     let mut ret_types: Vec<String> = Vec::with_capacity(arity);
-    let mut field_exprs: Vec<String> = Vec::with_capacity(arity);
+    let mut field_exprs: Vec<GoExpression> = Vec::with_capacity(arity);
 
     for (i, slot_ty) in tuple_params.iter().enumerate() {
-        let raw_field = format!("{tup}.{}", TUPLE_FIELDS[i]);
-        match emit_return_adapter(planner, &raw_field, slot_ty) {
+        let raw_field = field(&tup, TUPLE_FIELDS[i]);
+        match emit_return_adapter(planner, raw_field.clone(), slot_ty) {
             Some((inner_ret, inner_body)) => {
                 let sub = planner.fresh_var(Some("sub"));
                 planner.declare(&sub);
-                body.push_str(&format!(
-                    "{sub} := func() {inner_ret} {{\n{inner_body}}}()\n"
+                body.push(define(
+                    sub.clone(),
+                    GoExpression::immediate_call(
+                        inner_ret.clone(),
+                        LoweredBlock {
+                            statements: inner_body,
+                        },
+                        FunctionLiteralLayout::MultiLine,
+                    ),
                 ));
-                field_exprs.push(sub);
+                field_exprs.push(GoExpression::name(sub));
                 ret_types.push(inner_ret);
             }
             None => {
@@ -488,7 +501,7 @@ fn emit_tuple_return_adapter(
         }
     }
 
-    body.push_str(&format!("return {}\n", field_exprs.join(", ")));
+    body.push(multi_value_return(field_exprs));
     Some((format!("({})", ret_types.join(", ")), body))
 }
 
@@ -498,29 +511,29 @@ fn emit_tuple_return_adapter(
 pub(crate) fn emit_lisette_callback_wrapper(
     planner: &mut Planner,
     setup: &mut Vec<LoweredStatement>,
-    fn_value: &str,
+    fn_value: GoExpression,
     fn_type: &Type,
-) -> String {
+) -> GoExpression {
     let Type::Function(f) = fn_type else {
-        return fn_value.to_string();
+        return fn_value;
     };
     let params = &f.params;
 
     let return_type = f.return_type.as_ref();
 
-    let (param_strs, arg_names) = planner.build_wrapper_params(params);
+    let (param_strs, arguments) = planner.build_wrapper_params(params);
     let params_str = param_strs.join(", ");
 
-    let cb_var = planner.hoist_tmp_value_statement(setup, "cb", fn_value);
+    let cb_var = planner.hoist_tmp_value_statement(setup, "cb", fn_value.clone());
 
-    let mut prelude = String::new();
-    let inner_args: Vec<String> = arg_names
-        .iter()
+    let mut prelude = Vec::new();
+    let inner_args: Vec<GoExpression> = arguments
+        .into_iter()
         .zip(params.iter())
-        .map(|(name, param)| lower_arg_to_tagged(planner, &mut prelude, name, &param.ty))
+        .map(|(argument, param)| lower_arg_to_tagged(planner, &mut prelude, argument, &param.ty))
         .collect();
 
-    let call_str = format!("{}({})", cb_var, inner_args.join(", "));
+    let call = GoExpression::call(GoExpression::name(cb_var), inner_args);
 
     // Option<fn> adaptation only fires in interface-method shims. Here
     // a closure-valued Option means the caller owns the nil check.
@@ -529,15 +542,22 @@ pub(crate) fn emit_lisette_callback_wrapper(
         && let Some(inner) = ps.first()
         && matches!(inner.unwrap_forall(), Type::Function(_))
     {
-        return fn_value.to_string();
+        return fn_value;
     }
 
-    let adapter = emit_return_adapter(planner, &call_str, return_type);
-    let Some((go_ret, body)) = adapter else {
-        return fn_value.to_string();
+    let Some((go_ret, body)) = emit_return_adapter(planner, call, return_type) else {
+        return fn_value;
     };
 
-    format!("func({params_str}) {go_ret} {{\n{prelude}{body}}}")
+    prelude.extend(body);
+    GoExpression::function_literal(
+        params_str,
+        go_ret,
+        LoweredBlock {
+            statements: prelude,
+        },
+        FunctionLiteralLayout::MultiLine,
+    )
 }
 
 /// Wrap a lowered-return fn into a closure re-presenting the return in
@@ -545,36 +565,36 @@ pub(crate) fn emit_lisette_callback_wrapper(
 /// (arg, target) shape pair works.
 pub(crate) fn emit_fn_arg_shape_adapter(
     planner: &mut Planner,
-    output: &mut String,
-    fn_value: &str,
+    setup: &mut Vec<LoweredStatement>,
+    fn_value: GoExpression,
     arg_fn_type: &Type,
     arg_abi: &CallableReturnAbi,
     target_abi: &CallableReturnAbi,
-) -> Option<String> {
+) -> Option<GoExpression> {
     let params = arg_fn_type.get_function_params()?;
     let arg_ret = arg_fn_type.get_function_ret()?;
 
-    let cb_var = planner.hoist_tmp_value(output, "cb", fn_value);
-    let (param_strs, arg_names) = planner.build_wrapper_params(params);
-    let inner_call = format!("{}({})", cb_var, arg_names.join(", "));
+    let cb_var = planner.hoist_tmp_value_statement(setup, "cb", fn_value);
+    let (param_strs, arguments) = planner.build_wrapper_params(params);
+    let inner_call = GoExpression::call(GoExpression::name(cb_var), arguments);
 
     let outer_ret = planner.render_lowered_return_ty(target_abi, arg_ret);
 
     let body = if target_abi.is_passthrough() {
-        let statements = planner.lower_abi_to_tagged_return(&inner_call, arg_abi, arg_ret);
-        Renderer.render_setup(&statements)
+        planner.lower_abi_to_tagged_return(inner_call, arg_abi, arg_ret)
     } else {
-        let (wrap_statements, tagged) = planner.lower_abi_to_tagged(&inner_call, arg_abi, arg_ret);
-        let mut body = Renderer.render_setup(&wrap_statements);
-        render_lowered_result_return(planner, &mut body, &tagged, arg_ret, target_abi);
+        let (mut body, tagged) = planner.lower_abi_to_tagged(inner_call, arg_abi, arg_ret);
+        body.extend(emit_lowered_result_return(
+            planner, &tagged, arg_ret, target_abi,
+        ));
         body
     };
 
-    Some(format!(
-        "func({}) {} {{\n{}}}",
+    Some(GoExpression::function_literal(
         param_strs.join(", "),
         outer_ret,
-        body
+        LoweredBlock { statements: body },
+        FunctionLiteralLayout::MultiLine,
     ))
 }
 
@@ -583,39 +603,38 @@ pub(crate) fn emit_fn_arg_shape_adapter(
 /// lowered return.
 pub(crate) fn lower_arg_to_tagged(
     planner: &mut Planner,
-    prelude: &mut String,
-    arg_name: &str,
+    prelude: &mut Vec<LoweredStatement>,
+    argument: GoExpression,
     param_ty: &Type,
-) -> String {
+) -> GoExpression {
     let unwrapped = param_ty.unwrap_forall();
     let Type::Function(f) = unwrapped else {
-        return arg_name.to_string();
+        return argument;
     };
     let inner_params = &f.params;
     let inner_ret = f.return_type.as_ref();
-    let Some(shape) = planner.classify_direct_emission(inner_ret) else {
-        return arg_name.to_string();
+    let Some(abi) = planner.classify_direct_emission(inner_ret) else {
+        return argument;
     };
-    let abi = shape;
 
-    let (inner_param_strs, inner_arg_names) = planner.build_wrapper_params(inner_params);
-    let inner_call = format!("{}({})", arg_name, inner_arg_names.join(", "));
+    let (inner_param_strs, inner_arguments) = planner.build_wrapper_params(inner_params);
+    let inner_call = GoExpression::call(argument, inner_arguments);
     let tagged_ret = planner.use_go_type(inner_ret);
 
-    let wrap_statements = planner.lower_abi_to_tagged_return(&inner_call, &abi, inner_ret);
-    let body = Renderer.render_setup(&wrap_statements);
+    let body = planner.lower_abi_to_tagged_return(inner_call, &abi, inner_ret);
 
     let tagged_var = planner.fresh_var(Some("tagged"));
     planner.declare(&tagged_var);
-    write_line!(
-        prelude,
-        "{} := func({}) {} {{\n{}}}",
-        tagged_var,
-        inner_param_strs.join(", "),
-        tagged_ret,
-        body
-    );
-    tagged_var
+    prelude.push(define(
+        tagged_var.clone(),
+        GoExpression::function_literal(
+            inner_param_strs.join(", "),
+            tagged_ret,
+            LoweredBlock { statements: body },
+            FunctionLiteralLayout::MultiLine,
+        ),
+    ));
+    GoExpression::name(tagged_var)
 }
 
 /// Tail return for packed `Partial` and `Tuple` ABIs. A flattened `Partial`
@@ -647,7 +666,9 @@ fn lowered_tail_fallback(
         .lower_value(expression, ExpressionContext::value())
         .into_parts();
     let value = match hoist_hint {
-        Some(hint) => planner.hoist_tmp_value_statement(&mut statements, hint, &value),
+        Some(hint) => {
+            GoExpression::name(planner.hoist_tmp_value_statement(&mut statements, hint, value))
+        }
         None => value,
     };
     statements.extend(emit_lowered_result_return(
@@ -701,7 +722,7 @@ fn emit_lowered_partial_tail(
                     .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
-                multi_value_return(vec![v, "nil".to_string()])
+                multi_value_return(vec![v, GoExpression::nil()])
             }
             "Err" => {
                 let (setup, e) = planner
@@ -709,7 +730,7 @@ fn emit_lowered_partial_tail(
                     .into_parts();
                 statements.extend(setup);
                 let ok_ty = planner.facts.peel_alias(&return_ty).ok_type();
-                multi_value_return(vec![lowered_zero(planner, &ok_ty), e])
+                multi_value_return(vec![planner.zero_value_expression(&ok_ty), e])
             }
             "Both" => {
                 let (setup_v, v) = planner
@@ -778,8 +799,8 @@ fn lower_nullable_slot_value(
     let value = planner.lower_value(expression, ExpressionContext::value());
     let inner = planner.use_go_type(&slot_ty.ok_type());
     value.map_expression_as_computed(|setup, value| {
-        let projected =
-            planner.plan_option_projection(setup, value.as_str(), "unwrap", &inner, false);
-        GoExpression::name(projected).with_deferred_evaluation(true)
+        planner
+            .plan_option_projection(setup, value, "unwrap", &inner, false)
+            .with_deferred_evaluation(true)
     })
 }

--- a/crates/emit/src/calls/bounds.rs
+++ b/crates/emit/src/calls/bounds.rs
@@ -1,14 +1,14 @@
 use super::NativeMethodCall;
-use super::comma_ok::parenthesize_prefixed;
+use super::comma_ok::parenthesize_prefixed_expression;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::values::CaptureBoundary;
+use crate::plan::values::{CaptureBoundary, GoExpression};
 
 pub(crate) struct BoundsCheckedIndex {
-    pub element: String,
-    pub in_bounds: String,
-    pub out_of_bounds: String,
+    pub element: GoExpression,
+    pub in_bounds: GoExpression,
+    pub out_of_bounds: GoExpression,
 }
 
 impl Planner<'_> {
@@ -30,27 +30,46 @@ impl Planner<'_> {
             CaptureBoundary::SiblingSequence,
             "arg",
         );
-        let (setup, mut values) = sequenced.into_rendered();
+        let setup = sequenced.setup;
+        let mut values = sequenced.values;
         let index = values.pop().expect("index operand");
         let mut receiver = values.pop().expect("receiver operand");
         if call.receiver.get_type().is_ref() {
-            receiver = format!("*{receiver}");
+            receiver = GoExpression::dereference(receiver);
         }
-        let length = format!("len({receiver})");
-        let element = format!("{}[{index}]", parenthesize_prefixed(receiver));
-        let (in_bounds, out_of_bounds) = if index == "0" {
-            (format!("{length} > 0"), format!("{length} == 0"))
-        } else if index.parse::<u64>().is_ok() {
+        let length = || {
+            GoExpression::call(
+                GoExpression::name("len".to_string()),
+                vec![receiver.clone()],
+            )
+        };
+        let literal = |text: &str| GoExpression::literal(text.to_string());
+        let (in_bounds, out_of_bounds) = if index.as_str() == "0" {
             (
-                format!("{length} > {index}"),
-                format!("{length} <= {index}"),
+                GoExpression::binary(length(), ">", literal("0")),
+                GoExpression::binary(length(), "==", literal("0")),
+            )
+        } else if index.as_str().parse::<u64>().is_ok() {
+            (
+                GoExpression::binary(length(), ">", index.clone()),
+                GoExpression::binary(length(), "<=", index.clone()),
             )
         } else {
             (
-                format!("{index} >= 0 && {index} < {length}"),
-                format!("{index} < 0 || {index} >= {length}"),
+                GoExpression::binary(
+                    GoExpression::binary(index.clone(), ">=", literal("0")),
+                    "&&",
+                    GoExpression::binary(index.clone(), "<", length()),
+                ),
+                GoExpression::binary(
+                    GoExpression::binary(index.clone(), "<", literal("0")),
+                    "||",
+                    GoExpression::binary(index.clone(), ">=", length()),
+                ),
             )
         };
+        let element =
+            GoExpression::index(parenthesize_prefixed_expression(receiver.clone()), index);
         (
             setup,
             BoundsCheckedIndex {

--- a/crates/emit/src/calls/clone.rs
+++ b/crates/emit/src/calls/clone.rs
@@ -2,15 +2,13 @@ use syntax::parse::TUPLE_FIELDS;
 use syntax::types::{CompoundKind, Type};
 
 use crate::Planner;
+use crate::control_flow::propagation::plain_return;
 use crate::names::go_name;
+use crate::plan::bodies::{LoweredBlock, LoweredStatement, assign};
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::GoExpression;
 
 impl Planner<'_> {
-    pub(crate) fn render_clone(&mut self, value: &str, ty: &Type) -> String {
-        self.clone_expression(GoExpression::opaque(value.to_string()), ty)
-            .rendered()
-    }
-
     pub(crate) fn clone_expression(&mut self, value: GoExpression, ty: &Type) -> GoExpression {
         let peeled = self.facts.peel_alias(ty);
         let (function, closure) = match &peeled {
@@ -51,49 +49,64 @@ impl Planner<'_> {
             _ => return value,
         };
         let mut arguments = vec![value];
-        arguments.extend(closure.map(GoExpression::opaque));
+        arguments.extend(closure);
         GoExpression::call(GoExpression::name(function), arguments)
     }
 
-    fn element_clone(&mut self, ty: &Type) -> Option<String> {
+    fn element_clone(&mut self, ty: &Type) -> Option<GoExpression> {
         if !self.needs_clone(ty) {
             return None;
         }
         let peeled = self.facts.peel_alias(ty);
         let go_ty = self.use_go_type(ty);
+        let var = self.fresh_var(Some("e"));
+        let parameters = format!("{var} {go_ty}");
+        let element = GoExpression::name(var);
         match &peeled {
             Type::Tuple(elems) => {
-                let var = self.fresh_var(Some("e"));
-                let statements = self.tuple_clone_statements(&var, elems);
-                Some(format!(
-                    "func({var} {go_ty}) {go_ty} {{\n{}\nreturn {var}\n}}",
-                    statements.join("\n")
+                let mut statements = self.tuple_clone_statements(&element, elems);
+                statements.push(plain_return(element));
+                Some(GoExpression::function_literal(
+                    parameters,
+                    go_ty,
+                    LoweredBlock { statements },
+                    FunctionLiteralLayout::MultiLine,
                 ))
             }
             _ => {
-                let var = self.fresh_var(Some("e"));
-                let body = self.render_clone(&var, ty);
-                Some(format!("func({var} {go_ty}) {go_ty} {{ return {body} }}"))
+                let body = self.clone_expression(element, ty);
+                Some(GoExpression::function_literal(
+                    parameters,
+                    go_ty,
+                    LoweredBlock {
+                        statements: vec![plain_return(body)],
+                    },
+                    FunctionLiteralLayout::Inline,
+                ))
             }
         }
     }
 
-    fn tuple_clone_statements(&mut self, place: &str, elems: &[Type]) -> Vec<String> {
+    fn tuple_clone_statements(
+        &mut self,
+        place: &GoExpression,
+        elems: &[Type],
+    ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         for (index, elem) in elems.iter().enumerate() {
             let Some(field) = TUPLE_FIELDS.get(index) else {
                 break;
             };
-            let field_place = format!("{place}.{field}");
+            let field_place = GoExpression::selector(place.clone(), field.to_string());
             let peeled = self.facts.peel_alias(elem);
             match &peeled {
                 Type::Compound {
                     kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice | CompoundKind::Map,
                     ..
-                } => statements.push(format!(
-                    "{field_place} = {}",
-                    self.render_clone(&field_place, elem)
-                )),
+                } => {
+                    let clone = self.clone_expression(field_place.clone(), elem);
+                    statements.push(assign(field_place, clone));
+                }
                 Type::Tuple(inner) if self.needs_clone(elem) => {
                     statements.extend(self.tuple_clone_statements(&field_place, inner))
                 }

--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -1,15 +1,14 @@
 use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::calls::dispatch::extract_native_method_name;
-use crate::calls::go_interop::NilGuard;
+use crate::calls::go_interop::{NilGuard, is_nil, non_nil};
 use crate::context::expression::ExpressionContext;
 use crate::escape_reserved;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{Definition, LoweredStatement, define_many};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::values::GoExpression;
 use crate::state::scope::PairStatusKind;
 use crate::types::native::NativeGoType;
-use std::borrow::Cow;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -72,7 +71,12 @@ pub(crate) struct LoweredPair {
     success: PairSuccess,
     nil_guard: Option<NilGuard>,
     has_value_slot: bool,
-    initializer_call: Option<String>,
+    initializer_call: Option<GoExpression>,
+}
+
+pub(crate) struct PairCondition {
+    pub(crate) initializer: Option<Definition>,
+    pub(crate) condition: GoExpression,
 }
 
 impl LoweredPair {
@@ -86,28 +90,32 @@ impl LoweredPair {
         }
     }
 
-    fn binding(&self) -> String {
+    fn binding(&self) -> Vec<String> {
         match (self.has_value_slot, &self.value) {
-            (true, Some(value)) => format!("{value}, {}", self.status),
-            (true, None) => format!("_, {}", self.status),
-            (false, _) => self.status.clone(),
+            (true, Some(value)) => vec![value.clone(), self.status.clone()],
+            (true, None) => vec!["_".to_string(), self.status.clone()],
+            (false, _) => vec![self.status.clone()],
         }
     }
 
-    fn initializer(&self) -> Option<String> {
+    fn initializer(&self) -> Option<Definition> {
         let call = self.initializer_call.as_ref()?;
-        Some(format!("{} := {}", self.binding(), header_call(call)))
+        Some(Definition {
+            names: self.binding(),
+            value: header_call(call.clone()),
+        })
     }
 }
 
 /// Go reads a bare `T{` in an `if` header as the block, so such a receiver takes parentheses.
-pub(crate) fn header_call(call: &str) -> Cow<'_, str> {
-    let mut rest = call.trim_start_matches(['&', '*']);
+pub(crate) fn header_call(call: GoExpression) -> GoExpression {
+    let text = call.as_str();
+    let mut rest = text.trim_start_matches(['&', '*']);
     let type_name_end = rest
         .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == '.'))
         .unwrap_or(rest.len());
     if type_name_end == 0 {
-        return Cow::Borrowed(call);
+        return call;
     }
     rest = &rest[type_name_end..];
     if let Some(after_bracket) = rest.strip_prefix('[') {
@@ -121,14 +129,14 @@ pub(crate) fn header_call(call: &str) -> Cow<'_, str> {
             depth == 0
         });
         let Some((close, _)) = close else {
-            return Cow::Borrowed(call);
+            return call;
         };
         rest = &after_bracket[close + 1..];
     }
     if rest.starts_with('{') {
-        Cow::Owned(format!("({call})"))
+        GoExpression::parenthesized(call)
     } else {
-        Cow::Borrowed(call)
+        call
     }
 }
 
@@ -226,7 +234,7 @@ impl Planner<'_> {
     pub(crate) fn bind_pair(
         &mut self,
         statements: Vec<LoweredStatement>,
-        expression: String,
+        expression: GoExpression,
         slot: CommaOkValueSlot,
         kind: PairKind,
         status_hint: Option<&str>,
@@ -271,8 +279,8 @@ impl Planner<'_> {
         if opens_if {
             pair.initializer_call = Some(expression);
         } else {
-            let line = format!("{} := {expression}\n", pair.binding());
-            pair.statements.push(LoweredStatement::RawGo(line));
+            pair.statements
+                .push(define_many(pair.binding(), expression));
         }
         pair
     }
@@ -330,20 +338,21 @@ impl Planner<'_> {
         name
     }
 
-    pub(crate) fn pair_success_condition(&mut self, pair: &LoweredPair) -> String {
+    pub(crate) fn pair_success_condition(&mut self, pair: &LoweredPair) -> PairCondition {
         self.pair_condition(pair, true)
     }
 
-    pub(crate) fn pair_failure_condition(&mut self, pair: &LoweredPair) -> String {
+    pub(crate) fn pair_failure_condition(&mut self, pair: &LoweredPair) -> PairCondition {
         self.pair_condition(pair, false)
     }
 
-    fn pair_condition(&mut self, pair: &LoweredPair, success: bool) -> String {
+    fn pair_condition(&mut self, pair: &LoweredPair, success: bool) -> PairCondition {
+        let status = GoExpression::name(pair.status.clone());
         let status = match (pair.success, success) {
-            (PairSuccess::Truthy, true) => pair.status.clone(),
-            (PairSuccess::Truthy, false) => format!("!{}", pair.status),
-            (PairSuccess::Nil, true) => format!("{} == nil", pair.status),
-            (PairSuccess::Nil, false) => format!("{} != nil", pair.status),
+            (PairSuccess::Truthy, true) => status,
+            (PairSuccess::Truthy, false) => GoExpression::unary("!", status),
+            (PairSuccess::Nil, true) => is_nil(status),
+            (PairSuccess::Nil, false) => non_nil(status),
         };
         let condition = match pair.nil_guard {
             None => status,
@@ -351,22 +360,23 @@ impl Planner<'_> {
                 if guard.is_interface() {
                     self.require_stdlib();
                 }
-                let value = pair
-                    .value
-                    .as_deref()
-                    .expect("nil guard requires the value var");
+                let value = GoExpression::name(
+                    pair.value
+                        .clone()
+                        .expect("nil guard requires the value var"),
+                );
                 let nil_condition = if success {
                     guard.non_nil(value)
                 } else {
                     guard.is_nil(value)
                 };
                 let operator = if success { "&&" } else { "||" };
-                format!("{status} {operator} {nil_condition}")
+                GoExpression::binary(status, operator, nil_condition)
             }
         };
-        match pair.initializer() {
-            Some(initializer) => format!("{initializer}; {condition}"),
-            None => condition,
+        PairCondition {
+            initializer: pair.initializer(),
+            condition,
         }
     }
 
@@ -375,7 +385,7 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         pair: &CommaOkPair,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         match pair {
             CommaOkPair::LoweredCall => self
                 .lower_call(expression, None, ExpressionContext::value())
@@ -388,21 +398,12 @@ impl Planner<'_> {
                 let (setup, operand) = self
                     .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
-                let operand = parenthesize_prefixed(operand);
+                let operand = parenthesize_prefixed_expression(operand);
                 let target_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
                 let target = self.use_go_type(&target_ty);
-                (setup, format!("{}.({})", operand, target))
+                (setup, GoExpression::type_assertion(operand, target))
             }
         }
-    }
-}
-
-/// `*x` and `&x` bind looser than a postfix `[k]` or `.(T)`.
-pub(super) fn parenthesize_prefixed(operand: String) -> String {
-    if operand.starts_with('*') || operand.starts_with('&') {
-        format!("({operand})")
-    } else {
-        operand
     }
 }
 

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -7,14 +7,17 @@ use super::NativeCallContext;
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::abi::is_prelude_container_type;
+use crate::abi::transition::multi_value_return;
 use crate::calls::native::{native_method_is_pure, native_method_lowers_to_plain_call};
 use crate::context::expression::ExpressionContext;
+use crate::control_flow::propagation::plain_return;
 use crate::names::go_name;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{
+    ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign, define,
+};
 use crate::plan::calls::{CallPlan, CallableOrigin};
-use crate::plan::go_expression::CompositeLayout;
+use crate::plan::go_expression::{CompositeLayout, FunctionLiteralLayout};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, Stability, ValuePlan};
-use crate::types::go_type::render_conversion;
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments, StructFields};
@@ -225,9 +228,40 @@ impl<'a> Planner<'a> {
                     )
                 } else {
                     let zero = self.lisette_zero(&element_ty);
-                    GoExpression::opaque(format!(
-                        "func() []{element} {{ s := make([]{element}, {length}); for i := range s {{ s[i] = {zero} }}; return s }}()"
-                    ))
+                    let slice_type = format!("[]{element}");
+                    let slice = || GoExpression::name("s".to_string());
+                    let index = || GoExpression::name("i".to_string());
+                    GoExpression::immediate_call(
+                        slice_type.clone(),
+                        LoweredBlock {
+                            statements: vec![
+                                define(
+                                    "s".to_string(),
+                                    GoExpression::call(
+                                        GoExpression::name("make".to_string()),
+                                        vec![GoExpression::type_name(slice_type), length],
+                                    ),
+                                ),
+                                LoweredStatement::Loop(LoopPlan {
+                                    prologue: Vec::new(),
+                                    kind: LoopKind::Generated { label: None },
+                                    header: LoopHeader::Range {
+                                        key: Some("i".to_string()),
+                                        value: None,
+                                        iterable: slice(),
+                                    },
+                                    body: LoweredBlock {
+                                        statements: vec![assign(
+                                            GoExpression::index(slice(), index()),
+                                            zero,
+                                        )],
+                                    },
+                                }),
+                                plain_return(slice()),
+                            ],
+                        },
+                        FunctionLiteralLayout::MultiLine,
+                    )
                 };
                 Some(ValuePlan::observable_call(
                     setup,
@@ -274,13 +308,41 @@ impl<'a> Planner<'a> {
         let argument_effect = staged.evaluation.effect;
         let (setup, source) = staged.into_parts();
 
-        // A function element makes `[N]func(...)(s)` parse as a type.
-        let conversion = render_conversion(&array_go, "s");
-        let value = GoExpression::opaque(format!(
-            "func(s []{element_go}) ({array_go}, bool) {{ \
-             if len(s) != {length} {{ return {array_go}{{}}, false }}; \
-             return {conversion}, true }}({source})"
-        ));
+        let slice = || GoExpression::name("s".to_string());
+        let literal = |text: String| GoExpression::literal(text);
+        let value = GoExpression::call(
+            GoExpression::function_literal(
+                format!("s []{element_go}"),
+                format!("({array_go}, bool)"),
+                LoweredBlock {
+                    statements: vec![
+                        LoweredStatement::If(IfPlan::plain(
+                            GoExpression::binary(
+                                GoExpression::call(
+                                    GoExpression::name("len".to_string()),
+                                    vec![slice()],
+                                ),
+                                "!=",
+                                literal(length.to_string()),
+                            ),
+                            LoweredBlock {
+                                statements: vec![multi_value_return(vec![
+                                    GoExpression::empty_composite(array_go.clone()),
+                                    literal("false".to_string()),
+                                ])],
+                            },
+                            ElseArm::None,
+                        )),
+                        multi_value_return(vec![
+                            GoExpression::conversion(array_go, slice()),
+                            literal("true".to_string()),
+                        ]),
+                    ],
+                },
+                FunctionLiteralLayout::MultiLine,
+            ),
+            vec![source],
+        );
 
         Some(ValuePlan::observable_call(
             setup,

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -1,14 +1,14 @@
 mod nullable;
 mod wrappers;
 
-pub(crate) use wrappers::{NilGuard, WrapperTarget};
+pub(crate) use wrappers::{NilGuard, WrapperTarget, is_nil, non_nil, unexpected_nil_error};
 
 use crate::Planner;
 use crate::abi::callable::{CallableAbi, CallableReturnAbi, OptionReturnAbi};
 use crate::abi::coercion::{CoercionPlan, LayoutBridge, resolve_layout_bridge};
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{LoweredStatement, define_many};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::Expression;
@@ -26,18 +26,15 @@ impl Planner<'_> {
             let call = self.lower_call(call_expression, None, ExpressionContext::value());
             return call.map_expression_as_observable_computed(|setup, call| {
                 let values = self.create_temp_vars("ret", bridges.len());
-                setup.push(LoweredStatement::RawGo(format!(
-                    "{} := {}\n",
-                    values.join(", "),
-                    call
-                )));
+                setup.push(define_many(values.clone(), call));
                 let values = values
                     .into_iter()
                     .zip(&bridges)
-                    .map(|(value, bridge)| self.plan_layout_bridge(setup, &value, bridge))
+                    .map(|(value, bridge)| {
+                        self.plan_layout_bridge(setup, GoExpression::name(value), bridge)
+                    })
                     .collect::<Vec<_>>();
-                let tuple = self.plan_tuple_from_vars(setup, &values, result_ty);
-                GoExpression::name(tuple)
+                self.plan_tuple_from_vars(setup, values)
             });
         }
 
@@ -55,18 +52,21 @@ impl Planner<'_> {
         call_plan.map_expression_as_observable_computed(|setup, call| {
             let (wrap, value) = if payload_bridge.is_some() {
                 let (wrap, outcome) = self.lower_abi_wrapping_with_payload_bridge(
-                    call.as_str(),
+                    call,
                     &abi.result,
                     result_ty,
                     payload_bridge.as_ref(),
                     WrapperTarget::FreshSlot,
                 );
-                (wrap, outcome.expect("wrapper produced no slot"))
+                (
+                    wrap,
+                    GoExpression::name(outcome.expect("wrapper produced no slot")),
+                )
             } else {
-                self.lower_abi_to_tagged(call.as_str(), &abi.result, result_ty)
+                self.lower_abi_to_tagged(call, &abi.result, result_ty)
             };
             setup.extend(wrap);
-            GoExpression::name(value)
+            value
         })
     }
 
@@ -127,17 +127,17 @@ impl Planner<'_> {
 
     pub(crate) fn lower_abi_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         abi: &CallableReturnAbi,
         result_ty: &Type,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, Option<String>) {
-        self.lower_abi_wrapping_with_payload_bridge(call_str, abi, result_ty, None, target)
+        self.lower_abi_wrapping_with_payload_bridge(call, abi, result_ty, None, target)
     }
 
     pub(crate) fn lower_abi_wrapping_with_payload_bridge(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         abi: &CallableReturnAbi,
         result_ty: &Type,
         payload_bridge: Option<&LayoutBridge>,
@@ -152,28 +152,32 @@ impl Planner<'_> {
             }
             CallableReturnAbi::BareError => {
                 self.require_stdlib();
-                self.lower_bare_error_wrapping(call_str, result_ty, target)
+                self.lower_bare_error_wrapping(call, result_ty, target)
             }
             CallableReturnAbi::Result { payload } => {
                 self.require_stdlib();
-                self.lower_result_wrapping(call_str, result_ty, *payload, payload_bridge, target)
+                self.lower_result_wrapping(call, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Partial { payload } => {
                 self.require_stdlib();
-                self.lower_partial_wrapping(call_str, result_ty, *payload, payload_bridge, target)
+                self.lower_partial_wrapping(call, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Option(OptionReturnAbi::CommaOk { payload }) => {
-                self.lower_comma_ok_wrapping(call_str, result_ty, *payload, payload_bridge, target)
+                self.lower_comma_ok_wrapping(call, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let mut statements = Vec::new();
-                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", call_str);
-                let (wrap, outcome) = self.lower_nil_check_option_wrap(&raw_var, result_ty, target);
+                let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", call);
+                let (wrap, outcome) = self.lower_nil_check_option_wrap(
+                    GoExpression::name(raw_var),
+                    result_ty,
+                    target,
+                );
                 statements.extend(wrap);
                 (statements, outcome)
             }
             CallableReturnAbi::Option(OptionReturnAbi::Sentinel(value)) => {
-                self.lower_sentinel_wrapping(call_str, result_ty, *value, target)
+                self.lower_sentinel_wrapping(call, result_ty, *value, target)
             }
         }
     }
@@ -192,11 +196,11 @@ impl Planner<'_> {
             return None;
         }
         let payload_bridge = self.go_return_payload_bridge(abi, result_ty);
-        let (mut statements, call_str) = self
+        let (mut statements, call) = self
             .lower_call(expression, None, ExpressionContext::value())
             .into_parts();
         let (wrap, _) = self.lower_abi_wrapping_with_payload_bridge(
-            &call_str,
+            call,
             &abi.result,
             result_ty,
             payload_bridge.as_ref(),
@@ -222,7 +226,7 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         call_expression: &Expression,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let plan = self.plan_call(call_expression)?;
         if plan.resolved.abi.result.is_passthrough() {
             match plan.resolved.origin {
@@ -234,12 +238,12 @@ impl Planner<'_> {
             }
         }
 
-        let (call_setup, call_str) = self
+        let (call_setup, call) = self
             .lower_call(call_expression, None, ExpressionContext::value())
             .into_parts();
         setup.extend(call_setup);
 
-        Some(call_str)
+        Some(call)
     }
 
     pub(crate) fn create_temp_vars(&mut self, hint: &str, count: usize) -> Vec<String> {
@@ -252,33 +256,23 @@ impl Planner<'_> {
             .collect()
     }
 
-    fn emit_tuple_from_vars(
-        &mut self,
-        output: &mut String,
-        vars: &[String],
-        tuple_ty: &Type,
-    ) -> String {
-        let constructor = build_tuple_literal(self, vars, tuple_ty);
-        self.hoist_tmp_value(output, "tup", &constructor)
-    }
-
-    /// Structured counterpart of `emit_tuple_from_vars`.
     pub(crate) fn plan_tuple_from_vars(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        vars: &[String],
-        tuple_ty: &Type,
-    ) -> String {
-        let constructor = build_tuple_literal(self, vars, tuple_ty);
-        self.hoist_tmp_value_statement(statements, "tup", &constructor)
+        values: Vec<GoExpression>,
+    ) -> GoExpression {
+        let constructor = build_tuple_literal(self, values);
+        GoExpression::name(self.hoist_tmp_value_statement(statements, "tup", constructor))
     }
 }
 
 pub(super) fn build_tuple_literal(
     planner: &mut Planner,
-    vars: &[String],
-    _tuple_ty: &Type,
-) -> String {
+    values: Vec<GoExpression>,
+) -> GoExpression {
     planner.require_stdlib();
-    format!("lisette.MakeTuple{}({})", vars.len(), vars.join(", "))
+    GoExpression::call(
+        GoExpression::name(format!("lisette.MakeTuple{}", values.len())),
+        values,
+    )
 }

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -3,14 +3,30 @@ use crate::abi::callable::PayloadLayout;
 use crate::abi::coercion::{BridgeDirection, CoercionPlan, LayoutBridge};
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::calls::go_interop::build_tuple_literal;
-use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
+use crate::calls::go_interop::wrappers::{
+    WrapperOutcome, WrapperTarget, is_nil, is_nil_interface, leaf_block, non_nil,
+};
 use crate::context::expression::ExpressionContext;
-use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
-use crate::plan::bodies::{ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
+use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG, generic_call};
+use crate::plan::bodies::{
+    ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign,
+    define_many,
+};
 use crate::plan::values::{GoExpression, ValuePlan};
-use std::iter;
 use syntax::ast::Expression;
 use syntax::types::Type;
+
+fn is_some(option: GoExpression) -> GoExpression {
+    GoExpression::binary(
+        GoExpression::selector(option, "Tag".to_string()),
+        "==",
+        GoExpression::name(OPTION_SOME_TAG.to_string()),
+    )
+}
+
+fn some_payload(option: GoExpression) -> GoExpression {
+    GoExpression::selector(option, "SomeVal".to_string())
+}
 
 impl Planner<'_> {
     /// `Some(e)` and `None` written straight into a nullable Go slot.
@@ -57,7 +73,7 @@ impl Planner<'_> {
             let value = if payload.is_identity() {
                 value
             } else {
-                GoExpression::opaque(self.plan_layout_bridge(setup, value.as_str(), payload))
+                self.plan_layout_bridge(setup, value, payload)
             };
             let Some(pointee) = pointee else {
                 return value.with_deferred_evaluation(contains_deferred_evaluation);
@@ -69,7 +85,7 @@ impl Planner<'_> {
             setup.push(LoweredStatement::VarDecl {
                 name: copy.clone(),
                 go_type,
-                value: Some(value.rendered()),
+                value: Some(value),
             });
             GoExpression::address_of(GoExpression::name(copy))
                 .with_deferred_evaluation(contains_deferred_evaluation)
@@ -79,21 +95,25 @@ impl Planner<'_> {
     /// Wrap a sentinel-call via `OptionFromCommaOk` with `raw != sentinel`.
     pub(crate) fn lower_sentinel_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         option_ty: &Type,
         sentinel: i64,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         self.require_stdlib();
         let mut statements = Vec::new();
-        let raw = self.hoist_tmp_value_statement(&mut statements, "ret", call_str);
+        let raw = self.hoist_tmp_value_statement(&mut statements, "ret", call);
+        let raw = || GoExpression::name(raw.clone());
         let inner_ty_str = self.use_go_type(&option_ty.ok_type());
-        let value_expr = format!(
-            "lisette.OptionFromCommaOk[{}]({}, {} != {})",
-            inner_ty_str, raw, raw, sentinel
+        let value = generic_call(
+            "lisette.OptionFromCommaOk",
+            format!("[{}]", inner_ty_str),
+            vec![
+                raw(),
+                GoExpression::binary(raw(), "!=", GoExpression::literal(sentinel.to_string())),
+            ],
         );
-        let outcome =
-            self.push_simple_wrapper_value(&mut statements, target, "option", &value_expr);
+        let outcome = self.push_simple_wrapper_value(&mut statements, target, "option", value);
         (statements, outcome)
     }
 
@@ -102,7 +122,7 @@ impl Planner<'_> {
     /// `Packed` one from a Lisette `(Tuple_n[...], bool)`.
     pub(crate) fn lower_comma_ok_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         option_ty: &Type,
         layout: PayloadLayout,
         payload_bridge: Option<&LayoutBridge>,
@@ -121,9 +141,12 @@ impl Planner<'_> {
 
         if !needs_complex {
             let inner_ty_str = self.use_go_type(&inner_ty);
-            let value_expr = format!("lisette.OptionFromCommaOk[{}]({})", inner_ty_str, call_str);
-            let outcome =
-                self.push_simple_wrapper_value(&mut statements, target, "option", &value_expr);
+            let value = generic_call(
+                "lisette.OptionFromCommaOk",
+                format!("[{}]", inner_ty_str),
+                vec![call],
+            );
+            let outcome = self.push_simple_wrapper_value(&mut statements, target, "option", value);
             return (statements, outcome);
         }
 
@@ -139,26 +162,24 @@ impl Planner<'_> {
         let ok_var = self.fresh_var(Some("ret"));
         self.declare(&ok_var);
 
-        let all_vars: Vec<&str> = val_vars
-            .iter()
-            .map(|s| s.as_str())
-            .chain(iter::once(ok_var.as_str()))
-            .collect();
-        statements.push(LoweredStatement::RawGo(format!(
-            "{} := {}\n",
-            all_vars.join(", "),
-            call_str
-        )));
+        let mut all_vars = val_vars.clone();
+        all_vars.push(ok_var.clone());
+        statements.push(define_many(all_vars, call));
 
+        let first_val = GoExpression::name(val_vars[0].clone());
         let val_expression = if layout.is_flattened() && inner_tuple_arity.is_some() {
-            build_tuple_literal(self, &val_vars, &inner_ty)
+            let values = val_vars
+                .iter()
+                .map(|var| GoExpression::name(var.clone()))
+                .collect();
+            build_tuple_literal(self, values)
         } else {
-            val_vars[0].clone()
+            first_val.clone()
         };
         let (mut payload_setup, val_expression) = match payload_bridge {
             Some(bridge) => {
                 let mut setup = Vec::new();
-                let value = self.plan_layout_bridge(&mut setup, &val_expression, bridge);
+                let value = self.plan_layout_bridge(&mut setup, val_expression, bridge);
                 (setup, value)
             }
             None => (Vec::new(), val_expression),
@@ -169,12 +190,17 @@ impl Planner<'_> {
             fe.full_type_string()
         };
 
+        let ok = GoExpression::name(ok_var);
         let condition = if self.is_interface_option(option_ty) {
-            format!("{} && !lisette.IsNilInterface({})", ok_var, val_vars[0])
+            GoExpression::binary(
+                ok,
+                "&&",
+                GoExpression::unary("!", is_nil_interface(first_val)),
+            )
         } else if needs_nilable_validation {
-            format!("{} && {} != nil", ok_var, val_vars[0])
+            GoExpression::binary(ok, "&&", non_nil(first_val))
         } else {
-            ok_var.clone()
+            ok
         };
 
         let (sink, outcome) =
@@ -182,30 +208,29 @@ impl Planner<'_> {
 
         let some_wrapper = {
             let mut fe = FalliblePlanner::new(self, &fallible);
-            fe.emit_success(&val_expression)
+            fe.emit_success(val_expression)
         };
         let none_wrapper = {
             let mut fe = FalliblePlanner::new(self, &fallible);
             fe.emit_failure(None)
         };
 
-        let mut then_body = leaf_block(&sink, &some_wrapper);
+        let mut then_body = leaf_block(&sink, some_wrapper);
         payload_setup.append(&mut then_body.statements);
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
+        statements.push(LoweredStatement::If(IfPlan::plain(
             condition,
-            then_body: LoweredBlock {
+            LoweredBlock {
                 statements: payload_setup,
             },
-            else_arm: ElseArm::from_body(leaf_block(&sink, &none_wrapper), false),
-        }));
+            ElseArm::from_body(leaf_block(&sink, none_wrapper), false),
+        )));
         (statements, outcome)
     }
 
     /// Wrap a nilable Go value into a tagged `Option` via `OptionFromNilable`.
     pub(crate) fn lower_nil_check_option_wrap(
         &mut self,
-        raw_value: &str,
+        raw_value: GoExpression,
         option_ty: &Type,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
@@ -214,28 +239,28 @@ impl Planner<'_> {
         let inner_ty = option_ty.ok_type();
         let inner_ty_str = self.use_go_type(&inner_ty);
         let is_nil_check = if self.is_interface_option(option_ty) {
-            format!("lisette.IsNilInterface({})", raw_value)
+            is_nil_interface(raw_value.clone())
         } else {
-            format!("{} == nil", raw_value)
+            is_nil(raw_value.clone())
         };
-        let value_expr = format!(
-            "lisette.OptionFromNilable[{}]({}, {})",
-            inner_ty_str, raw_value, is_nil_check
+        let value = generic_call(
+            "lisette.OptionFromNilable",
+            format!("[{}]", inner_ty_str),
+            vec![raw_value, is_nil_check],
         );
-        let outcome =
-            self.push_simple_wrapper_value(&mut statements, target, "option", &value_expr);
+        let outcome = self.push_simple_wrapper_value(&mut statements, target, "option", value);
         (statements, outcome)
     }
 
     pub(crate) fn plan_option_projection(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        option_value: &str,
+        option_value: GoExpression,
         slot_hint: &str,
         slot_ty: &str,
         address: bool,
-    ) -> String {
-        let opt_var = self.stable_source(statements, "opt", option_value);
+    ) -> GoExpression {
+        let option = self.stable_source(statements, "opt", option_value);
         let slot_var = self.fresh_var(Some(slot_hint));
         self.declare(&slot_var);
         statements.push(LoweredStatement::VarDecl {
@@ -245,33 +270,38 @@ impl Planner<'_> {
         });
 
         self.require_stdlib();
-        let amp = if address { "&" } else { "" };
-        let body = LoweredBlock {
-            statements: vec![LoweredStatement::RawGo(format!(
-                "{} = {}{}.SomeVal\n",
-                slot_var, amp, opt_var
-            ))],
+        let payload = some_payload(option.clone());
+        let payload = if address {
+            GoExpression::address_of(payload)
+        } else {
+            payload
         };
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: format!("{}.Tag == {}", opt_var, OPTION_SOME_TAG),
-            then_body: body,
-            else_arm: ElseArm::None,
-        }));
-        slot_var
+        let body = LoweredBlock {
+            statements: vec![assign(GoExpression::name(slot_var.clone()), payload)],
+        };
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            is_some(option),
+            body,
+            ElseArm::None,
+        )));
+        GoExpression::name(slot_var)
     }
 
     /// Wrap a Go `*T` (T value-typed) into Lisette `Option<T>`.
     fn plan_pointer_to_option_wrap(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        ptr_value: &str,
+        pointer: GoExpression,
         option_ty: &Type,
-    ) -> String {
+    ) -> GoExpression {
         self.require_stdlib();
         let inner_ty_str = self.use_go_type(&option_ty.ok_type());
-        let value_expr = format!("lisette.OptionFromPointer[{}]({})", inner_ty_str, ptr_value);
-        self.hoist_tmp_value_statement(statements, "option", &value_expr)
+        let value = generic_call(
+            "lisette.OptionFromPointer",
+            format!("[{}]", inner_ty_str),
+            vec![pointer],
+        );
+        GoExpression::name(self.hoist_tmp_value_statement(statements, "option", value))
     }
 
     /// `FreshSlot` form of `lower_nil_check_option_wrap` (extends `statements`
@@ -279,23 +309,23 @@ impl Planner<'_> {
     pub(crate) fn plan_nil_check_option_wrap(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        raw_value: &str,
+        raw_value: GoExpression,
         option_ty: &Type,
-    ) -> String {
+    ) -> GoExpression {
         let (wrap_statements, outcome) =
             self.lower_nil_check_option_wrap(raw_value, option_ty, WrapperTarget::FreshSlot);
         statements.extend(wrap_statements);
-        outcome.expect("FreshSlot produces a slot")
+        GoExpression::name(outcome.expect("FreshSlot produces a slot"))
     }
 
     pub(crate) fn plan_layout_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: &str,
+        value: GoExpression,
         bridge: &LayoutBridge,
-    ) -> String {
+    ) -> GoExpression {
         match bridge {
-            LayoutBridge::Identity => value.to_string(),
+            LayoutBridge::Identity => value,
             LayoutBridge::UnwrapNullableOption {
                 target_payload,
                 payload,
@@ -364,8 +394,13 @@ impl Planner<'_> {
             }
             LayoutBridge::Reference { pointee } => {
                 let source = self.stable_source(statements, "src", value);
-                let pointee = self.plan_layout_bridge(statements, &format!("*{source}"), pointee);
-                self.hoist_tmp_value_statement(statements, "ref", &format!("&{pointee}"))
+                let pointee =
+                    self.plan_layout_bridge(statements, GoExpression::dereference(source), pointee);
+                GoExpression::name(self.hoist_tmp_value_statement(
+                    statements,
+                    "ref",
+                    GoExpression::address_of(pointee),
+                ))
             }
             LayoutBridge::Function { source, target, .. } => {
                 self.plan_function_layout_bridge(statements, value, source, target)
@@ -379,11 +414,11 @@ impl Planner<'_> {
     fn plan_option_projection_with_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        option_value: &str,
+        option_value: GoExpression,
         target_payload: &ValueLayout,
         payload_bridge: &LayoutBridge,
         address: bool,
-    ) -> String {
+    ) -> GoExpression {
         let option = self.stable_source(statements, "opt", option_value);
         let target_type = target_payload.go_type(self);
         let target_type = self.use_rendered_go_type(target_type);
@@ -404,34 +439,33 @@ impl Planner<'_> {
         let mut then_statements = Vec::new();
         let payload = self.plan_layout_bridge(
             &mut then_statements,
-            &format!("{}.SomeVal", option),
+            some_payload(option.clone()),
             payload_bridge,
         );
         let payload = if address {
-            format!("&{payload}")
+            GoExpression::address_of(payload)
         } else {
             payload
         };
-        then_statements.push(LoweredStatement::RawGo(format!("{slot} = {payload}\n")));
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: format!("{}.Tag == {}", option, OPTION_SOME_TAG),
-            then_body: LoweredBlock {
+        then_statements.push(assign(GoExpression::name(slot.clone()), payload));
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            is_some(option),
+            LoweredBlock {
                 statements: then_statements,
             },
-            else_arm: ElseArm::None,
-        }));
-        slot
+            ElseArm::None,
+        )));
+        GoExpression::name(slot)
     }
 
     fn plan_option_wrap_with_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        raw_value: &str,
+        raw_value: GoExpression,
         option_type: &Type,
         payload_bridge: &LayoutBridge,
         pointer: bool,
-    ) -> String {
+    ) -> GoExpression {
         self.require_stdlib();
         let source = self.stable_source(statements, "raw", raw_value);
         let fallible = Fallible::from_type(option_type).expect("Option type expected");
@@ -448,48 +482,47 @@ impl Planner<'_> {
         });
 
         let raw_payload = if pointer {
-            format!("*{source}")
+            GoExpression::dereference(source.clone())
         } else {
             source.clone()
         };
         let mut then_statements = Vec::new();
-        let payload = self.plan_layout_bridge(&mut then_statements, &raw_payload, payload_bridge);
+        let payload = self.plan_layout_bridge(&mut then_statements, raw_payload, payload_bridge);
         let some = {
             let mut planner = FalliblePlanner::new(self, &fallible);
-            planner.emit_success(&payload)
+            planner.emit_success(payload)
         };
-        then_statements.push(LoweredStatement::RawGo(format!("{option} = {some}\n")));
+        then_statements.push(assign(GoExpression::name(option.clone()), some));
         let none = {
             let mut planner = FalliblePlanner::new(self, &fallible);
             planner.emit_failure(None)
         };
         let condition = if !pointer && self.is_interface_option(option_type) {
-            format!("!lisette.IsNilInterface({source})")
+            GoExpression::unary("!", is_nil_interface(source))
         } else {
-            format!("{source} != nil")
+            non_nil(source)
         };
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
+        statements.push(LoweredStatement::If(IfPlan::plain(
             condition,
-            then_body: LoweredBlock {
+            LoweredBlock {
                 statements: then_statements,
             },
-            else_arm: ElseArm::from_body(
+            ElseArm::from_body(
                 LoweredBlock {
-                    statements: vec![LoweredStatement::RawGo(format!("{option} = {none}\n"))],
+                    statements: vec![assign(GoExpression::name(option.clone()), none)],
                 },
                 false,
             ),
-        }));
-        option
+        )));
+        GoExpression::name(option)
     }
 
     fn plan_aggregate_layout_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: &str,
+        value: GoExpression,
         bridge: &LayoutBridge,
-    ) -> String {
+    ) -> GoExpression {
         let LayoutBridge::Aggregate {
             source,
             target,
@@ -525,25 +558,31 @@ impl Planner<'_> {
             });
             output
         } else {
-            self.hoist_tmp_value_statement(
-                statements,
-                output_hint,
-                &format!("make({}, len({}))", target_type, source),
-            )
+            let make = GoExpression::call(
+                GoExpression::name("make".to_string()),
+                vec![
+                    GoExpression::type_name(target_type),
+                    GoExpression::call(GoExpression::name("len".to_string()), vec![source.clone()]),
+                ],
+            );
+            self.hoist_tmp_value_statement(statements, output_hint, make)
         };
         let index = self.fresh_var(Some("i"));
         self.declare(&index);
         let element = self.fresh_var(Some("v"));
         self.declare(&element);
         let mut key_statements = Vec::new();
-        let output_index = key_bridge.map_or_else(
-            || index.clone(),
-            |bridge| self.plan_layout_bridge(&mut key_statements, &index, bridge),
-        );
+        let output_index = match key_bridge {
+            Some(bridge) => self.plan_layout_bridge(
+                &mut key_statements,
+                GoExpression::name(index.clone()),
+                bridge,
+            ),
+            None => GoExpression::name(index.clone()),
+        };
         let mut body = self.plan_aggregate_element_bridge(
-            &output,
-            &output_index,
-            &element,
+            GoExpression::index(GoExpression::name(output.clone()), output_index),
+            GoExpression::name(element.clone()),
             source_layout,
             element_bridge,
         );
@@ -554,17 +593,20 @@ impl Planner<'_> {
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
             kind: LoopKind::Generated { label: None },
-            header: format!("for {index}, {element} := range {source} {{\n"),
+            header: LoopHeader::Range {
+                key: Some(index),
+                value: Some(element),
+                iterable: source,
+            },
             body,
         }));
-        output
+        GoExpression::name(output)
     }
 
     fn plan_aggregate_element_bridge(
         &mut self,
-        output: &str,
-        index: &str,
-        element: &str,
+        slot: GoExpression,
+        element: GoExpression,
         source_layout: &ValueLayout,
         bridge: &LayoutBridge,
     ) -> LoweredBlock {
@@ -573,27 +615,23 @@ impl Planner<'_> {
             | LayoutBridge::UnwrapPointerOption { payload, .. } => {
                 let pointer = matches!(bridge, LayoutBridge::UnwrapPointerOption { .. });
                 let mut then_statements = Vec::new();
-                let projected = format!("{element}.SomeVal");
+                let projected = some_payload(element.clone());
                 let projected = if payload.is_identity() {
                     projected
                 } else {
-                    self.plan_layout_bridge(&mut then_statements, &projected, payload)
+                    self.plan_layout_bridge(&mut then_statements, projected, payload)
                 };
                 let projected = if pointer {
-                    format!("&{projected}")
+                    GoExpression::address_of(projected)
                 } else {
                     projected
                 };
-                then_statements.push(LoweredStatement::RawGo(format!(
-                    "{output}[{index}] = {projected}\n"
-                )));
+                then_statements.push(assign(slot.clone(), projected));
                 let needs_nil_else = matches!(source_layout, ValueLayout::Map { .. }) || pointer;
                 let else_arm = if needs_nil_else {
                     ElseArm::from_body(
                         LoweredBlock {
-                            statements: vec![LoweredStatement::RawGo(format!(
-                                "{output}[{index}] = nil\n"
-                            ))],
+                            statements: vec![assign(slot, GoExpression::nil())],
                         },
                         false,
                     )
@@ -601,14 +639,13 @@ impl Planner<'_> {
                     ElseArm::None
                 };
                 LoweredBlock {
-                    statements: vec![LoweredStatement::If(IfPlan {
-                        condition_setup: Vec::new(),
-                        condition: format!("{element}.Tag == {OPTION_SOME_TAG}"),
-                        then_body: LoweredBlock {
+                    statements: vec![LoweredStatement::If(IfPlan::plain(
+                        is_some(element),
+                        LoweredBlock {
                             statements: then_statements,
                         },
                         else_arm,
-                    })],
+                    ))],
                 }
             }
             LayoutBridge::WrapNullableOption {
@@ -623,49 +660,44 @@ impl Planner<'_> {
             } => {
                 let pointer = matches!(bridge, LayoutBridge::WrapPointerOption { .. });
                 let raw_payload = if pointer {
-                    format!("*{element}")
+                    GoExpression::dereference(element.clone())
                 } else {
-                    element.to_string()
+                    element.clone()
                 };
                 let mut then_statements = Vec::new();
                 let payload = if payload.is_identity() {
                     raw_payload
                 } else {
-                    self.plan_layout_bridge(&mut then_statements, &raw_payload, payload)
+                    self.plan_layout_bridge(&mut then_statements, raw_payload, payload)
                 };
                 let fallible = Fallible::from_type(option_type).expect("Option type expected");
                 let some = {
                     let mut planner = FalliblePlanner::new(self, &fallible);
-                    planner.emit_success(&payload)
+                    planner.emit_success(payload)
                 };
                 let none = {
                     let mut planner = FalliblePlanner::new(self, &fallible);
                     planner.emit_failure(None)
                 };
-                then_statements.push(LoweredStatement::RawGo(format!(
-                    "{output}[{index}] = {some}\n"
-                )));
+                then_statements.push(assign(slot.clone(), some));
                 let condition = if !pointer && self.is_interface_option(option_type) {
-                    format!("!lisette.IsNilInterface({element})")
+                    GoExpression::unary("!", is_nil_interface(element))
                 } else {
-                    format!("{element} != nil")
+                    non_nil(element)
                 };
                 LoweredBlock {
-                    statements: vec![LoweredStatement::If(IfPlan {
-                        condition_setup: Vec::new(),
+                    statements: vec![LoweredStatement::If(IfPlan::plain(
                         condition,
-                        then_body: LoweredBlock {
+                        LoweredBlock {
                             statements: then_statements,
                         },
-                        else_arm: ElseArm::from_body(
+                        ElseArm::from_body(
                             LoweredBlock {
-                                statements: vec![LoweredStatement::RawGo(format!(
-                                    "{output}[{index}] = {none}\n"
-                                ))],
+                                statements: vec![assign(slot, none)],
                             },
                             false,
                         ),
-                    })],
+                    ))],
                 }
             }
             LayoutBridge::Aggregate { .. }
@@ -673,17 +705,13 @@ impl Planner<'_> {
             | LayoutBridge::Function { .. } => {
                 let mut inner_statements = Vec::new();
                 let inner = self.plan_layout_bridge(&mut inner_statements, element, bridge);
-                inner_statements.push(LoweredStatement::RawGo(format!(
-                    "{output}[{index}] = {inner}\n"
-                )));
+                inner_statements.push(assign(slot, inner));
                 LoweredBlock {
                     statements: inner_statements,
                 }
             }
             LayoutBridge::Identity => LoweredBlock {
-                statements: vec![LoweredStatement::RawGo(format!(
-                    "{output}[{index}] = {element}\n"
-                ))],
+                statements: vec![assign(slot, element)],
             },
         }
     }

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -1,19 +1,38 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::callable::{CallableAbi, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::coercion::{LayoutBridge, resolve_layout_bridge};
 use crate::abi::layout::{FunctionLayout, ValueLayout};
+use crate::abi::transition::multi_value_return;
 use crate::control_flow::fallible::{
-    Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR,
+    Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR, generic_call,
 };
 use crate::control_flow::propagation::plain_return;
 use crate::is_order_sensitive;
 use crate::names::go_name;
-use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement};
-use crate::write_line;
+use crate::plan::bodies::{
+    ElseArm, IfPlan, LoweredBlock, LoweredStatement, assign, define, define_many,
+    expression_statement,
+};
+use crate::plan::go_expression::FunctionLiteralLayout;
+use crate::plan::values::GoExpression;
 use syntax::ast::Expression;
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::{FunctionParameter, Type};
+
+pub(crate) fn is_nil(value: GoExpression) -> GoExpression {
+    GoExpression::binary(value, "==", GoExpression::nil())
+}
+
+pub(crate) fn non_nil(value: GoExpression) -> GoExpression {
+    GoExpression::binary(value, "!=", GoExpression::nil())
+}
+
+pub(crate) fn is_nil_interface(value: GoExpression) -> GoExpression {
+    GoExpression::call(
+        GoExpression::name("lisette.IsNilInterface".to_string()),
+        vec![value],
+    )
+}
 
 #[derive(Clone, Copy)]
 pub(crate) enum NilGuard {
@@ -24,17 +43,17 @@ pub(crate) enum NilGuard {
 }
 
 impl NilGuard {
-    pub(crate) fn is_nil(self, var: &str) -> String {
+    pub(crate) fn is_nil(self, value: GoExpression) -> GoExpression {
         match self {
-            NilGuard::Pointer => format!("{var} == nil"),
-            NilGuard::Interface => format!("lisette.IsNilInterface({var})"),
+            NilGuard::Pointer => is_nil(value),
+            NilGuard::Interface => is_nil_interface(value),
         }
     }
 
-    pub(crate) fn non_nil(self, var: &str) -> String {
+    pub(crate) fn non_nil(self, value: GoExpression) -> GoExpression {
         match self {
-            NilGuard::Pointer => format!("{var} != nil"),
-            NilGuard::Interface => format!("!lisette.IsNilInterface({var})"),
+            NilGuard::Pointer => non_nil(value),
+            NilGuard::Interface => GoExpression::unary("!", is_nil_interface(value)),
         }
     }
 
@@ -62,16 +81,16 @@ pub(super) enum ResolvedSink {
     Return,
 }
 
-/// `slot = value` (a `RawGo` leaf) or a structured `return value`.
-fn leaf_statement(sink: &ResolvedSink, value: &str) -> LoweredStatement {
+/// `slot = value` or `return value`.
+fn leaf_statement(sink: &ResolvedSink, value: GoExpression) -> LoweredStatement {
     match sink {
-        ResolvedSink::Slot(name) => LoweredStatement::RawGo(format!("{} = {}\n", name, value)),
-        ResolvedSink::Return => plain_return(value.to_string()),
+        ResolvedSink::Slot(name) => assign(GoExpression::name(name.clone()), value),
+        ResolvedSink::Return => plain_return(value),
     }
 }
 
 /// A single-statement branch body for a wrapper-dispatch `If`.
-pub(super) fn leaf_block(sink: &ResolvedSink, value: &str) -> LoweredBlock {
+pub(super) fn leaf_block(sink: &ResolvedSink, value: GoExpression) -> LoweredBlock {
     LoweredBlock {
         statements: vec![leaf_statement(sink, value)],
     }
@@ -85,14 +104,21 @@ fn tuple_slots(layout: &ValueLayout) -> &[ValueLayout] {
     }
 }
 
+fn names(names: &[String]) -> Vec<GoExpression> {
+    names
+        .iter()
+        .map(|name| GoExpression::name(name.clone()))
+        .collect()
+}
+
 impl Planner<'_> {
     pub(crate) fn plan_function_layout_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: &str,
+        value: GoExpression,
         source: &FunctionLayout,
         target: &FunctionLayout,
-    ) -> String {
+    ) -> GoExpression {
         debug_assert!(source.return_abi.same_logical_contract(&target.return_abi));
         let function = self.hoist_tmp_value_statement(statements, "cb", value);
         let mut body = Vec::new();
@@ -107,45 +133,46 @@ impl Planner<'_> {
             let target_type = self.use_rendered_go_type(target_type);
             parameters.push(format!("{name} {target_type}"));
             let bridge = resolve_layout_bridge(self, target, source);
-            let argument = self.plan_layout_bridge(&mut body, &name, &bridge);
+            let argument = self.plan_layout_bridge(&mut body, GoExpression::name(name), &bridge);
             if source.logical_type().get_name() == Some("VarArgs") {
-                arguments.push(format!("{argument}..."));
+                arguments.push(GoExpression::spread(argument));
             } else {
                 arguments.push(argument);
             }
         }
 
-        let call = format!("{function}({})", arguments.join(", "));
-        self.plan_function_result_bridge(&mut body, &call, source, target);
-        let body = Renderer.render_setup(&body);
+        let call = GoExpression::call(GoExpression::name(function), arguments);
+        self.plan_function_result_bridge(&mut body, call, source, target);
         let result = target
             .result_go_type(self)
-            .map(|result| self.use_rendered_go_type(result));
-        let signature = match result {
-            Some(result) => format!("func({}) {result}", parameters.join(", ")),
-            None => format!("func({})", parameters.join(", ")),
-        };
-        format!("{signature} {{\n{body}}}")
+            .map(|result| self.use_rendered_go_type(result))
+            .unwrap_or_default();
+        GoExpression::function_literal(
+            parameters.join(", "),
+            result,
+            LoweredBlock { statements: body },
+            FunctionLiteralLayout::MultiLine,
+        )
     }
 
     fn plan_function_result_bridge(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        call: &str,
+        call: GoExpression,
         source: &FunctionLayout,
         target: &FunctionLayout,
     ) {
         match &source.return_abi {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => {
                 if source.result.logical_type().is_unit() {
-                    statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+                    statements.push(expression_statement(call));
                     return;
                 }
                 let bridge = resolve_layout_bridge(self, &source.result, &target.result);
                 let value = self.plan_layout_bridge(statements, call, &bridge);
                 statements.push(plain_return(value));
             }
-            CallableReturnAbi::BareError => statements.push(plain_return(call.to_string())),
+            CallableReturnAbi::BareError => statements.push(plain_return(call)),
             CallableReturnAbi::Result { .. }
             | CallableReturnAbi::Partial { .. }
             | CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
@@ -164,52 +191,52 @@ impl Planner<'_> {
                     1
                 };
                 let mut values = self.create_temp_vars("ret", slot_count + 1);
-                statements.push(LoweredStatement::RawGo(format!(
-                    "{} := {call}\n",
-                    values.join(", ")
-                )));
+                statements.push(define_many(values.clone(), call));
                 let auxiliary = values.pop().expect("a lowered callable has a status slot");
 
                 if matches!(source.return_abi, CallableReturnAbi::Partial { .. }) && !source_flat {
                     let ok_type = source.result.logical_type().ok_type();
-                    if let Some(condition) = self.partial_ok_nil_check(&ok_type, &values[0]) {
-                        statements.push(LoweredStatement::If(IfPlan {
-                            condition_setup: Vec::new(),
+                    if let Some(condition) =
+                        self.partial_ok_nil_check(&ok_type, GoExpression::name(values[0].clone()))
+                    {
+                        statements.push(LoweredStatement::If(IfPlan::plain(
                             condition,
-                            then_body: LoweredBlock {
-                                statements: vec![plain_return(format!("nil, {auxiliary}"))],
+                            LoweredBlock {
+                                statements: vec![multi_value_return(vec![
+                                    GoExpression::nil(),
+                                    GoExpression::name(auxiliary.clone()),
+                                ])],
                             },
-                            else_arm: ElseArm::None,
-                        }));
+                            ElseArm::None,
+                        )));
                     }
                 }
 
                 let mut values = self.bridge_payload_slots(
                     statements,
-                    values,
+                    names(&values),
                     source_payload,
                     target_payload,
                     target.return_abi.has_flattened_payload(),
                 );
-                values.push(auxiliary);
-                statements.push(plain_return(values.join(", ")));
+                values.push(GoExpression::name(auxiliary));
+                statements.push(multi_value_return(values));
             }
             CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let raw = self.hoist_tmp_value_statement(statements, "raw", call);
                 let condition = if self.is_interface_option(source.result.logical_type()) {
                     self.require_stdlib();
-                    format!("lisette.IsNilInterface({raw})")
+                    is_nil_interface(GoExpression::name(raw.clone()))
                 } else {
-                    format!("{raw} == nil")
+                    is_nil(GoExpression::name(raw.clone()))
                 };
-                statements.push(LoweredStatement::If(IfPlan {
-                    condition_setup: Vec::new(),
+                statements.push(LoweredStatement::If(IfPlan::plain(
                     condition,
-                    then_body: LoweredBlock {
-                        statements: vec![plain_return("nil".to_string())],
+                    LoweredBlock {
+                        statements: vec![plain_return(GoExpression::nil())],
                     },
-                    else_arm: ElseArm::None,
-                }));
+                    ElseArm::None,
+                )));
                 let source_payload = source
                     .payload
                     .as_deref()
@@ -219,18 +246,16 @@ impl Planner<'_> {
                     .as_deref()
                     .expect("nullable option target has a payload layout");
                 let bridge = resolve_layout_bridge(self, source_payload, target_payload);
-                let value = self.plan_layout_bridge(statements, &raw, &bridge);
+                let value = self.plan_layout_bridge(statements, GoExpression::name(raw), &bridge);
                 statements.push(plain_return(value));
             }
             CallableReturnAbi::Option(OptionReturnAbi::Sentinel(_)) => {
-                statements.push(plain_return(call.to_string()))
+                statements.push(plain_return(call))
             }
             CallableReturnAbi::Tuple { arity } => {
                 let values = self.create_temp_vars("ret", *arity);
-                statements.push(LoweredStatement::RawGo(format!(
-                    "{} := {call}\n",
-                    values.join(", ")
-                )));
+                statements.push(define_many(values.clone(), call));
+                let values = names(&values);
                 let (
                     ValueLayout::Tuple {
                         elements: source, ..
@@ -240,7 +265,7 @@ impl Planner<'_> {
                     },
                 ) = (source.result.as_ref(), target.result.as_ref())
                 else {
-                    statements.push(plain_return(values.join(", ")));
+                    statements.push(multi_value_return(values));
                     return;
                 };
                 let values = values
@@ -248,10 +273,10 @@ impl Planner<'_> {
                     .zip(source.iter().zip(target))
                     .map(|(value, (source, target))| {
                         let bridge = resolve_layout_bridge(self, source, target);
-                        self.plan_layout_bridge(statements, &value, &bridge)
+                        self.plan_layout_bridge(statements, value, &bridge)
                     })
                     .collect::<Vec<_>>();
-                statements.push(plain_return(values.join(", ")));
+                statements.push(multi_value_return(values));
             }
         }
     }
@@ -261,37 +286,42 @@ impl Planner<'_> {
     fn bridge_payload_slots(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        values: Vec<String>,
+        values: Vec<GoExpression>,
         source: &ValueLayout,
         target: &ValueLayout,
         target_flat: bool,
-    ) -> Vec<String> {
+    ) -> Vec<GoExpression> {
         let source_flat = values.len() > 1;
         if !source_flat && !target_flat {
             let bridge = resolve_layout_bridge(self, source, target);
-            return vec![self.plan_layout_bridge(statements, &values[0], &bridge)];
+            let [value] = <[GoExpression; 1]>::try_from(values)
+                .unwrap_or_else(|_| unreachable!("a packed payload is one value"));
+            return vec![self.plan_layout_bridge(statements, value, &bridge)];
         }
         let source_slots = tuple_slots(source);
         let target_slots = tuple_slots(target);
-        let elements: Vec<String> = if source_flat {
+        let elements: Vec<GoExpression> = if source_flat {
             values
         } else {
+            let packed = &values[0];
             (0..source_slots.len())
-                .map(|index| format!("{}.{}", values[0], TUPLE_FIELDS[index]))
+                .map(|index| {
+                    GoExpression::selector(packed.clone(), TUPLE_FIELDS[index].to_string())
+                })
                 .collect()
         };
-        let bridged: Vec<String> = elements
+        let bridged: Vec<GoExpression> = elements
             .into_iter()
             .zip(source_slots.iter().zip(target_slots))
             .map(|(value, (source, target))| {
                 let bridge = resolve_layout_bridge(self, source, target);
-                self.plan_layout_bridge(statements, &value, &bridge)
+                self.plan_layout_bridge(statements, value, &bridge)
             })
             .collect();
         if target_flat {
             bridged
         } else {
-            vec![self.plan_tuple_from_vars(statements, &bridged, target.logical_type())]
+            vec![self.plan_tuple_from_vars(statements, bridged)]
         }
     }
 
@@ -329,19 +359,33 @@ impl Planner<'_> {
         }
     }
 
+    /// Destructure a Go multi-return into error and value temps. A `Flattened`
+    /// tuple ok type (Go-imported `(T1, ..., Tn, error)`) gets N+1 temps and a
+    /// rebuilt Lisette tuple; a `Packed` one (Lisette `(Tuple_n[...], error)`)
+    /// gets 2 temps like any other ok type.
     fn push_go_returns(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        call_str: &str,
+        call: GoExpression,
         ok_ty: &Type,
         layout: PayloadLayout,
-    ) -> (String, String) {
-        let mut buffer = String::new();
-        let result = self.extract_go_returns(&mut buffer, call_str, ok_ty, layout);
-        if !buffer.is_empty() {
-            statements.push(LoweredStatement::RawGo(buffer));
+    ) -> (String, GoExpression) {
+        if layout.is_flattened()
+            && let Type::Tuple(elements) = ok_ty
+        {
+            let tuple_arity = elements.len();
+            let temp_vars = self.create_temp_vars("ret", tuple_arity + 1);
+            statements.push(define_many(temp_vars.clone(), call));
+            let tuple = self.plan_tuple_from_vars(statements, names(&temp_vars[..tuple_arity]));
+            (temp_vars.last().unwrap().clone(), tuple)
+        } else {
+            let val_var = self.fresh_var(Some("ret"));
+            self.declare(&val_var);
+            let err_var = self.fresh_var(Some("ret"));
+            self.declare(&err_var);
+            statements.push(define_many(vec![val_var.clone(), err_var.clone()], call));
+            (err_var, GoExpression::name(val_var))
         }
-        result
     }
 
     /// Single-leaf write for wrappers that fold to one constructor expression.
@@ -350,22 +394,19 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         target: WrapperTarget<'_>,
         name_hint: &'static str,
-        value_expr: &str,
+        value: GoExpression,
     ) -> WrapperOutcome {
         match target {
             WrapperTarget::FreshSlot => {
-                Some(self.hoist_tmp_value_statement(statements, name_hint, value_expr))
+                Some(self.hoist_tmp_value_statement(statements, name_hint, value))
             }
             WrapperTarget::Slot(name) => {
                 self.declare(name);
-                statements.push(LoweredStatement::RawGo(format!(
-                    "{} := {}\n",
-                    name, value_expr
-                )));
+                statements.push(define(name.to_string(), value));
                 Some(name.to_string())
             }
             WrapperTarget::Return => {
-                statements.push(plain_return(value_expr.to_string()));
+                statements.push(plain_return(value));
                 None
             }
         }
@@ -376,7 +417,7 @@ impl Planner<'_> {
     /// Lower a `(T, error)` Go return into a tagged `Partial`.
     pub(crate) fn lower_partial_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         partial_ty: &Type,
         layout: PayloadLayout,
         payload_bridge: Option<&LayoutBridge>,
@@ -389,41 +430,45 @@ impl Planner<'_> {
         let pkg = go_name::GO_STDLIB_PKG;
 
         let mut statements = Vec::new();
-        let (err_var, val_var) = self.push_go_returns(&mut statements, call_str, &ok_ty, layout);
-        let nil_check = self.partial_ok_nil_check(&ok_ty, &val_var);
+        let (err_var, val_value) = self.push_go_returns(&mut statements, call, &ok_ty, layout);
+        let err = || GoExpression::name(err_var.clone());
+        let val = || val_value.clone();
+        let nil_check = self.partial_ok_nil_check(&ok_ty, val());
 
-        let type_params = format!("{}, {}", ok_ty_str, err_ty_str);
-        let result_ty_str = format!("{pkg}.Partial[{type_params}]");
+        let type_params = format!("[{}, {}]", ok_ty_str, err_ty_str);
+        let result_ty_str = format!("{pkg}.Partial{type_params}");
         let (sink, outcome) =
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
 
-        let (mut both_setup, both_value) =
-            self.plan_optional_payload_bridge(&val_var, payload_bridge);
-        let both = format!("{PARTIAL_BOTH_CTOR}[{type_params}]({both_value}, {err_var})");
-        both_setup.push(leaf_statement(&sink, &both));
+        let (mut both_setup, both_value) = self.plan_optional_payload_bridge(val(), payload_bridge);
+        let both = generic_call(
+            PARTIAL_BOTH_CTOR,
+            type_params.clone(),
+            vec![both_value, err()],
+        );
+        both_setup.push(leaf_statement(&sink, both));
         let both_body = LoweredBlock {
             statements: both_setup,
         };
 
-        let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(&val_var, payload_bridge);
+        let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(val(), payload_bridge);
         ok_setup.push(leaf_statement(
             &sink,
-            &format!("{PARTIAL_OK_CTOR}[{type_params}]({ok_value})"),
+            generic_call(PARTIAL_OK_CTOR, type_params.clone(), vec![ok_value]),
         ));
         let ok_body = LoweredBlock {
             statements: ok_setup,
         };
 
-        let then_body = if let Some(check) = &nil_check {
-            let inner = IfPlan {
-                condition_setup: Vec::new(),
-                condition: check.clone(),
-                then_body: leaf_block(
+        let then_body = if let Some(check) = nil_check {
+            let inner = IfPlan::plain(
+                check,
+                leaf_block(
                     &sink,
-                    &format!("{PARTIAL_ERR_CTOR}[{type_params}]({err_var})"),
+                    generic_call(PARTIAL_ERR_CTOR, type_params, vec![err()]),
                 ),
-                else_arm: ElseArm::from_body(both_body, false),
-            };
+                ElseArm::from_body(both_body, false),
+            );
             LoweredBlock {
                 statements: vec![LoweredStatement::If(inner)],
             }
@@ -433,12 +478,11 @@ impl Planner<'_> {
 
         let else_arm = ElseArm::from_body(ok_body, false);
 
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: format!("{} != nil", err_var),
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            non_nil(err()),
             then_body,
             else_arm,
-        }));
+        )));
         (statements, outcome)
     }
 
@@ -459,12 +503,16 @@ impl Planner<'_> {
         })
     }
 
-    pub(crate) fn partial_ok_nil_check(&mut self, ok_ty: &Type, val: &str) -> Option<String> {
+    pub(crate) fn partial_ok_nil_check(
+        &mut self,
+        ok_ty: &Type,
+        value: GoExpression,
+    ) -> Option<GoExpression> {
         let guard = self.partial_ok_nil_guard(ok_ty)?;
         if guard.is_interface() {
             self.require_stdlib();
         }
-        Some(guard.is_nil(val))
+        Some(guard.is_nil(value))
     }
 
     fn go_result_needs_nil_guard(&self, ok_ty: &Type) -> bool {
@@ -490,7 +538,7 @@ impl Planner<'_> {
     /// Lower a `(T, error)` Go return into a tagged `Result`.
     pub(crate) fn lower_result_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         result_ty: &Type,
         layout: PayloadLayout,
         payload_bridge: Option<&LayoutBridge>,
@@ -501,7 +549,9 @@ impl Planner<'_> {
 
         let mut statements = Vec::new();
         let ok_ty = fallible.ok_ty();
-        let (err_var, ok_val) = self.push_go_returns(&mut statements, call_str, ok_ty, layout);
+        let (err_var, ok_value) = self.push_go_returns(&mut statements, call, ok_ty, layout);
+        let err = || GoExpression::name(err_var.clone());
+        let ok = || ok_value.clone();
 
         let result_ty_str = {
             let mut fe = FalliblePlanner::new(self, &fallible);
@@ -513,90 +563,89 @@ impl Planner<'_> {
         let (sink, outcome) =
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
 
-        let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(&ok_val, payload_bridge);
+        let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(ok(), payload_bridge);
         let ok_wrapper = {
             let mut fe = FalliblePlanner::new(self, &fallible);
-            fe.emit_success(&ok_value)
+            fe.emit_success(ok_value)
         };
-        ok_setup.push(leaf_statement(&sink, &ok_wrapper));
+        ok_setup.push(leaf_statement(&sink, ok_wrapper));
         let ok_body = LoweredBlock {
             statements: ok_setup,
         };
 
         let err_wrapper = {
             let mut fe = FalliblePlanner::new(self, &fallible);
-            fe.emit_failure(Some(&err_var))
+            fe.emit_failure(Some(err()))
         };
-        let then_body = leaf_block(&sink, &err_wrapper);
+        let then_body = leaf_block(&sink, err_wrapper);
 
         let else_arm = if needs_nil_guard {
             let nil_check = if ok_ty.is_tuple() {
-                format!("{}.First", ok_val)
+                GoExpression::selector(ok(), "First".to_string())
             } else {
-                ok_val.clone()
+                ok()
             };
             let nil_condition = if self.facts.is_interface(ok_ty) {
-                format!("lisette.IsNilInterface({})", nil_check)
+                is_nil_interface(nil_check)
             } else {
-                format!("{} == nil", nil_check)
+                is_nil(nil_check)
             };
             self.require_errors();
             let nil_err = {
                 let mut fe = FalliblePlanner::new(self, &fallible);
-                fe.emit_failure(Some("errors.New(\"unexpected nil\")"))
+                fe.emit_failure(Some(unexpected_nil_error()))
             };
-            ElseArm::ElseIf(Box::new(IfPlan {
-                condition_setup: Vec::new(),
-                condition: nil_condition,
-                then_body: leaf_block(&sink, &nil_err),
-                else_arm: ElseArm::from_body(ok_body, false),
-            }))
+            ElseArm::ElseIf(Box::new(IfPlan::plain(
+                nil_condition,
+                leaf_block(&sink, nil_err),
+                ElseArm::from_body(ok_body, false),
+            )))
         } else {
             ElseArm::from_body(ok_body, false)
         };
 
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: format!("{} != nil", err_var),
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            non_nil(err()),
             then_body,
             else_arm,
-        }));
+        )));
         (statements, outcome)
     }
 
     /// Lower a bare `error` Go return into a tagged `Result<(), E>`.
     pub(crate) fn lower_bare_error_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         result_ty: &Type,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let fallible = Fallible::from_type(result_ty).expect("Result type expected");
         debug_assert!(fallible.ok_ty().is_unit());
-        self.lower_unit_result_wrapping(call_str, &fallible, target)
+        self.lower_unit_result_wrapping(call, &fallible, target)
     }
 
     fn plan_optional_payload_bridge(
         &mut self,
-        value: &str,
+        value: GoExpression,
         bridge: Option<&LayoutBridge>,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let mut statements = Vec::new();
-        let value = bridge.map_or_else(
-            || value.to_string(),
-            |bridge| self.plan_layout_bridge(&mut statements, value, bridge),
-        );
+        let value = match bridge {
+            Some(bridge) => self.plan_layout_bridge(&mut statements, value, bridge),
+            None => value,
+        };
         (statements, value)
     }
 
     fn lower_unit_result_wrapping(
         &mut self,
-        call_str: &str,
+        call: GoExpression,
         fallible: &Fallible,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let mut statements = Vec::new();
-        let err_var = self.hoist_tmp_value_statement(&mut statements, "ret", call_str);
+        let err_var = self.hoist_tmp_value_statement(&mut statements, "ret", call);
+        let err = || GoExpression::name(err_var.clone());
 
         let result_ty_str = {
             let mut fe = FalliblePlanner::new(self, fallible);
@@ -608,60 +657,30 @@ impl Planner<'_> {
 
         let err_wrapper = {
             let mut fe = FalliblePlanner::new(self, fallible);
-            fe.emit_failure(Some(&err_var))
+            fe.emit_failure(Some(err()))
         };
-        let then_body = leaf_block(&sink, &err_wrapper);
+        let then_body = leaf_block(&sink, err_wrapper);
 
         let ok_wrapper = {
             let mut fe = FalliblePlanner::new(self, fallible);
-            fe.emit_success("struct{}{}")
+            fe.emit_success(GoExpression::empty_composite("struct{}".to_string()))
         };
-        let else_arm = ElseArm::from_body(leaf_block(&sink, &ok_wrapper), false);
+        let else_arm = ElseArm::from_body(leaf_block(&sink, ok_wrapper), false);
 
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: format!("{} != nil", err_var),
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            non_nil(err()),
             then_body,
             else_arm,
-        }));
+        )));
         (statements, outcome)
-    }
-
-    /// Destructure a Go multi-return into error and value temps. A `Flattened`
-    /// tuple ok type (Go-imported `(T1, ..., Tn, error)`) gets N+1 temps and a
-    /// rebuilt Lisette tuple; a `Packed` one (Lisette `(Tuple_n[...], error)`)
-    /// gets 2 temps like any other ok type.
-    fn extract_go_returns(
-        &mut self,
-        output: &mut String,
-        call_str: &str,
-        ok_ty: &Type,
-        layout: PayloadLayout,
-    ) -> (String, String) {
-        if layout.is_flattened()
-            && let Type::Tuple(elements) = ok_ty
-        {
-            let tuple_arity = elements.len();
-            let temp_vars = self.create_temp_vars("ret", tuple_arity + 1);
-            write_line!(output, "{} := {}", temp_vars.join(", "), call_str);
-            let tuple_var = self.emit_tuple_from_vars(output, &temp_vars[..tuple_arity], ok_ty);
-            (temp_vars.last().unwrap().clone(), tuple_var)
-        } else {
-            let val_var = self.fresh_var(Some("ret"));
-            self.declare(&val_var);
-            let err_var = self.fresh_var(Some("ret"));
-            self.declare(&err_var);
-            write_line!(output, "{}, {} := {}", val_var, err_var, call_str);
-            (err_var, val_var)
-        }
     }
 
     fn hoist_go_fn_if_needed(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-    ) -> String {
-        let go_fn_str = self.capture_operand_into(setup, expression);
+    ) -> GoExpression {
+        let go_fn = self.capture_operand_into(setup, expression);
 
         let is_go_package_fn = matches!(
             expression.unwrap_parens(),
@@ -670,50 +689,51 @@ impl Planner<'_> {
                 .is_some_and(|m| m.starts_with(go_name::GO_IMPORT_PREFIX))
         );
         if is_go_package_fn {
-            return go_fn_str;
+            return go_fn;
         }
 
         if is_order_sensitive(expression) {
-            self.hoist_tmp_value_statement(setup, "fn", &go_fn_str)
+            GoExpression::name(self.hoist_tmp_value_statement(setup, "fn", go_fn))
         } else {
-            go_fn_str
+            go_fn
         }
     }
 
     pub(crate) fn build_wrapper_params(
         &mut self,
         params: &[FunctionParameter],
-    ) -> (Vec<String>, Vec<String>) {
+    ) -> (Vec<String>, Vec<GoExpression>) {
         let mut param_strs = Vec::new();
-        let mut arg_names = Vec::new();
+        let mut arguments = Vec::new();
         let last_index = params.len().saturating_sub(1);
         for (i, param) in params.iter().enumerate() {
             let name = format!("arg{}", i);
             let ty_str = self.use_go_type(&param.ty);
             param_strs.push(format!("{} {}", name, ty_str));
+            let argument = GoExpression::name(name);
             if i == last_index && param.ty.get_name() == Some("VarArgs") {
-                arg_names.push(format!("{}...", name));
+                arguments.push(GoExpression::spread(argument));
             } else {
-                arg_names.push(name);
+                arguments.push(argument);
             }
         }
-        (param_strs, arg_names)
+        (param_strs, arguments)
     }
 
     /// Common wrapper-builder prologue: returns `(return_type, param_strs,
-    /// call_str)` for a go-fn expression, or `None` for non-function types.
+    /// call)` for a go-fn expression, or `None` for non-function types.
     fn wrapper_call_parts(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-    ) -> Option<(Type, Vec<String>, String)> {
+    ) -> Option<(Type, Vec<String>, GoExpression)> {
         let fn_type = expression.get_type();
         let f = fn_type.as_function_type()?;
         let (params, return_type) = (f.params.clone(), (*f.return_type).clone());
-        let go_fn_str = self.hoist_go_fn_if_needed(setup, expression);
-        let (param_strs, arg_names) = self.build_wrapper_params(&params);
-        let call_str = format!("{}({})", go_fn_str, arg_names.join(", "));
-        Some((return_type, param_strs, call_str))
+        let go_fn = self.hoist_go_fn_if_needed(setup, expression);
+        let (param_strs, arguments) = self.build_wrapper_params(&params);
+        let call = GoExpression::call(go_fn, arguments);
+        Some((return_type, param_strs, call))
     }
 
     pub(crate) fn emit_go_fn_wrapper(
@@ -721,10 +741,10 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         abi: &CallableAbi,
-    ) -> String {
+    ) -> GoExpression {
         self.require_stdlib();
 
-        let (return_type, param_strs, call_str) = self
+        let (return_type, param_strs, call) = self
             .wrapper_call_parts(setup, expression)
             .expect("expected function type");
 
@@ -737,37 +757,32 @@ impl Planner<'_> {
             }
             CallableReturnAbi::Tuple { arity } => {
                 let temp_vars = self.create_temp_vars("ret", *arity);
-                statements.push(LoweredStatement::RawGo(format!(
-                    "{} := {}\n",
-                    temp_vars.join(", "),
-                    call_str
-                )));
-                Some(self.plan_tuple_from_vars(&mut statements, &temp_vars, &return_type))
+                statements.push(define_many(temp_vars.clone(), call));
+                Some(self.plan_tuple_from_vars(&mut statements, names(&temp_vars)))
             }
             result => {
                 let payload_bridge = self.go_return_payload_bridge(abi, &return_type);
                 let (wrap, outcome) = self.lower_abi_wrapping_with_payload_bridge(
-                    &call_str,
+                    call,
                     result,
                     &return_type,
                     payload_bridge.as_ref(),
                     WrapperTarget::Return,
                 );
                 statements.extend(wrap);
-                outcome
+                outcome.map(GoExpression::name)
             }
         };
 
-        let mut body = Renderer.render_setup(&statements);
-        if let Some(result_var) = outcome {
-            write_line!(body, "return {}", result_var);
+        if let Some(result) = outcome {
+            statements.push(plain_return(result));
         }
 
-        format!(
-            "func({}) {} {{\n{}}}",
+        GoExpression::function_literal(
             param_strs.join(", "),
             ret_ty_str,
-            body
+            LoweredBlock { statements },
+            FunctionLiteralLayout::MultiLine,
         )
     }
 
@@ -776,10 +791,10 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-    ) -> String {
+    ) -> GoExpression {
         self.require_stdlib();
 
-        let (return_type, param_strs, call_str) = self
+        let (return_type, param_strs, call) = self
             .wrapper_call_parts(setup, expression)
             .expect("expected function type");
 
@@ -792,17 +807,20 @@ impl Planner<'_> {
         );
         let arity = ok_ty.tuple_arity().expect("tuple ok type");
 
-        let mut body = String::new();
+        let mut statements = Vec::new();
         let temp_vars = self.create_temp_vars("ret", arity + 1);
-        write_line!(body, "{} := {}", temp_vars.join(", "), call_str);
-        let tuple_str = self.emit_tuple_from_vars(&mut body, &temp_vars[..arity], &ok_ty);
-        write_line!(body, "return {}, {}", tuple_str, temp_vars[arity]);
+        statements.push(define_many(temp_vars.clone(), call));
+        let tuple = self.plan_tuple_from_vars(&mut statements, names(&temp_vars[..arity]));
+        statements.push(multi_value_return(vec![
+            tuple,
+            GoExpression::name(temp_vars[arity].clone()),
+        ]));
 
-        format!(
-            "func({}) {} {{\n{}}}",
+        GoExpression::function_literal(
             param_strs.join(", "),
             ret_ty_str,
-            body
+            LoweredBlock { statements },
+            FunctionLiteralLayout::MultiLine,
         )
     }
 
@@ -811,24 +829,36 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         sentinel: i64,
-    ) -> String {
-        let (return_type, param_strs, call_str) = self
+    ) -> GoExpression {
+        let (return_type, param_strs, call) = self
             .wrapper_call_parts(setup, expression)
             .expect("expected function type");
 
         let inner_ty_str = self.use_go_type(&return_type.ok_type());
         let ret_var = self.fresh_var(Some("ret"));
         self.declare(&ret_var);
+        let ret = || GoExpression::name(ret_var.clone());
 
-        let mut body = String::new();
-        write_line!(body, "{} := {}", ret_var, call_str);
-        write_line!(body, "return {}, {} != {}", ret_var, ret_var, sentinel);
+        let statements = vec![
+            define(ret_var.clone(), call),
+            multi_value_return(vec![
+                ret(),
+                GoExpression::binary(ret(), "!=", GoExpression::literal(sentinel.to_string())),
+            ]),
+        ];
 
-        format!(
-            "func({}) ({}, bool) {{\n{}}}",
+        GoExpression::function_literal(
             param_strs.join(", "),
-            inner_ty_str,
-            body
+            format!("({}, bool)", inner_ty_str),
+            LoweredBlock { statements },
+            FunctionLiteralLayout::MultiLine,
         )
     }
+}
+
+pub(crate) fn unexpected_nil_error() -> GoExpression {
+    GoExpression::call(
+        GoExpression::name("errors.New".to_string()),
+        vec![GoExpression::literal("\"unexpected nil\"".to_string())],
+    )
 }

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -2,10 +2,12 @@ use super::NativeCallContext;
 use crate::Planner;
 use crate::calls::dispatch::extract_native_method_name;
 use crate::context::expression::ExpressionContext;
+use crate::control_flow::propagation::plain_return;
 use crate::expressions::access::index_access::range_var_bounds;
 use crate::names::go_name;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{LoweredBlock, LoweredStatement};
 use crate::plan::calls::plan_variadic_spread;
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
@@ -625,12 +627,12 @@ impl Planner<'_> {
             {
                 let mut staged = self.stage_native_method(ctx, form);
                 self.require_slices();
-                let searched = staged.arguments[0].as_str().to_string();
-                let target = self.hoist_tmp_value_statement(&mut staged.setup, "want", &searched);
-                let predicate = self.contains_predicate(&element, &target, &[]);
+                let searched = staged.arguments[0].clone();
+                let target = self.hoist_tmp_value_statement(&mut staged.setup, "want", searched);
+                let predicate = self.contains_predicate(&element, GoExpression::name(target), &[]);
                 let body = GoExpression::call(
                     GoExpression::name("slices.ContainsFunc".to_string()),
-                    vec![staged.receiver.clone(), GoExpression::opaque(predicate)],
+                    vec![staged.receiver.clone(), predicate],
                 );
                 return staged.finish(body);
             }
@@ -769,7 +771,7 @@ impl Planner<'_> {
                 receiver
             }
         } else {
-            GoExpression::name(self.hoist_tmp_value_statement(setup, "arr", receiver.as_str()))
+            GoExpression::name(self.hoist_tmp_value_statement(setup, "arr", receiver))
         };
         GoExpression::slice(base, None, None, None)
     }
@@ -983,7 +985,7 @@ impl Planner<'_> {
     pub(super) fn lower_map_index_pair(
         &mut self,
         expression: &Expression,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let Expression::Call {
             expression: function,
             args,
@@ -1012,7 +1014,7 @@ impl Planner<'_> {
         let mut staged = self.stage_native_method(&ctx, NativeMethodForm::Dot);
         let receiver = super::comma_ok::parenthesize_prefixed_expression(staged.receiver);
         let key = staged.arguments.remove(0);
-        (staged.setup, GoExpression::index(receiver, key).rendered())
+        (staged.setup, GoExpression::index(receiver, key))
     }
 
     fn lower_string_substring(
@@ -1092,39 +1094,25 @@ impl Planner<'_> {
         )
     }
 
-    pub(crate) fn render_equality(
+    pub(crate) fn equality_expression(
         &mut self,
-        lhs: &str,
-        rhs: &str,
+        lhs: GoExpression,
+        rhs: GoExpression,
         ty: &Type,
         generics: &[Generic],
-    ) -> String {
-        self.equality_test(
-            GoExpression::opaque(lhs.to_string()),
-            GoExpression::opaque(rhs.to_string()),
-            ty,
-            generics,
-            false,
-        )
-        .rendered()
+    ) -> GoExpression {
+        self.equality_test(lhs, rhs, ty, generics, false)
     }
 
     /// `!=` where equality is an operator, a `!` prefix where it is a call.
-    pub(crate) fn render_inequality(
+    pub(crate) fn inequality_expression(
         &mut self,
-        lhs: &str,
-        rhs: &str,
+        lhs: GoExpression,
+        rhs: GoExpression,
         ty: &Type,
         generics: &[Generic],
-    ) -> String {
-        self.equality_test(
-            GoExpression::opaque(lhs.to_string()),
-            GoExpression::opaque(rhs.to_string()),
-            ty,
-            generics,
-            true,
-        )
-        .rendered()
+    ) -> GoExpression {
+        self.equality_test(lhs, rhs, ty, generics, true)
     }
 
     fn equality_test(
@@ -1154,7 +1142,7 @@ impl Planner<'_> {
                     let eq = self.equality_closure(&elem, generics);
                     negate(GoExpression::call(
                         GoExpression::name("slices.EqualFunc".to_string()),
-                        vec![lhs, rhs, GoExpression::opaque(eq)],
+                        vec![lhs, rhs, eq],
                     ))
                 }
                 _ => negate(GoExpression::call(
@@ -1173,7 +1161,7 @@ impl Planner<'_> {
                     let eq = self.equality_closure(&value, generics);
                     negate(GoExpression::call(
                         GoExpression::name("maps.EqualFunc".to_string()),
-                        vec![lhs, rhs, GoExpression::opaque(eq)],
+                        vec![lhs, rhs, eq],
                     ))
                 }
                 _ => negate(GoExpression::call(
@@ -1192,19 +1180,30 @@ impl Planner<'_> {
         GoExpression::binary(lhs, operator, rhs)
     }
 
-    fn equality_closure(&mut self, ty: &Type, generics: &[Generic]) -> String {
+    fn equality_closure(&mut self, ty: &Type, generics: &[Generic]) -> GoExpression {
         let go_ty = self.use_go_type(ty);
         let a = self.fresh_var(Some("a"));
         let b = self.fresh_var(Some("b"));
-        let body = self.render_equality(&a, &b, ty, generics);
-        format!("func({a} {go_ty}, {b} {go_ty}) bool {{ return {body} }}")
+        let body = self.equality_expression(
+            GoExpression::name(a.clone()),
+            GoExpression::name(b.clone()),
+            ty,
+            generics,
+        );
+        predicate_literal(format!("{a} {go_ty}, {b} {go_ty}"), body)
     }
 
-    fn contains_predicate(&mut self, ty: &Type, target: &str, generics: &[Generic]) -> String {
+    fn contains_predicate(
+        &mut self,
+        ty: &Type,
+        target: GoExpression,
+        generics: &[Generic],
+    ) -> GoExpression {
         let go_ty = self.use_go_type(ty);
         let element = self.fresh_var(Some("e"));
-        let body = self.render_equality(&element, target, ty, generics);
-        format!("func({element} {go_ty}) bool {{ return {body} }}")
+        let body =
+            self.equality_expression(GoExpression::name(element.clone()), target, ty, generics);
+        predicate_literal(format!("{element} {go_ty}"), body)
     }
 
     fn needs_custom_equality(&self, ty: &Type, generics: &[Generic]) -> bool {
@@ -1215,6 +1214,17 @@ impl Planner<'_> {
         let peeled = self.facts.peel_alias(ty);
         peeled.is_slice() || peeled.is_map()
     }
+}
+
+fn predicate_literal(parameters: String, body: GoExpression) -> GoExpression {
+    GoExpression::function_literal(
+        parameters,
+        "bool".to_string(),
+        LoweredBlock {
+            statements: vec![plain_return(body)],
+        },
+        FunctionLiteralLayout::Inline,
+    )
 }
 
 fn is_cloneable_container(ty: &Type) -> bool {

--- a/crates/emit/src/calls/predicates.rs
+++ b/crates/emit/src/calls/predicates.rs
@@ -1,8 +1,8 @@
 use crate::Planner;
-use crate::calls::comma_ok::CommaOkValueSlot;
+use crate::calls::comma_ok::{CommaOkValueSlot, PairCondition};
 use crate::patterns::matching::{OptionFusePlan, ResultFusePlan};
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
+use crate::plan::values::{EvaluationEffect, ValuePlan};
 use syntax::ast::{Expression, UnaryOperator};
 use syntax::program::CallKind;
 
@@ -75,7 +75,7 @@ impl Planner<'_> {
         predicate: FusedPredicate<'_>,
         negated: bool,
         slot: CommaOkValueSlot,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, PairCondition) {
         match predicate {
             FusedPredicate::Result { fuse, succeeds } => {
                 let pair = fuse.bind(self, slot, None);
@@ -101,7 +101,7 @@ impl Planner<'_> {
     pub(crate) fn lower_fused_predicate_condition(
         &mut self,
         condition: &Expression,
-    ) -> Option<(Vec<LoweredStatement>, String)> {
+    ) -> Option<(Vec<LoweredStatement>, PairCondition)> {
         let (target, negated) = strip_negations(condition);
         let predicate = self.fused_predicate(target)?;
         Some(self.bind_fused_predicate(predicate, negated, CommaOkValueSlot::Unused))
@@ -115,9 +115,10 @@ impl Planner<'_> {
         let predicate = self.fused_predicate(expression)?;
         let (setup, condition) =
             self.bind_fused_predicate(predicate, negated, CommaOkValueSlot::Discarded);
+        debug_assert!(condition.initializer.is_none());
         Some(ValuePlan::plain_call(
             setup,
-            GoExpression::opaque_with_deferred_evaluation(condition, true),
+            condition.condition.with_deferred_evaluation(true),
             EvaluationEffect::EffectfulCall,
         ))
     }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -16,13 +16,14 @@ use crate::context::expression::ExpressionContext;
 use crate::expressions::staging::LaterStages;
 use crate::expressions::staging::{SpreadSequenceOptions, VariadicCombine};
 use crate::names::generics::extract_type_mapping;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{
+    LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign, define,
+};
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee};
 use crate::plan::go_expression::GoExpressionNode;
 use crate::plan::values::{
     CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
 };
-use crate::write_line;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::types::Type;
 
@@ -351,11 +352,8 @@ impl<'a> Planner<'a> {
             && LaterStages::sequenced(&args_setup, args_effect)
                 .can_change(self.place_read_stability(function));
         if callee_needs_pin {
-            callee = GoExpression::name(self.hoist_tmp_value_statement(
-                &mut setup,
-                "callee",
-                callee.as_str(),
-            ));
+            let pinned = self.hoist_tmp_value_statement(&mut setup, "callee", callee);
+            callee = GoExpression::name(pinned);
         }
 
         let call = match collapse_fmt_print(self, &callee, args, &arguments) {
@@ -582,7 +580,7 @@ impl<'a> Planner<'a> {
 
     /// Classify and lower a single call argument: dispatch is plan-driven and
     /// returns typed setup. The plain `Direct` / `TaggedGoLowering` paths produce
-    /// typed `TempBind` setup; adapter and slot-bridge paths retain their own
+    /// `Define` setup; adapter and slot-bridge paths retain their own
     /// structured setup until sequencing.
     fn lower_call_arg(
         &mut self,
@@ -627,8 +625,8 @@ impl<'a> Planner<'a> {
                 let arg_ctx = self.direct_arg_emit_ctx(param, true);
                 let argument = self.lower_composite_value(arg, arg_ctx);
                 argument.map_expression_as_computed(|setup, value| {
-                    let lowered = self.emit_lower_arg_to_tagged(setup, value.as_str(), target);
-                    GoExpression::opaque_with_deferred_evaluation(lowered, true)
+                    self.emit_lower_arg_to_tagged(setup, value, target)
+                        .with_deferred_evaluation(true)
                 })
             }
             ArgumentPlan::Direct => self.lower_direct_arg(arg, ctx, param, declared_param_ty),
@@ -887,20 +885,9 @@ impl<'a> Planner<'a> {
             ExpressionContext::value().with_function_slot_origin(param_origin),
         );
         Some(argument.map_expression_as_computed(|setup, value| {
-            let mut buffer = String::new();
-            let adapted = emit_fn_arg_shape_adapter(
-                self,
-                &mut buffer,
-                value.as_str(),
-                &arg_fn,
-                &arg_abi,
-                &param_abi,
-            )
-            .expect("fn_arg_shapes resolved a function signature");
-            if !buffer.is_empty() {
-                setup.push(LoweredStatement::RawGo(buffer));
-            }
-            GoExpression::opaque_with_deferred_evaluation(adapted, true)
+            emit_fn_arg_shape_adapter(self, setup, value, &arg_fn, &arg_abi, &param_abi)
+                .expect("fn_arg_shapes resolved a function signature")
+                .with_deferred_evaluation(true)
         }))
     }
 
@@ -940,13 +927,9 @@ impl<'a> Planner<'a> {
         let source = self
             .lower_value(spread, ExpressionContext::value())
             .map_expression_as_name(|setup, source_value| {
-                GoExpression::name(self.hoist_tmp_value_statement(
-                    setup,
-                    "src",
-                    source_value.as_str(),
-                ))
+                GoExpression::name(self.hoist_tmp_value_statement(setup, "src", source_value))
             });
-        let source_variable = source.rendered();
+        let source_variable = source.expression.clone();
 
         let target_element_ret = self.render_lowered_return_ty(&param_abi, arg_ret);
         let arg_fn_params = arg_fn.get_function_params().unwrap_or(&[]);
@@ -964,20 +947,47 @@ impl<'a> Planner<'a> {
         self.declare(&adapted);
         let loop_cb = self.fresh_var(Some("cb"));
 
-        let mut body = String::new();
-        let closure =
-            emit_fn_arg_shape_adapter(self, &mut body, &loop_cb, &arg_fn, &arg_abi, &param_abi)?;
-        write_line!(body, "{}[i] = {}", adapted, closure);
+        let mut body = Vec::new();
+        let closure = emit_fn_arg_shape_adapter(
+            self,
+            &mut body,
+            GoExpression::name(loop_cb.clone()),
+            &arg_fn,
+            &arg_abi,
+            &param_abi,
+        )?;
+        body.push(assign(
+            GoExpression::index(
+                GoExpression::name(adapted.clone()),
+                GoExpression::name("i".to_string()),
+            ),
+            closure,
+        ));
 
         Some(source.map_expression_as_name(|setup, _source_value| {
-            setup.push(LoweredStatement::RawGo(format!(
-                "{} := make([]{}, len({}))\n",
-                adapted, target_element_ty, source_variable
-            )));
-            setup.push(LoweredStatement::RawGo(format!(
-                "for i, {} := range {} {{\n{}}}\n",
-                loop_cb, source_variable, body
-            )));
+            setup.push(define(
+                adapted.clone(),
+                GoExpression::call(
+                    GoExpression::name("make".to_string()),
+                    vec![
+                        GoExpression::type_name(format!("[]{target_element_ty}")),
+                        GoExpression::call(
+                            GoExpression::name("len".to_string()),
+                            vec![source_variable.clone()],
+                        ),
+                    ],
+                ),
+            ));
+            setup.push(LoweredStatement::Loop(LoopPlan {
+                prologue: Vec::new(),
+                kind: LoopKind::Generated { label: None },
+                header: LoopHeader::Range {
+                    key: Some("i".to_string()),
+                    value: Some(loop_cb),
+                    iterable: source_variable,
+                },
+                body: LoweredBlock { statements: body },
+            }));
             GoExpression::name(adapted)
         }))
     }
@@ -1045,32 +1055,15 @@ impl<'a> Planner<'a> {
                         .facts
                         .resolve_to_function_type(effective_param_ty.unwrap_forall())
                         .expect("callback target resolves to a fn type");
-                    GoExpression::opaque(emit_lisette_callback_wrapper(
-                        self,
-                        setup,
-                        value.as_str(),
-                        &param_fn_ty,
-                    ))
+                    emit_lisette_callback_wrapper(self, setup, value, &param_fn_ty)
                 }
                 AbiTransition::WrapToTagged | AbiTransition::Reencode => {
                     let arg_fn_ty = self
                         .facts
                         .resolve_to_function_type(arg.get_type().unwrap_forall())
                         .expect("callback source resolves to a fn type");
-                    let mut buffer = String::new();
-                    let adapted = emit_fn_arg_shape_adapter(
-                        self,
-                        &mut buffer,
-                        value.as_str(),
-                        &arg_fn_ty,
-                        source,
-                        target,
-                    )
-                    .expect("callback ABI transition has a function signature");
-                    if !buffer.is_empty() {
-                        setup.push(LoweredStatement::RawGo(buffer));
-                    }
-                    GoExpression::opaque(adapted)
+                    emit_fn_arg_shape_adapter(self, setup, value, &arg_fn_ty, source, target)
+                        .expect("callback ABI transition has a function signature")
                 }
                 AbiTransition::Incompatible => {
                     unreachable!("type-checked callback ABIs must describe the same result")

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -5,9 +5,11 @@ use super::native::NativeCallResult;
 use super::{NativeCallContext, NativeMethodCall};
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
+use crate::control_flow::fallible::generic_call;
 use crate::names::go_name;
 use crate::plan::bodies::{
-    ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan,
+    ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
+    PlacePlan, assign, define,
 };
 use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression};
@@ -133,6 +135,10 @@ struct SliceLoopShape<'a> {
     element_ty: Type,
 }
 
+fn name(text: &str) -> GoExpression {
+    GoExpression::name(text.to_string())
+}
+
 impl Planner<'_> {
     /// The parts of a `map`, `filter`, `fold`, or `find` call that inline as a loop.
     fn slice_loop_shape<'a>(
@@ -256,7 +262,8 @@ impl Planner<'_> {
         }
         let sequenced = self.sequence_values(stages, ctx.capture_boundary, "arg");
         let effect = sequenced.effect;
-        let (mut setup, values) = sequenced.into_rendered();
+        let mut setup = sequenced.setup;
+        let values = sequenced.values;
         let source = values[0].clone();
 
         let result = match (found, ctx.result_name) {
@@ -274,10 +281,10 @@ impl Planner<'_> {
                         value: None,
                     });
                 }
-                setup.push(LoweredStatement::TempBind {
-                    name: sink.flag.to_string(),
-                    value: "false".to_string(),
-                });
+                setup.push(define(
+                    sink.flag.to_string(),
+                    GoExpression::literal("false".to_string()),
+                ));
             }
             None => {
                 self.declare(&result);
@@ -316,16 +323,14 @@ impl Planner<'_> {
         });
 
         // Go rejects a range variable nothing reads.
-        let header = match (&index, element_name.as_str()) {
-            (Some(index), "_") => index.clone(),
-            (Some(index), element) => format!("{}, {}", index, element),
-            (None, "_") => String::new(),
-            (None, element) => format!("_, {}", element),
-        };
-        let header = if header.is_empty() {
-            format!("for range {} {{\n", source)
-        } else {
-            format!("for {} := range {} {{\n", header, source)
+        let header = LoopHeader::Range {
+            key: match (&index, element_name.as_str()) {
+                (Some(index), _) => Some(index.clone()),
+                (None, "_") => None,
+                (None, _) => Some("_".to_string()),
+            },
+            value: (element_name != "_").then_some(element_name),
+            iterable: source,
         };
         setup.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
@@ -390,33 +395,43 @@ impl Planner<'_> {
         kind: SliceLoop,
         result: &str,
         result_ty: &Type,
-        source: &str,
-        init: Option<&String>,
+        source: &GoExpression,
+        init: Option<&GoExpression>,
     ) -> LoweredStatement {
         match kind {
             SliceLoop::Map => {
                 let element = self.first_type_argument_go_string(result_ty);
-                LoweredStatement::TempBind {
-                    name: result.to_string(),
-                    value: format!("make([]{}, len({}))", element, source),
-                }
+                define(
+                    result.to_string(),
+                    GoExpression::call(
+                        name("make"),
+                        vec![
+                            GoExpression::type_name(format!("[]{}", element)),
+                            GoExpression::call(name("len"), vec![source.clone()]),
+                        ],
+                    ),
+                )
             }
-            SliceLoop::Filter => LoweredStatement::RawGo(format!(
-                "var {} []{}\n",
-                result,
-                self.first_type_argument_go_string(result_ty)
-            )),
-            SliceLoop::Fold => LoweredStatement::TempBind {
+            SliceLoop::Filter => LoweredStatement::VarDecl {
                 name: result.to_string(),
-                value: init.expect("fold stages its initial value").clone(),
+                go_type: format!("[]{}", self.first_type_argument_go_string(result_ty)),
+                value: None,
             },
+            SliceLoop::Fold => define(
+                result.to_string(),
+                init.expect("fold stages its initial value").clone(),
+            ),
             SliceLoop::Find => {
                 self.require_stdlib();
                 let payload = self.first_type_argument_go_string(result_ty);
-                LoweredStatement::TempBind {
-                    name: result.to_string(),
-                    value: format!("{}.MakeOptionNone[{}]()", go_name::GO_STDLIB_PKG, payload),
-                }
+                define(
+                    result.to_string(),
+                    generic_call(
+                        &format!("{}.MakeOptionNone", go_name::GO_STDLIB_PKG),
+                        format!("[{}]", payload),
+                        Vec::new(),
+                    ),
+                )
             }
         }
     }
@@ -437,11 +452,11 @@ impl Planner<'_> {
         if let SliceLoop::Map | SliceLoop::Fold = kind {
             let (slot, target_ty) = match kind {
                 SliceLoop::Map => (
-                    format!("{}[{}]", result, index.expect("map binds a loop index")),
+                    GoExpression::index(name(result), name(index.expect("map binds a loop index"))),
                     self.first_type_argument(result_ty)
                         .expect("map returns a slice carrying its element type"),
                 ),
-                _ => (result.to_string(), result_ty.clone()),
+                _ => (name(result), result_ty.clone()),
             };
             let place = PlacePlan::Assign {
                 local: &slot,
@@ -454,45 +469,46 @@ impl Planner<'_> {
         let (mut statements, condition) = plan.into_parts();
         let then_body = match kind {
             SliceLoop::Filter => LoweredBlock {
-                statements: vec![LoweredStatement::RawGo(format!(
-                    "{} = append({}, {})\n",
-                    result, result, element_name
-                ))],
+                statements: vec![assign(
+                    name(result),
+                    GoExpression::call(name("append"), vec![name(result), name(element_name)]),
+                )],
             },
             SliceLoop::Find => {
                 let mut statements = Vec::new();
                 match found {
                     Some(sink) => {
                         if let Some(value) = sink.value {
-                            statements.push(LoweredStatement::RawGo(format!(
-                                "{value} = {element_name}\n"
-                            )));
+                            statements.push(assign(name(value), name(element_name)));
                         }
-                        statements.push(LoweredStatement::RawGo(format!("{} = true\n", sink.flag)));
+                        statements.push(assign(
+                            name(sink.flag),
+                            GoExpression::literal("true".to_string()),
+                        ));
                     }
                     None => {
                         self.require_stdlib();
                         let payload = self.use_go_type(element_ty);
-                        statements.push(LoweredStatement::RawGo(format!(
-                            "{} = {}.MakeOptionSome[{}]({})\n",
-                            result,
-                            go_name::GO_STDLIB_PKG,
-                            payload,
-                            element_name
-                        )));
+                        statements.push(assign(
+                            name(result),
+                            generic_call(
+                                &format!("{}.MakeOptionSome", go_name::GO_STDLIB_PKG),
+                                format!("[{}]", payload),
+                                vec![name(element_name)],
+                            ),
+                        ));
                     }
                 }
-                statements.push(LoweredStatement::RawGo("break\n".to_string()));
+                statements.push(LoweredStatement::Break(LoopTransfer::Unlabeled));
                 LoweredBlock { statements }
             }
             SliceLoop::Map | SliceLoop::Fold => unreachable!("assign-place kinds returned above"),
         };
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
+        statements.push(LoweredStatement::If(IfPlan::plain(
             condition,
             then_body,
-            else_arm: ElseArm::None,
-        }));
+            ElseArm::None,
+        )));
         statements
     }
 

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -323,7 +323,7 @@ impl Planner<'_> {
     ) -> ValuePlan {
         let value = mem::replace(&mut stage.expression, GoExpression::empty());
         if matches!(receiver.unwrap_parens(), Expression::Call { .. }) {
-            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", value.as_str());
+            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", value);
             stage.expression = GoExpression::address_of(GoExpression::name(tmp));
             return stage.into_addressed_location();
         }
@@ -336,7 +336,7 @@ impl Planner<'_> {
             stage.make_observable_computed();
             stage
         } else {
-            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", addressed.as_str());
+            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", addressed);
             ValuePlan::captured(stage.setup, tmp)
         }
     }

--- a/crates/emit/src/calls/unwrap_or.rs
+++ b/crates/emit/src/calls/unwrap_or.rs
@@ -4,7 +4,7 @@ use crate::context::expression::ExpressionContext;
 use crate::patterns::matching::{OptionArms, OptionFusePlan, ResultFusePlan};
 use crate::plan::bodies::{AssignForm, ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
 use crate::plan::placement::collapse_declared_temp;
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::{Expression, Literal, Pattern};
 use syntax::types::Type;
 
@@ -160,7 +160,7 @@ impl Planner<'_> {
                 let bound = fuse.bind(self, slot);
                 let failure = bound.none_condition(self);
                 let value = bound
-                    .value()
+                    .value_name()
                     .expect("a payload slot was requested")
                     .to_string();
                 (bound.statements, failure, value)
@@ -176,11 +176,12 @@ impl Planner<'_> {
         statements.append(&mut default.setup);
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: failure,
+            initializer: failure.initializer,
+            condition: failure.condition,
             then_body: LoweredBlock {
                 statements: vec![LoweredStatement::Assign(AssignForm::Simple {
                     target_capture: Vec::new(),
-                    target_str: value.clone(),
+                    target: GoExpression::name(value.clone()),
                     value: default,
                 })],
             },
@@ -202,11 +203,12 @@ impl Planner<'_> {
             some_body: map.body,
             none_body: default,
         };
+        let target = GoExpression::name(target.to_string());
         self.lower_fused_option_arms(
             fuse,
             arms,
             &PlacePlan::Assign {
-                local: target,
+                local: &target,
                 target_ty: Some(target_ty),
             },
         )

--- a/crates/emit/src/calls/wrap_err.rs
+++ b/crates/emit/src/calls/wrap_err.rs
@@ -7,7 +7,7 @@ use syntax::ast::{Expression, FormatStringPart, Literal};
 
 pub(crate) struct WrapMessage {
     format: String,
-    args: Vec<String>,
+    args: Vec<GoExpression>,
 }
 
 impl Planner<'_> {
@@ -102,8 +102,7 @@ impl Planner<'_> {
                             values.push(value);
                         }
                     }
-                    let (format, args) = self.sprintf_pieces(parts, values, true);
-                    (format, args.iter().map(GoExpression::rendered).collect())
+                    self.sprintf_pieces(parts, values, true)
                 }
                 _ => {
                     let value = self.lower_composite_value(message, ExpressionContext::value());
@@ -118,16 +117,17 @@ impl Planner<'_> {
         (setup, prepared)
     }
 
-    pub(crate) fn wrap_error(&mut self, messages: &[WrapMessage], error: String) -> String {
+    pub(crate) fn wrap_error(
+        &mut self,
+        messages: &[WrapMessage],
+        error: GoExpression,
+    ) -> GoExpression {
         messages.iter().fold(error, |error, message| {
             self.require_fmt();
-            let mut args = message.args.clone();
+            let mut args = vec![GoExpression::literal(format!("\"{}: %w\"", message.format))];
+            args.extend(message.args.iter().cloned());
             args.push(error);
-            format!(
-                "fmt.Errorf(\"{}: %w\", {})",
-                message.format,
-                args.join(", ")
-            )
+            GoExpression::call(GoExpression::name("fmt.Errorf".to_string()), args)
         })
     }
 }

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -121,18 +121,37 @@ impl Fallible {
         self.is_result()
     }
 
-    fn make_success(&self, value: &str, inner_ty: &str, err_ty: Option<&str>) -> String {
-        let pkg = go_name::GO_STDLIB_PKG;
+    fn make_success(
+        &self,
+        value: GoExpression,
+        inner_ty: &str,
+        err_ty: Option<&str>,
+    ) -> GoExpression {
         match self {
             Self::Option { .. } => {
-                format!("{pkg}.MakeOptionSome[{}]({})", inner_ty, value)
+                generic_call(OPTION_SOME_CTOR, format!("[{}]", inner_ty), vec![value])
             }
             Self::Result { .. } => {
                 let err_ty = err_ty.expect("Result must have error type");
-                format!("{pkg}.MakeResultOk[{}, {}]({})", inner_ty, err_ty, value)
+                generic_call(
+                    RESULT_OK_CTOR,
+                    format!("[{}, {}]", inner_ty, err_ty),
+                    vec![value],
+                )
             }
         }
     }
+}
+
+pub(crate) fn generic_call(
+    callee: &str,
+    type_arguments: String,
+    arguments: Vec<GoExpression>,
+) -> GoExpression {
+    GoExpression::call(
+        GoExpression::instantiation(GoExpression::name(callee.to_string()), type_arguments),
+        arguments,
+    )
 }
 
 impl Planner<'_> {
@@ -149,22 +168,22 @@ impl Planner<'_> {
     pub(crate) fn coerce_value(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: String,
+        value: GoExpression,
         from: &Type,
         to: &Type,
-    ) -> String {
+    ) -> GoExpression {
         let coercion = CoercionPlan::internal(self, from, to);
-        let (setup, value) = coercion.lower(self, GoExpression::opaque(value));
+        let (setup, value) = coercion.lower(self, value);
         statements.extend(setup);
-        value.rendered()
+        value
     }
 
     pub(crate) fn convert_error_to_return_context(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: String,
+        value: GoExpression,
         fallible: &Fallible,
-    ) -> String {
+    ) -> GoExpression {
         let (Some(from), Some(to)) = (fallible.err_ty().cloned(), self.contextual_err_ty(fallible))
         else {
             return value;
@@ -226,7 +245,7 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
         }
     }
 
-    pub(crate) fn emit_success(&mut self, value: &str) -> String {
+    pub(crate) fn emit_success(&mut self, value: GoExpression) -> GoExpression {
         self.planner.require_stdlib();
         let inner_ty = self.ok_type_string();
         let err_ty = self.err_type_string();
@@ -234,27 +253,23 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
             .make_success(value, &inner_ty, err_ty.as_deref())
     }
 
-    pub(crate) fn emit_failure(&mut self, error_value: Option<&str>) -> String {
+    pub(crate) fn emit_failure(&mut self, error_value: Option<GoExpression>) -> GoExpression {
         self.planner.require_stdlib();
-        let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.ok_type_string();
         if self.fallible.is_result() {
             let err_ty = self.err_type_string().expect("Result must have error type");
-            format!(
-                "{pkg}.MakeResultErr[{}, {}]({})",
-                inner_ty,
-                err_ty,
-                error_value.unwrap_or("")
-            )
+            make_failure(&inner_ty, Some(&err_ty), error_value)
         } else {
-            format!("{pkg}.MakeOptionNone[{}]()", inner_ty)
+            make_failure(&inner_ty, None, None)
         }
     }
 
     /// Emit a failure wrapper using the contextual ok and err types (from return context).
-    pub(crate) fn emit_contextual_failure(&mut self, error_value: Option<&str>) -> String {
+    pub(crate) fn emit_contextual_failure(
+        &mut self,
+        error_value: Option<GoExpression>,
+    ) -> GoExpression {
         self.planner.require_stdlib();
-        let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.contextual_ok_type_string();
         if self.fallible.is_result() {
             let err_ty = self
@@ -262,14 +277,9 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
                 .contextual_err_ty(self.fallible)
                 .expect("Result must have error type");
             let err_ty = self.planner.use_go_type(&err_ty);
-            format!(
-                "{pkg}.MakeResultErr[{}, {}]({})",
-                inner_ty,
-                err_ty,
-                error_value.unwrap_or("")
-            )
+            make_failure(&inner_ty, Some(&err_ty), error_value)
         } else {
-            format!("{pkg}.MakeOptionNone[{}]()", inner_ty)
+            make_failure(&inner_ty, None, None)
         }
     }
 
@@ -291,5 +301,20 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
             GoExpression::instantiation(GoExpression::name(constructor.to_string()), type_args),
             arg.into_iter().collect(),
         )
+    }
+}
+
+fn make_failure(
+    inner_ty: &str,
+    err_ty: Option<&str>,
+    error_value: Option<GoExpression>,
+) -> GoExpression {
+    match err_ty {
+        Some(err_ty) => generic_call(
+            RESULT_ERR_CTOR,
+            format!("[{}, {}]", inner_ty, err_ty),
+            error_value.into_iter().collect(),
+        ),
+        None => generic_call(OPTION_NONE_CTOR, format!("[{}]", inner_ty), Vec::new()),
     }
 }

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -5,15 +5,15 @@ use crate::abi::transition;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
-use crate::plan::bodies::{LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{LoweredBlock, LoweredStatement, define};
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::placement::is_unit_call;
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::Expression;
 use syntax::types::Type;
 
 impl Planner<'_> {
-    /// `try { ... }` → `ClosureBind` over `func() T { ... }()`; value is the
-    /// bound result var.
+    /// `try { ... }` → `result := func() T { ... }()`; value is the bound result var.
     pub(crate) fn lower_try_block(&mut self, items: &[Expression], ty: &Type) -> ValuePlan {
         self.require_stdlib();
 
@@ -35,12 +35,10 @@ impl Planner<'_> {
             planner.with_isolated_function(|planner| planner.lower_try_body(items, &fallible))
         });
 
-        let setup = vec![LoweredStatement::ClosureBind {
-            name: result_var.clone(),
-            closure_open: format!("func() {} {{\n", full_ty),
-            body,
-            closure_close: "}()\n".to_string(),
-        }];
+        let setup = vec![define(
+            result_var.clone(),
+            GoExpression::immediate_call(full_ty, body, FunctionLiteralLayout::MultiLine),
+        )];
         ValuePlan::captured(setup, result_var)
     }
 
@@ -91,18 +89,21 @@ impl Planner<'_> {
         if final_expression.is_empty() {
             statements.push(self.lower_try_unit_return(fallible));
         } else {
-            statements.push(self.lower_try_success_return(&final_expression, fallible));
+            statements.push(self.lower_try_success_return(final_expression, fallible));
         }
         statements
     }
 
     fn lower_try_unit_return(&mut self, fallible: &Fallible) -> LoweredStatement {
-        let (unit_val, packages) = self.zero_value(fallible.ok_ty());
-        self.require_packages(&packages);
-        self.lower_try_success_return(&unit_val, fallible)
+        let unit_val = self.zero_value_expression(fallible.ok_ty());
+        self.lower_try_success_return(unit_val, fallible)
     }
 
-    fn lower_try_success_return(&mut self, value: &str, fallible: &Fallible) -> LoweredStatement {
+    fn lower_try_success_return(
+        &mut self,
+        value: GoExpression,
+        fallible: &Fallible,
+    ) -> LoweredStatement {
         let ok_return = {
             let mut fe = FalliblePlanner::new(self, fallible);
             fe.emit_success(value)
@@ -134,14 +135,14 @@ impl Planner<'_> {
                     statements.extend(setup);
                     Some(value)
                 } else {
-                    Some(String::new())
+                    None
                 }
             }
             Expression::Identifier { .. } => {
                 if fallible.classify_constructor(expression) != Some(ConstructorKind::Failure) {
                     return None;
                 }
-                Some(String::new())
+                None
             }
             _ => return None,
         };
@@ -150,14 +151,14 @@ impl Planner<'_> {
         if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
             let values = if fallible.is_result() {
-                let err_expr = err_arg.unwrap_or_default();
+                let err_expr = err_arg.expect("`Err` carries an error payload");
                 let err_expr =
                     self.convert_error_to_return_context(&mut statements, err_expr, fallible);
-                transition::lowered_err_values(self, &shape, &return_ty, &err_expr)
+                transition::lowered_err_values(self, &shape, &return_ty, err_expr)
             } else {
                 transition::lowered_none_values(self, &shape, &return_ty)
             };
-            statements.push(plain_return(values.join(", ")));
+            statements.push(transition::multi_value_return(values));
         } else {
             self.require_stdlib();
             let err_arg = err_arg.map(|value| {
@@ -165,15 +166,14 @@ impl Planner<'_> {
             });
             let err_return = {
                 let mut fe = FalliblePlanner::new(self, fallible);
-                fe.emit_contextual_failure(err_arg.as_deref())
+                fe.emit_contextual_failure(err_arg)
             };
             statements.push(plain_return(err_return));
         }
         Some(statements)
     }
 
-    /// `recover { ... }` → `ClosureBind` over
-    /// `lisette.RecoverBlock(func() T { ... })`.
+    /// `recover { ... }` → `result := lisette.RecoverBlock(func() T { ... })`.
     pub(crate) fn lower_recover_block(&mut self, items: &[Expression], ty: &Type) -> ValuePlan {
         self.require_stdlib();
 
@@ -194,12 +194,18 @@ impl Planner<'_> {
             })
         });
 
-        let setup = vec![LoweredStatement::ClosureBind {
-            name: result_var.clone(),
-            closure_open: format!("lisette.RecoverBlock(func() {} {{\n", inner_ty_str),
-            body,
-            closure_close: "})\n".to_string(),
-        }];
+        let setup = vec![define(
+            result_var.clone(),
+            GoExpression::call(
+                GoExpression::name("lisette.RecoverBlock".to_string()),
+                vec![GoExpression::function_literal(
+                    String::new(),
+                    inner_ty_str,
+                    body,
+                    FunctionLiteralLayout::MultiLine,
+                )],
+            ),
+        )];
         ValuePlan::captured(setup, result_var)
     }
 
@@ -250,9 +256,7 @@ impl Planner<'_> {
 
     /// A structured zero-value return for a `recover` block's inner type.
     fn lower_zero_return(&mut self, ty: &Type) -> LoweredStatement {
-        let (zero, packages) = self.zero_value(ty);
-        self.require_packages(&packages);
-        plain_return(zero)
+        plain_return(self.zero_value_expression(ty))
     }
 }
 

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -1,14 +1,21 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::pattern_has_bindings;
 use crate::patterns::sites::PatternSubject;
-use crate::plan::bodies::{LoweredBlock, LoweredStatement, directed};
-use crate::plan::values::CaptureBoundary;
+use crate::plan::bodies::{LoopHeader, LoweredBlock, LoweredStatement, define, directed, discard};
+use crate::plan::values::{CaptureBoundary, GoExpression};
 use crate::types::native::NativeGoType;
 use crate::types::shape::RangeShape;
 use syntax::ast::{Binding, Expression, Pattern};
 use syntax::types::Type;
+
+fn range_header(key: &str, value: Option<&str>, iterable: GoExpression) -> LoopHeader {
+    LoopHeader::Range {
+        key: (key != "_").then(|| key.to_string()),
+        value: value.filter(|value| *value != "_").map(str::to_string),
+        iterable,
+    }
+}
 
 impl Planner<'_> {
     /// Lower a `for` statement, dispatching on iterable/pattern shape.
@@ -64,12 +71,12 @@ impl Planner<'_> {
     }
 
     /// Plan `expr` as an operand, pushing its setup into `prologue` and
-    /// returning the value text.
+    /// returning the value.
     pub(crate) fn capture_operand_into(
         &mut self,
         prologue: &mut Vec<LoweredStatement>,
         expr: &Expression,
-    ) -> String {
+    ) -> GoExpression {
         let plan = self.plan_operand(expr, ExpressionContext::value());
         let (setup, value) = plan.into_parts();
         prologue.extend(setup);
@@ -83,7 +90,7 @@ impl Planner<'_> {
         iterable: &Expression,
         range_shape: RangeShape,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         self.with_scope(|this| {
             let mut prologue = Vec::new();
             let range_var = if this.is_unmutated_identifier(iterable) {
@@ -97,22 +104,22 @@ impl Planner<'_> {
                 )
             };
             let loop_var = this.bind_loop_pattern(&binding.pattern, Some("i"));
-            let header = match range_shape {
-                RangeShape::Range => format!(
-                    "for {} := {}.Start; {} < {}.End; {}++ {{\n",
-                    loop_var, range_var, loop_var, range_var, loop_var
-                ),
-                RangeShape::RangeInclusive => format!(
-                    "for {} := {}.Start; {} <= {}.End; {}++ {{\n",
-                    loop_var, range_var, loop_var, range_var, loop_var
-                ),
-                RangeShape::RangeFrom => format!(
-                    "for {} := {}.Start; ; {}++ {{\n",
-                    loop_var, range_var, loop_var
-                ),
+            let bound = |field: &str| GoExpression::selector(range_var.clone(), field.to_string());
+            let compare = |operator: &str| {
+                GoExpression::binary(GoExpression::name(loop_var.clone()), operator, bound("End"))
+            };
+            let condition = match range_shape {
+                RangeShape::Range => Some(compare("<")),
+                RangeShape::RangeInclusive => Some(compare("<=")),
+                RangeShape::RangeFrom => None,
                 RangeShape::RangeTo | RangeShape::RangeToInclusive => {
                     unreachable!("RangeTo/RangeToInclusive are not iterable")
                 }
+            };
+            let header = LoopHeader::Counted {
+                variable: loop_var,
+                start: bound("Start"),
+                condition,
             };
             let lowered_body = this.lower_block_as_body(body);
             (prologue, header, lowered_body)
@@ -125,16 +132,12 @@ impl Planner<'_> {
         binding: &Binding,
         receiver: &Expression,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         self.with_scope(|this| {
             let mut prologue = Vec::new();
-            let receiver_str = this.capture_operand_into(&mut prologue, receiver);
+            let receiver = this.capture_operand_into(&mut prologue, receiver);
             let loop_var = this.bind_loop_pattern(&binding.pattern, None);
-            let header = if loop_var == "_" {
-                format!("for range {} {{\n", receiver_str)
-            } else {
-                format!("for _, {} := range {} {{\n", loop_var, receiver_str)
-            };
+            let header = range_header("_", Some(&loop_var), receiver);
             let lowered_body = this.lower_block_as_body(body);
             (prologue, header, lowered_body)
         })
@@ -146,7 +149,7 @@ impl Planner<'_> {
         binding: &Binding,
         receiver: &Expression,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         self.with_scope(|this| {
             let mut prologue = Vec::new();
             let receiver_var = if this.is_unmutated_identifier(receiver) {
@@ -161,17 +164,28 @@ impl Planner<'_> {
             };
             let index_var = this.fresh_var(Some("i"));
             let loop_var = this.bind_loop_pattern(&binding.pattern, None);
-            let mut header = format!(
-                "for {} := 0; {} < len({}); {}++ {{\n",
-                index_var, index_var, receiver_var, index_var
-            );
+            let header = LoopHeader::Counted {
+                variable: index_var.clone(),
+                start: GoExpression::literal("0".to_string()),
+                condition: Some(GoExpression::binary(
+                    GoExpression::name(index_var.clone()),
+                    "<",
+                    GoExpression::call(
+                        GoExpression::name("len".to_string()),
+                        vec![receiver_var.clone()],
+                    ),
+                )),
+            };
+            let mut lowered_body = this.lower_block_as_body(body);
             if loop_var != "_" {
-                header.push_str(&format!(
-                    "{} := {}[{}]\n",
-                    loop_var, receiver_var, index_var
-                ));
+                lowered_body.statements.insert(
+                    0,
+                    define(
+                        loop_var,
+                        GoExpression::index(receiver_var, GoExpression::name(index_var)),
+                    ),
+                );
             }
-            let lowered_body = this.lower_block_as_body(body);
             (prologue, header, lowered_body)
         })
     }
@@ -182,12 +196,12 @@ impl Planner<'_> {
     fn capture_iterable_operand(
         &mut self,
         iterable: &Expression,
-    ) -> (Vec<LoweredStatement>, String, bool) {
+    ) -> (Vec<LoweredStatement>, GoExpression, bool) {
         let mut prologue = Vec::new();
         let iter_raw = self.capture_operand_into(&mut prologue, iterable);
         let iterable_ty = iterable.get_type();
         let mut iter_expression = if iterable_ty.is_ref() {
-            format!("*{}", iter_raw)
+            GoExpression::dereference(iter_raw)
         } else {
             iter_raw
         };
@@ -196,7 +210,10 @@ impl Planner<'_> {
             .is_some_and(|shape| matches!(shape, NativeGoType::Channel | NativeGoType::Receiver));
         if is_channel {
             self.require_stdlib();
-            iter_expression = format!("lisette.ChannelRange({})", iter_expression);
+            iter_expression = GoExpression::call(
+                GoExpression::name("lisette.ChannelRange".to_string()),
+                vec![iter_expression],
+            );
         }
         let single_var = is_channel || self.iter_seq_arity(&iterable_ty) == Some(1);
         (prologue, iter_expression, single_var)
@@ -208,17 +225,15 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable);
 
         let (header, lowered_body) = self.with_scope(|this| {
             let loop_var = this.bind_loop_pattern(&binding.pattern, None);
-            let header = if loop_var == "_" {
-                format!("for range {} {{\n", iter_expression)
-            } else if single_var {
-                format!("for {} := range {} {{\n", loop_var, iter_expression)
+            let header = if single_var {
+                range_header(&loop_var, None, iter_expression)
             } else {
-                format!("for _, {} := range {} {{\n", loop_var, iter_expression)
+                range_header("_", Some(&loop_var), iter_expression)
             };
             (header, this.lower_block_as_body(body))
         });
@@ -233,7 +248,7 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         let Pattern::Tuple { elements, .. } = &binding.pattern else {
             unreachable!("lower_map_tuple_for requires a tuple pattern");
         };
@@ -251,13 +266,13 @@ impl Planner<'_> {
 
         let (header, lowered_body) = self.with_scope(|this| {
             if first_is_simple && second_is_simple {
-                this.lower_map_tuple_simple_body(first, second, &iter_expression, body)
+                this.lower_map_tuple_simple_body(first, second, iter_expression, body)
             } else {
                 this.lower_map_tuple_compound_body(
                     first,
                     second,
                     &binding.ty,
-                    &iter_expression,
+                    iter_expression,
                     body,
                 )
             }
@@ -270,22 +285,22 @@ impl Planner<'_> {
         &mut self,
         first: &Pattern,
         second: &Pattern,
-        iter_expression: &str,
+        iter_expression: GoExpression,
         body: &Expression,
-    ) -> (String, LoweredBlock) {
+    ) -> (LoopHeader, LoweredBlock) {
         let first_is_discard =
             matches!(first, Pattern::WildCard { .. }) || self.go_name_for_binding(first).is_none();
         let second_is_discard = matches!(second, Pattern::WildCard { .. })
             || self.go_name_for_binding(second).is_none();
         let header = if first_is_discard && second_is_discard {
-            format!("for range {} {{\n", iter_expression)
+            range_header("_", None, iter_expression)
         } else if second_is_discard {
             let key = self.bind_loop_pattern(first, None);
-            format!("for {} := range {} {{\n", key, iter_expression)
+            range_header(&key, None, iter_expression)
         } else {
             let key = self.bind_loop_pattern(first, None);
             let value = self.bind_loop_pattern(second, None);
-            format!("for {}, {} := range {} {{\n", key, value, iter_expression)
+            range_header(&key, Some(&value), iter_expression)
         };
         (header, self.lower_block_as_body(body))
     }
@@ -297,9 +312,9 @@ impl Planner<'_> {
         first: &Pattern,
         second: &Pattern,
         binding_ty: &Type,
-        iter_expression: &str,
+        iter_expression: GoExpression,
         body: &Expression,
-    ) -> (String, LoweredBlock) {
+    ) -> (LoopHeader, LoweredBlock) {
         let element_tys: &[Type] = match binding_ty {
             Type::Tuple(tys) => tys.as_slice(),
             _ => &[],
@@ -309,48 +324,41 @@ impl Planner<'_> {
 
         let key_var = self.fresh_var(Some("key"));
         let value_var = self.fresh_var(Some("value"));
-        let header = format!(
-            "for {}, {} := range {} {{\n",
-            key_var, value_var, iter_expression
-        );
+        let header = LoopHeader::Range {
+            key: Some(key_var.clone()),
+            value: Some(value_var.clone()),
+            iterable: iter_expression,
+        };
 
-        let ((bindings, lowered_body), used) = self.capture_go_uses(|this| {
-            let mut bindings = String::new();
+        let ((mut bindings, lowered_body), used) = self.capture_go_uses(|this| {
             let key_statements = this.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(key_var.clone()),
                 first,
                 first_ty,
             );
-            Renderer.render_lowered_block(
-                &mut bindings,
-                &LoweredBlock {
-                    statements: key_statements,
-                },
-            );
-            if !bindings.is_empty() {
+            let key_block = LoweredBlock {
+                statements: key_statements,
+            };
+            if !key_block.renders_empty() {
                 this.scope.record_go_use(&key_var);
             }
-            let after_key = bindings.len();
             let value_statements = this.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(value_var.clone()),
                 second,
                 second_ty,
             );
-            Renderer.render_lowered_block(
-                &mut bindings,
-                &LoweredBlock {
-                    statements: value_statements,
-                },
-            );
-            if bindings.len() > after_key {
+            let value_block = LoweredBlock {
+                statements: value_statements,
+            };
+            if !value_block.renders_empty() {
                 this.scope.record_go_use(&value_var);
             }
+            let mut bindings = key_block.statements;
+            bindings.extend(value_block.statements);
             (bindings, this.lower_block_as_body(body))
         });
 
-        let mut inner = vec![LoweredStatement::RawGo(bindings)];
-        inner.extend(lowered_body.statements);
-        let body_block = LoweredBlock { statements: inner };
+        bindings.extend(lowered_body.statements);
 
         let references_value = used.contains(&value_var);
         let references_key = used.contains(&key_var);
@@ -358,12 +366,12 @@ impl Planner<'_> {
         // Discard guards: value first, then key (insertion order matters).
         let mut statements = Vec::new();
         if !references_value {
-            statements.push(LoweredStatement::RawGo(format!("_ = {}\n", value_var)));
+            statements.push(discard(GoExpression::name(value_var)));
         }
         if !references_key {
-            statements.push(LoweredStatement::RawGo(format!("_ = {}\n", key_var)));
+            statements.push(discard(GoExpression::name(key_var)));
         }
-        statements.extend(body_block.statements);
+        statements.extend(bindings);
         (header, LoweredBlock { statements })
     }
 
@@ -375,50 +383,44 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable);
 
         let (header, body_block) = self.with_scope(|this| {
             if !pattern_has_bindings(&binding.pattern) {
-                let header = format!("for range {} {{\n", iter_expression);
+                let header = range_header("_", None, iter_expression);
                 (header, this.lower_block_as_body(body))
             } else {
                 let item_var = this.fresh_var(Some("item"));
                 let header = if single_var {
-                    format!("for {} := range {} {{\n", item_var, iter_expression)
+                    range_header(&item_var, None, iter_expression)
                 } else {
-                    format!("for _, {} := range {} {{\n", item_var, iter_expression)
+                    range_header("_", Some(&item_var), iter_expression)
                 };
-                let ((bindings, lowered_body), used) = this.capture_go_uses(|this| {
-                    let mut bindings = String::new();
+                let ((mut bindings, lowered_body), used) = this.capture_go_uses(|this| {
                     let binding_statements = this.lower_irrefutable_pattern_site(
                         PatternSubject::for_value(item_var.clone()),
                         &binding.pattern,
                         &binding.ty,
                     );
-                    Renderer.render_lowered_block(
-                        &mut bindings,
-                        &LoweredBlock {
-                            statements: binding_statements,
-                        },
-                    );
-                    if !bindings.is_empty() {
+                    let binding_block = LoweredBlock {
+                        statements: binding_statements,
+                    };
+                    if !binding_block.renders_empty() {
                         this.scope.record_go_use(&item_var);
                     }
-                    (bindings, this.lower_block_as_body(body))
+                    (binding_block.statements, this.lower_block_as_body(body))
                 });
 
-                let mut inner = vec![LoweredStatement::RawGo(bindings)];
-                inner.extend(lowered_body.statements);
-                let body_block = LoweredBlock { statements: inner };
+                bindings.extend(lowered_body.statements);
 
                 let references_item = used.contains(&item_var);
 
                 let mut statements = Vec::new();
                 if !references_item {
-                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", item_var)));
+                    statements.push(discard(GoExpression::name(item_var)));
                 }
-                statements.extend(body_block.statements);
+                statements.extend(bindings);
                 (header, LoweredBlock { statements })
             }
         });
@@ -431,7 +433,7 @@ impl Planner<'_> {
         binding: &Binding,
         iterable: &Expression,
         body: &Expression,
-    ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
+    ) -> (Vec<LoweredStatement>, LoopHeader, LoweredBlock) {
         let Expression::Range {
             start,
             end,
@@ -451,7 +453,7 @@ impl Planner<'_> {
                 prologue.extend(setup);
                 (value, is_observable)
             }
-            None => ("0".to_string(), false),
+            None => (GoExpression::literal("0".to_string()), false),
         };
         let checkpoint = prologue.len();
         let end_expression = end.as_ref().map(|end| {
@@ -471,41 +473,37 @@ impl Planner<'_> {
             // hoist start into its own temp before them so it evaluates first.
             let var = self.fresh_var(Some("start"));
             self.declare(&var);
-            prologue.insert(
-                checkpoint,
-                LoweredStatement::TempBind {
-                    name: var.clone(),
-                    value: start_expression,
-                },
-            );
-            start_expression = var;
+            prologue.insert(checkpoint, define(var.clone(), start_expression));
+            start_expression = GoExpression::name(var);
         }
 
-        let counts_from_zero = !*inclusive && start_expression == "0";
+        let counts_from_zero = !*inclusive && start_expression.as_str() == "0";
         let (header, lowered_body) = self.with_scope(|this| {
             let header = match end_expression {
                 Some(end_expression) if counts_from_zero => {
                     let loop_var = this.bind_loop_pattern(&binding.pattern, None);
-                    if loop_var == "_" {
-                        format!("for range {} {{\n", end_expression)
-                    } else {
-                        format!("for {} := range {} {{\n", loop_var, end_expression)
-                    }
+                    range_header(&loop_var, None, end_expression)
                 }
                 Some(end_expression) => {
                     let loop_var = this.bind_loop_pattern(&binding.pattern, Some("i"));
                     let operator = if *inclusive { "<=" } else { "<" };
-                    format!(
-                        "for {} := {}; {} {} {}; {}++ {{\n",
-                        loop_var, start_expression, loop_var, operator, end_expression, loop_var
-                    )
+                    LoopHeader::Counted {
+                        variable: loop_var.clone(),
+                        start: start_expression,
+                        condition: Some(GoExpression::binary(
+                            GoExpression::name(loop_var),
+                            operator,
+                            end_expression,
+                        )),
+                    }
                 }
                 None => {
                     let loop_var = this.bind_loop_pattern(&binding.pattern, Some("i"));
-                    format!(
-                        "for {} := {}; ; {}++ {{\n",
-                        loop_var, start_expression, loop_var
-                    )
+                    LoopHeader::Counted {
+                        variable: loop_var,
+                        start: start_expression,
+                        condition: None,
+                    }
                 }
             };
             (header, this.lower_block_as_body(body))

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -2,12 +2,14 @@ use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::transition;
 use crate::calls::comma_ok::CommaOkValueSlot;
-use crate::calls::go_interop::NilGuard;
+use crate::calls::go_interop::{NilGuard, non_nil, unexpected_nil_error};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::is_go_never;
-use crate::plan::bodies::{AssignForm, LoweredBlock, LoweredStatement, PlacePlan, ReturnForm};
-use crate::plan::values::{GoExpression, ValuePlan};
+use crate::plan::bodies::{
+    Definition, LoweredBlock, LoweredStatement, PlacePlan, ReturnForm, assign, define,
+};
+use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
 use crate::state::scope::PairStatusKind;
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -19,17 +21,9 @@ struct WrappedReturnInfo<'a> {
     lowered: Option<&'a CallableReturnAbi>,
 }
 
-pub(crate) fn plain_return(value: String) -> LoweredStatement {
+pub(crate) fn plain_return(value: GoExpression) -> LoweredStatement {
     LoweredStatement::Return(ReturnForm::Plain {
-        value: ValuePlan::opaque(value),
-    })
-}
-
-fn simple_assign(target: String, value: String) -> LoweredStatement {
-    LoweredStatement::Assign(AssignForm::Simple {
-        target_capture: Vec::new(),
-        target_str: target,
-        value: ValuePlan::opaque(value),
+        value: ValuePlan::computed(Vec::new(), value, EvaluationEffect::Pure),
     })
 }
 
@@ -57,31 +51,22 @@ impl Planner<'_> {
             return (statements, GoExpression::empty());
         }
 
-        if let Some((statements, value)) =
-            self.try_lower_fused_propagate(expression, &fallible, result_var_name)
+        if let Some(fused) = self.try_lower_fused_propagate(expression, &fallible, result_var_name)
         {
-            let value = if value.is_empty() {
-                GoExpression::empty()
-            } else {
-                GoExpression::name(value)
-            };
-            return (statements, value);
+            return fused;
         }
 
         self.require_stdlib();
-        let (check_setup, check_var) = self.hoist_propagate_check_var(expression);
+        let (check_setup, check) = self.hoist_propagate_check_var(expression);
         statements.extend(check_setup);
-        statements.push(self.build_propagate_failure_check(&check_var, &fallible));
+        statements.push(self.build_propagate_failure_check(&check, &fallible));
 
-        let ok_access = GoExpression::selector(
-            GoExpression::name(check_var),
-            fallible.ok_field().to_string(),
-        );
+        let ok_access = GoExpression::selector(check, fallible.ok_field().to_string());
         let value = match result_var_name {
             None => ok_access,
             Some("_") => GoExpression::name("_".to_string()),
             Some(name) => {
-                statements.push(self.bind_propagate_ok(name, ok_access.as_str()));
+                statements.push(self.bind_propagate_ok(name, ok_access));
                 GoExpression::name(name.to_string())
             }
         };
@@ -101,10 +86,9 @@ impl Planner<'_> {
             return;
         }
         let inner_ty = fallible.ok_ty();
-        let (zero, packages) = self.zero_value(inner_ty);
-        self.require_packages(&packages);
+        let zero = self.zero_value_expression(inner_ty);
         if self.is_declared(var_name) {
-            statements.push(simple_assign(var_name.to_string(), zero));
+            statements.push(assign(GoExpression::name(var_name.to_string()), zero));
         } else {
             // Declared so the dead-path binding stays in scope for later references.
             let go_ty = self.use_go_type(inner_ty);
@@ -120,14 +104,14 @@ impl Planner<'_> {
     fn hoist_propagate_check_var(
         &mut self,
         expression: &Expression,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let plan = self.plan_operand(expression, ExpressionContext::value());
         let requires_capture = !matches!(expression, Expression::Identifier { .. })
             || plan.expression.contains_deferred_evaluation();
         let (mut setup, value) = plan.into_parts();
         if requires_capture {
-            let check = self.hoist_tmp_value_statement(&mut setup, "check", &value);
-            (setup, check)
+            let check = self.hoist_tmp_value_statement(&mut setup, "check", value);
+            (setup, GoExpression::name(check))
         } else {
             (setup, value)
         }
@@ -136,15 +120,21 @@ impl Planner<'_> {
     /// The `if check.Tag != <success> { return <failure> }` failure guard.
     fn build_propagate_failure_check(
         &mut self,
-        check_var: &str,
+        check: &GoExpression,
         fallible: &Fallible,
     ) -> LoweredStatement {
-        let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
-        let success_tag = fallible.success_tag();
-        let err_expr = format!("{}{}", check_var, err_field);
-        let (setup, values) = self.propagate_failure_values(fallible, &err_expr);
+        let err_expr = if fallible.is_result() {
+            GoExpression::selector(check.clone(), "ErrVal".to_string())
+        } else {
+            check.clone()
+        };
+        let (setup, values) = self.propagate_failure_values(fallible, err_expr);
         transition::tag_check(
-            format!("{}.Tag != {}", check_var, success_tag),
+            GoExpression::binary(
+                GoExpression::selector(check.clone(), "Tag".to_string()),
+                "!=",
+                GoExpression::name(fallible.success_tag().to_string()),
+            ),
             setup,
             values,
         )
@@ -153,8 +143,8 @@ impl Planner<'_> {
     fn propagate_failure_values(
         &mut self,
         fallible: &Fallible,
-        err_expr: &str,
-    ) -> (Vec<LoweredStatement>, Vec<String>) {
+        err_expr: GoExpression,
+    ) -> (Vec<LoweredStatement>, Vec<GoExpression>) {
         let mut setup = Vec::new();
         let return_ctx = self.return_ctx();
         let values = if let Some(shape) = return_ctx.lowered_shape() {
@@ -162,20 +152,15 @@ impl Planner<'_> {
             // Option propagation: failure carries no payload, so return a
             // shape-specific `None` rather than an err-return.
             if fallible.is_result() {
-                let err_expr = self.convert_error_to_return_context(
-                    &mut setup,
-                    err_expr.to_string(),
-                    fallible,
-                );
-                transition::lowered_err_values(self, &shape, &return_ty, &err_expr)
+                let err_expr = self.convert_error_to_return_context(&mut setup, err_expr, fallible);
+                transition::lowered_err_values(self, &shape, &return_ty, err_expr)
             } else {
                 transition::lowered_none_values(self, &shape, &return_ty)
             }
         } else {
-            let err_expr =
-                self.convert_error_to_return_context(&mut setup, err_expr.to_string(), fallible);
+            let err_expr = self.convert_error_to_return_context(&mut setup, err_expr, fallible);
             let mut fe = FalliblePlanner::new(self, fallible);
-            vec![fe.emit_contextual_failure(Some(&err_expr))]
+            vec![fe.emit_contextual_failure(Some(err_expr))]
         };
         (setup, values)
     }
@@ -187,7 +172,7 @@ impl Planner<'_> {
         expression: &Expression,
         fallible: &Fallible,
         result_var_name: Option<&str>,
-    ) -> Option<(Vec<LoweredStatement>, String)> {
+    ) -> Option<(Vec<LoweredStatement>, GoExpression)> {
         let (call, wraps) = self.peel_wrap_err(expression);
         let plan = self.plan_call(call)?;
         let expression_ty = call.get_type();
@@ -234,7 +219,7 @@ impl Planner<'_> {
             return None;
         }
 
-        let (mut statements, call_str) = self
+        let (mut statements, call) = self
             .lower_call(call, None, ExpressionContext::value())
             .into_parts();
         let want_value = !matches!(result_var_name, Some("_"));
@@ -257,22 +242,24 @@ impl Planner<'_> {
         let (message_setup, wraps) = self.prepare_wrap_messages(&wraps, true);
         let opens_if = value_var.is_none() && message_setup.is_empty();
         let outcome_var = self.pair_status(None, status_kind, opens_if);
-        let bind_line = match &value_var {
-            Some(value) => format!("{value}, {outcome_var} := {call_str}"),
-            None if has_value_slot => format!("_, {outcome_var} := {call_str}"),
-            None => format!("{outcome_var} := {call_str}"),
+        let outcome = || GoExpression::name(outcome_var.clone());
+        let binding = Definition {
+            names: match &value_var {
+                Some(value) => vec![value.clone(), outcome_var.clone()],
+                None if has_value_slot => vec!["_".to_string(), outcome_var.clone()],
+                None => vec![outcome_var.clone()],
+            },
+            value: call,
         };
         let initializer = if opens_if {
-            Some(bind_line)
+            Some(binding)
         } else {
-            statements.push(LoweredStatement::RawGo(format!("{bind_line}\n")));
+            statements.push(LoweredStatement::Define(binding));
             None
         };
         statements.extend(message_setup);
-        let open_if = |condition: String| match &initializer {
-            Some(initializer) => format!("{initializer}; {condition}"),
-            None => condition,
-        };
+        let guarded_value =
+            || GoExpression::name(value_var.clone().expect("nil guard requires the value var"));
 
         if comma_ok {
             let failure_condition = match nil_guard {
@@ -280,59 +267,63 @@ impl Planner<'_> {
                     if guard.is_interface() {
                         self.require_stdlib();
                     }
-                    let val = value_var
-                        .as_deref()
-                        .expect("nil guard requires the value var");
-                    format!("!{} || {}", outcome_var, guard.is_nil(val))
+                    GoExpression::binary(
+                        GoExpression::unary("!", outcome()),
+                        "||",
+                        guard.is_nil(guarded_value()),
+                    )
                 }
-                None => format!("!{}", outcome_var),
+                None => GoExpression::unary("!", outcome()),
             };
             let (failure_setup, failure_values) =
-                self.propagate_failure_values(fallible, &outcome_var);
-            statements.push(transition::tag_check(
-                open_if(failure_condition),
+                self.propagate_failure_values(fallible, outcome());
+            statements.push(transition::tag_check_with_initializer(
+                initializer,
+                failure_condition,
                 failure_setup,
                 failure_values,
             ));
         } else {
-            let error = self.wrap_error(&wraps, outcome_var.clone());
-            let (failure_setup, failure_values) = self.propagate_failure_values(fallible, &error);
-            statements.push(transition::tag_check(
-                open_if(format!("{} != nil", outcome_var)),
+            let error = self.wrap_error(&wraps, outcome());
+            let (failure_setup, failure_values) = self.propagate_failure_values(fallible, error);
+            statements.push(transition::tag_check_with_initializer(
+                initializer,
+                non_nil(outcome()),
                 failure_setup,
                 failure_values,
             ));
             if let Some(guard) = nil_guard {
-                let val = value_var
-                    .as_deref()
-                    .expect("nil guard requires the value var");
                 if guard.is_interface() {
                     self.require_stdlib();
                 }
                 self.require_errors();
-                let error = self.wrap_error(&wraps, "errors.New(\"unexpected nil\")".to_string());
-                let (nil_setup, nil_failure) = self.propagate_failure_values(fallible, &error);
+                let error = self.wrap_error(&wraps, unexpected_nil_error());
+                let (nil_setup, nil_failure) = self.propagate_failure_values(fallible, error);
                 statements.push(transition::tag_check(
-                    guard.is_nil(val),
+                    guard.is_nil(guarded_value()),
                     nil_setup,
                     nil_failure,
                 ));
             }
         }
 
-        let ok_value = value_var.map(|val| match &payload_bridge {
-            Some(bridge) if want_value => self.plan_layout_bridge(&mut statements, &val, bridge),
-            _ => val,
+        let ok_value = value_var.map(|val| {
+            let val = GoExpression::name(val);
+            match &payload_bridge {
+                Some(bridge) if want_value => self.plan_layout_bridge(&mut statements, val, bridge),
+                _ => val,
+            }
         });
+        let unit = || GoExpression::empty_composite("struct{}".to_string());
 
         let value = match result_var_name {
-            None => ok_value.unwrap_or_else(|| "struct{}{}".to_string()),
-            Some("_") => "_".to_string(),
-            Some(name) if let_slot.is_some() => name.to_string(),
+            None => ok_value.unwrap_or_else(unit),
+            Some("_") => GoExpression::name("_".to_string()),
+            Some(name) if let_slot.is_some() => GoExpression::name(name.to_string()),
             Some(name) => {
-                let v = ok_value.unwrap_or_else(|| "struct{}{}".to_string());
-                statements.push(self.bind_propagate_ok(name, &v));
-                name.to_string()
+                let v = ok_value.unwrap_or_else(unit);
+                statements.push(self.bind_propagate_ok(name, v));
+                GoExpression::name(name.to_string())
             }
         };
         Some((statements, value))
@@ -346,15 +337,12 @@ impl Planner<'_> {
         self.lower_propagate(inner, Some("_")).0
     }
 
-    fn bind_propagate_ok(&mut self, name: &str, ok_access: &str) -> LoweredStatement {
+    fn bind_propagate_ok(&mut self, name: &str, ok_access: GoExpression) -> LoweredStatement {
         if self.is_declared(name) {
-            simple_assign(name.to_string(), ok_access.to_string())
+            assign(GoExpression::name(name.to_string()), ok_access)
         } else {
             self.declare(name);
-            LoweredStatement::TempBind {
-                name: name.to_string(),
-                value: ok_access.to_string(),
-            }
+            define(name.to_string(), ok_access)
         }
     }
 
@@ -397,16 +385,8 @@ impl Planner<'_> {
         ReturnForm::Plain {
             value: plan.map_expression_as_computed(|setup, raw_value| {
                 let contains_deferred_evaluation = raw_value.contains_deferred_evaluation();
-                let mut coercion_buffer = String::new();
-                let final_value = self.apply_type_coercion(
-                    &mut coercion_buffer,
-                    return_ctx.ty(),
-                    expression,
-                    raw_value,
-                );
-                if !coercion_buffer.is_empty() {
-                    setup.push(LoweredStatement::RawGo(coercion_buffer));
-                }
+                let final_value =
+                    self.apply_type_coercion(setup, return_ctx.ty(), expression, raw_value);
                 final_value.with_deferred_evaluation(contains_deferred_evaluation)
             }),
         }
@@ -436,14 +416,14 @@ impl Planner<'_> {
         let mut statements = Vec::new();
 
         if is_go_never(expression) {
-            let (setup, call_str) = self
+            let (setup, call) = self
                 .lower_call(expression, None, ExpressionContext::value())
                 .into_parts();
             statements.extend(setup);
-            // Kept as `RawGo`: this is a Go-never call (`panic(...)`) whose
-            // `ends_with_diverge` must stay true; `ExpressionStatementForm::Async`
-            // reports false.
-            statements.push(LoweredStatement::RawGo(format!("{}\n", call_str)));
+            statements.push(LoweredStatement::ExpressionStatement {
+                expression: call,
+                diverges: true,
+            });
             return Some(statements);
         }
 
@@ -490,11 +470,7 @@ impl Planner<'_> {
         {
             let (setup, value) = self.lower_propagate(inner, None);
             statements.extend(setup);
-            statements.extend(self.wrapped_value_return(
-                value.rendered(),
-                &return_ty,
-                lowered.as_ref(),
-            ));
+            statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref()));
             return Some(statements);
         }
 
@@ -508,7 +484,7 @@ impl Planner<'_> {
 
     fn wrapped_value_return(
         &mut self,
-        value: String,
+        value: GoExpression,
         return_ty: &Type,
         lowered: Option<&CallableReturnAbi>,
     ) -> Vec<LoweredStatement> {
@@ -518,7 +494,7 @@ impl Planner<'_> {
         // The destructure references the value multiple times (`.Tag`,
         // `.OkVal`, `.ErrVal` etc.); hoist to avoid re-evaluating.
         let mut statements = Vec::new();
-        let temp = self.hoist_tmp_value_statement(&mut statements, "v", &value);
+        let temp = GoExpression::name(self.hoist_tmp_value_statement(&mut statements, "v", value));
         statements.extend(transition::emit_lowered_result_return(
             self, &temp, return_ty, shape,
         ));
@@ -587,7 +563,7 @@ impl Planner<'_> {
                 }
                 Vec::new()
             } else if args.is_empty() {
-                vec!["struct{}{}".to_string()]
+                vec![GoExpression::empty_composite("struct{}".to_string())]
             } else if shape.has_flattened_payload()
                 && let Expression::Tuple { elements, .. } = args[0].unwrap_parens()
             {
@@ -601,7 +577,7 @@ impl Planner<'_> {
                     .into_parts();
                 statements.extend(setup);
                 let (projection, parts) =
-                    transition::lowered_payload_values(self, shape, fallible.ok_ty(), &value);
+                    transition::lowered_payload_values(self, shape, fallible.ok_ty(), value);
                 statements.extend(projection);
                 parts
             };
@@ -614,7 +590,7 @@ impl Planner<'_> {
                 .into_parts();
             let success = {
                 let mut fe = FalliblePlanner::new(self, fallible);
-                fe.emit_success(&arg)
+                fe.emit_success(arg)
             };
             statements.extend(setup);
             statements.push(plain_return(success));
@@ -650,13 +626,13 @@ impl Planner<'_> {
         });
         let returned = if let Some(shape) = lowered {
             let values = match error {
-                Some(error) => transition::lowered_err_values(self, shape, return_ty, &error),
+                Some(error) => transition::lowered_err_values(self, shape, return_ty, error),
                 None => transition::lowered_none_values(self, shape, return_ty),
             };
             transition::multi_value_return(values)
         } else {
             let mut fe = FalliblePlanner::new(self, fallible);
-            plain_return(fe.emit_failure(error.as_deref()))
+            plain_return(fe.emit_failure(error))
         };
         statements.push(returned);
         statements
@@ -682,7 +658,7 @@ impl Planner<'_> {
             statements.extend(setup);
             let ok_ty = self.facts.peel_alias(return_ty).ok_type();
             let (projection, payload) =
-                transition::lowered_payload_values(self, shape, &ok_ty, value.as_str());
+                transition::lowered_payload_values(self, shape, &ok_ty, value);
             statements.extend(projection);
             statements.push(transition::multi_value_return(
                 transition::lowered_ok_values(shape, payload),
@@ -706,8 +682,9 @@ impl Planner<'_> {
             && !source.has_nil_guard()
         {
             let pair = self.bind_comma_ok_pair(expression, source, CommaOkValueSlot::Temp);
-            let ok = pair.status().to_string();
-            let value = pair.value.expect("Temp slot always captures the value");
+            let ok = GoExpression::name(pair.status().to_string());
+            let value =
+                GoExpression::name(pair.value.expect("Temp slot always captures the value"));
             let mut statements = pair.statements;
             statements.push(transition::multi_value_return(vec![value, ok]));
             return statements;
@@ -732,12 +709,12 @@ impl Planner<'_> {
                     && self.go_result_layout_bridge(&abi, return_ty).is_none()
                     && self.go_return_payload_bridge(&abi, return_ty).is_none();
                 if unbridged {
-                    let (setup, call_str) = self
+                    let (setup, call) = self
                         .lower_call(expression, None, ExpressionContext::value())
                         .into_parts();
                     statements.extend(setup);
                     statements.extend(self.lower_abi_to_tagged_return(
-                        &call_str,
+                        call,
                         &abi.result,
                         return_ty,
                     ));
@@ -756,7 +733,8 @@ impl Planner<'_> {
                 .lower_value(expression, ExpressionContext::value())
                 .into_parts();
             statements.extend(setup);
-            let temp = self.hoist_tmp_value_statement(&mut statements, "v", &value);
+            let temp =
+                GoExpression::name(self.hoist_tmp_value_statement(&mut statements, "v", value));
             statements.extend(transition::emit_lowered_result_return(
                 self, &temp, return_ty, shape,
             ));

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -5,7 +5,7 @@ use crate::patterns::sites::{
 };
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan,
-    SelectStatementPlan,
+    SelectStatementPlan, assign, discard,
 };
 use crate::plan::go_expression::GoExpressionNode;
 use crate::plan::placement::unreachable_panic_if_needed;
@@ -20,7 +20,7 @@ enum PreparedChannelOperation {
 }
 
 struct SelectReceiveContext<'a> {
-    channel: &'a str,
+    channel: &'a GoExpression,
     body: &'a Expression,
     default_body: Option<&'a Expression>,
     retry_var: Option<&'a str>,
@@ -32,7 +32,7 @@ enum PreparedSelectArm<'a> {
     Receive {
         binding: &'a Pattern,
         body: &'a Expression,
-        channel: String,
+        channel: GoExpression,
         element_ty: Type,
     },
     Send {
@@ -41,7 +41,7 @@ enum PreparedSelectArm<'a> {
     },
     MatchReceive {
         arms: &'a [MatchArm],
-        channel: String,
+        channel: GoExpression,
         element_ty: Type,
     },
     Default {
@@ -160,15 +160,12 @@ impl Planner<'_> {
                     let channel_has_call = channel.evaluation.effect.has_call();
                     let (channel_setup, ch) = channel.into_parts();
                     setup.extend(channel_setup);
-                    let channel = if binding.is_some_pattern() {
-                        self.hoist_tmp_value_statement(setup, "ch", &ch)
-                    } else {
-                        if needs_retry_loop && channel_has_call {
-                            self.hoist_tmp_value_statement(setup, "ch", &ch)
+                    let channel =
+                        if binding.is_some_pattern() || (needs_retry_loop && channel_has_call) {
+                            GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch))
                         } else {
                             ch
-                        }
-                    };
+                        };
                     PreparedSelectArm::Receive {
                         binding,
                         body,
@@ -185,7 +182,7 @@ impl Planner<'_> {
                     let (channel_setup, ch) = channel.into_parts();
                     setup.extend(channel_setup);
                     let ch = if needs_retry_loop && channel_has_call {
-                        self.hoist_tmp_value_statement(setup, "ch", &ch)
+                        GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch))
                     } else {
                         ch
                     };
@@ -240,24 +237,19 @@ impl Planner<'_> {
             return Vec::new();
         }
 
+        let ok = GoExpression::name(ok_var.to_string());
         let plan = if body_empty {
-            IfPlan {
-                condition_setup: Vec::new(),
-                condition: format!("!{}", ok_var),
-                then_body: else_block.expect("body_empty && has_else"),
-                else_arm: ElseArm::None,
-            }
+            IfPlan::plain(
+                GoExpression::unary("!", ok),
+                else_block.expect("body_empty && has_else"),
+                ElseArm::None,
+            )
         } else {
             let else_arm = match else_block {
                 Some(body) => ElseArm::from_body(body, false),
                 None => ElseArm::None,
             };
-            IfPlan {
-                condition_setup: Vec::new(),
-                condition: ok_var.to_string(),
-                then_body: body_block,
-                else_arm,
-            }
+            IfPlan::plain(ok, body_block, else_arm)
         };
         vec![LoweredStatement::If(plan)]
     }
@@ -268,7 +260,10 @@ impl Planner<'_> {
         if let Some(retry_var) = ctx.retry_var {
             return Some(LoweredBlock {
                 statements: vec![
-                    LoweredStatement::RawGo(format!("{} = nil\n", retry_var)),
+                    assign(
+                        GoExpression::name(retry_var.to_string()),
+                        GoExpression::nil(),
+                    ),
                     LoweredStatement::Continue(LoopTransfer::Unlabeled),
                 ],
             });
@@ -309,7 +304,7 @@ impl Planner<'_> {
             });
             let mut then_statements: Vec<LoweredStatement> = Vec::new();
             if !used.contains(&receiver_var) {
-                then_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", receiver_var)));
+                then_statements.push(discard(GoExpression::name(receiver_var.clone())));
             }
             then_statements.extend(body_statements);
             (receiver_var, ok_var, then_statements)
@@ -320,17 +315,16 @@ impl Planner<'_> {
             None => ElseArm::None,
         };
         let receive_vars = format!("{}, {}", receiver_var, ok_var);
-        let if_plan = IfPlan {
-            condition_setup: Vec::new(),
-            condition: ok_var,
-            then_body: LoweredBlock {
+        let if_plan = IfPlan::plain(
+            GoExpression::name(ok_var),
+            LoweredBlock {
                 statements: then_statements,
             },
             else_arm,
-        };
+        );
         SelectArmPlan::Receive {
             receive_vars: Some(receive_vars),
-            channel: ctx.channel.to_string(),
+            channel: ctx.channel.clone(),
             body: LoweredBlock {
                 statements: vec![LoweredStatement::If(if_plan)],
             },
@@ -373,7 +367,7 @@ impl Planner<'_> {
             });
             return SelectArmPlan::Receive {
                 receive_vars: Some(format!("_, {}", ok_var)),
-                channel: ctx.channel.to_string(),
+                channel: ctx.channel.clone(),
                 body: LoweredBlock { statements: body },
             };
         }
@@ -411,7 +405,7 @@ impl Planner<'_> {
             body_statements.extend(block.statements);
             SelectArmPlan::Receive {
                 receive_vars,
-                channel: ctx.channel.to_string(),
+                channel: ctx.channel.clone(),
                 body: LoweredBlock {
                     statements: body_statements,
                 },
@@ -436,7 +430,7 @@ impl Planner<'_> {
                 ch = cancel_deref_of_address(ch);
             }
             if ch_has_call {
-                ch = GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch.as_str()));
+                ch = GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch));
             }
             match operation {
                 ChannelOperation::Send { value, .. } => {
@@ -445,11 +439,9 @@ impl Planner<'_> {
                     setup.extend(value_plan.setup);
                     let mut val = value_plan.expression;
                     if val_has_call {
-                        val = GoExpression::name(self.hoist_tmp_value_statement(
-                            setup,
-                            "send_val",
-                            val.as_str(),
-                        ));
+                        val = GoExpression::name(
+                            self.hoist_tmp_value_statement(setup, "send_val", val),
+                        );
                     }
                     PreparedChannelOperation::Send(ch, val)
                 }
@@ -464,13 +456,13 @@ impl Planner<'_> {
                 ch = cancel_deref_of_address(ch);
             }
             if expression_has_call {
-                ch = GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch.as_str()));
+                ch = GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch));
             }
             PreparedChannelOperation::Receive(ch)
         }
     }
 
-    /// `case <send>:` (or `default:`) plus the arm body.
+    /// `case ch <- v:` or a bare `case <-ch:` plus the arm body.
     fn lower_send_arm(
         &mut self,
         operation: &PreparedChannelOperation,
@@ -480,11 +472,13 @@ impl Planner<'_> {
         let block = self.lower_block_to_place(body, place);
         match operation {
             PreparedChannelOperation::Send(ch, val) => SelectArmPlan::Send {
-                operation: GoExpression::opaque(format!("{} <- {}", ch, val)),
+                channel: ch.clone(),
+                value: val.clone(),
                 body: block,
             },
-            PreparedChannelOperation::Receive(ch) => SelectArmPlan::Send {
-                operation: GoExpression::receive(ch.clone()),
+            PreparedChannelOperation::Receive(ch) => SelectArmPlan::Receive {
+                receive_vars: None,
+                channel: ch.clone(),
                 body: block,
             },
         }
@@ -493,7 +487,7 @@ impl Planner<'_> {
     fn lower_match_receive_arm(
         &mut self,
         match_arms: &[MatchArm],
-        channel: &str,
+        channel: &GoExpression,
         element_ty: &Type,
         place: &PlacePlan,
     ) -> SelectArmPlan {
@@ -533,17 +527,17 @@ impl Planner<'_> {
             // precede the structured body inside the `case x, ok := <-ch:` arm.
             let mut body_statements: Vec<LoweredStatement> = Vec::new();
             if !used.contains(&ok_var) {
-                body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", ok_var)));
+                body_statements.push(discard(GoExpression::name(ok_var.clone())));
             }
             if case_var != "_" && !used.contains(&case_var) {
-                body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", case_var)));
+                body_statements.push(discard(GoExpression::name(case_var.clone())));
             }
             if let Some(plan) = arms_plan {
                 body_statements.push(LoweredStatement::If(plan));
             }
             SelectArmPlan::Receive {
                 receive_vars: Some(format!("{}, {}", case_var, ok_var)),
-                channel: channel.to_string(),
+                channel: channel.clone(),
                 body: LoweredBlock {
                     statements: body_statements,
                 },
@@ -583,8 +577,6 @@ impl Planner<'_> {
     }
 }
 
-/// `*&x` → `x` (avoids redundant deref when the emitter has already
-/// produced an `&`-prefixed expression).
 /// `*&x` is `x`. Any other pointer gets dereferenced.
 fn cancel_deref_of_address(channel: GoExpression) -> GoExpression {
     let contains_deferred_evaluation = channel.contains_deferred_evaluation();
@@ -610,25 +602,17 @@ fn build_receive_arms_plan(
     some: Option<LoweredBlock>,
     none: Option<LoweredBlock>,
 ) -> Option<IfPlan> {
+    let ok = || GoExpression::name(ok_var.to_string());
     match (some, none) {
-        (Some(some), Some(none)) => Some(IfPlan {
-            condition_setup: Vec::new(),
-            condition: ok_var.to_string(),
-            then_body: some,
-            else_arm: ElseArm::from_body(none, false),
-        }),
-        (Some(some), None) => Some(IfPlan {
-            condition_setup: Vec::new(),
-            condition: ok_var.to_string(),
-            then_body: some,
-            else_arm: ElseArm::None,
-        }),
-        (None, Some(none)) => Some(IfPlan {
-            condition_setup: Vec::new(),
-            condition: format!("!{}", ok_var),
-            then_body: none,
-            else_arm: ElseArm::None,
-        }),
+        (Some(some), Some(none)) => {
+            Some(IfPlan::plain(ok(), some, ElseArm::from_body(none, false)))
+        }
+        (Some(some), None) => Some(IfPlan::plain(ok(), some, ElseArm::None)),
+        (None, Some(none)) => Some(IfPlan::plain(
+            GoExpression::unary("!", ok()),
+            none,
+            ElseArm::None,
+        )),
         (None, None) => None,
     }
 }

--- a/crates/emit/src/control_flow/targets.rs
+++ b/crates/emit/src/control_flow/targets.rs
@@ -1,6 +1,6 @@
 use crate::plan::bodies::{
-    AssignForm, BreakValuePlan, CompoundKind, ElseArm, ExpressionStatementForm, IfPlan, LoopId,
-    LoopKind, LoopTransfer, LoweredBlock, LoweredStatement, ReturnForm,
+    AssignForm, BreakValuePlan, CompoundKind, ElseArm, IfPlan, LoopId, LoopKind, LoopTransfer,
+    LoweredBlock, LoweredStatement, ReturnForm,
 };
 use crate::plan::values::ValuePlan;
 
@@ -141,10 +141,6 @@ impl Legalizer {
                     self.walk_value(value, interception);
                 }
             },
-            LoweredStatement::Expression(plan) => match plan {
-                ExpressionStatementForm::Async { value } => self.walk_value(value, interception),
-                ExpressionStatementForm::AsyncBlock { .. } => {}
-            },
             LoweredStatement::Select(plan) => {
                 self.walk_statements(&mut plan.setup, interception);
                 let arm_interception = if plan.retry_loop {
@@ -169,11 +165,12 @@ impl Legalizer {
             }
             LoweredStatement::WhileLet(body) => self.walk_block(body, interception),
             LoweredStatement::Directed { inner, .. } => self.walk_statement(inner, interception),
-            LoweredStatement::TempBind { .. }
+            LoweredStatement::Async { .. }
+            | LoweredStatement::Define(_)
             | LoweredStatement::VarDecl { .. }
-            | LoweredStatement::ClosureBind { .. }
-            | LoweredStatement::RawGo(_)
-            | LoweredStatement::DivergingRawGo(_)
+            | LoweredStatement::Discard(_)
+            | LoweredStatement::AssignMany { .. }
+            | LoweredStatement::ExpressionStatement { .. }
             | LoweredStatement::UnreachablePanic => {}
         }
     }

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -2,6 +2,7 @@ use crate::Planner;
 use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, EnumLayout};
 use crate::definitions::structs::{StringFormat, should_synthesize_stringer};
 use crate::names::go_name::{self, prelude_qualifier};
+use crate::plan::values::GoExpression;
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use syntax::ast::{Attribute, Generic};
 use syntax::program::{Definition, DefinitionBody};
@@ -148,13 +149,24 @@ impl Planner<'_> {
                 .iter()
                 .zip(layout_variant.fields.iter())
                 .map(|(sem_field, layout_field)| {
-                    let mut lhs = format!("{receiver}.{}", layout_field.go_name);
-                    let mut rhs = format!("{other}.{}", layout_field.go_name);
-                    if layout_field.is_recursive() {
-                        lhs = format!("(*{lhs})");
-                        rhs = format!("(*{rhs})");
-                    }
-                    self.render_equality(&lhs, &rhs, &sem_field.ty, &sem_generics)
+                    let field = |base: &str| {
+                        let access = GoExpression::selector(
+                            GoExpression::name(base.to_string()),
+                            layout_field.go_name.clone(),
+                        );
+                        if layout_field.is_recursive() {
+                            GoExpression::parenthesized(GoExpression::dereference(access))
+                        } else {
+                            access
+                        }
+                    };
+                    self.equality_expression(
+                        field(&receiver),
+                        field(&other),
+                        &sem_field.ty,
+                        &sem_generics,
+                    )
+                    .rendered()
                 })
                 .collect();
             cases.push(format!(

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -7,7 +7,9 @@ use crate::abi::callable::CallableReturnAbi;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::PatternSubject;
-use crate::plan::bodies::LoweredBlock;
+use crate::plan::bodies::{LoweredBlock, LoweredStatement};
+use crate::plan::go_expression::FunctionLiteralLayout;
+use crate::plan::values::GoExpression;
 use crate::state::package_state::FunctionEmissionContext;
 use crate::types::native::NativeGoType;
 use crate::utils::{group_params, receiver_name};
@@ -76,7 +78,7 @@ impl Planner<'_> {
         body: &Expression,
         ty: &Type,
         ctx: ExpressionContext<'_>,
-    ) -> String {
+    ) -> GoExpression {
         self.with_isolated_function(|this| {
             let (mut param_pairs, destructure_bindings) = this.build_lambda_param_pairs(params);
 
@@ -97,17 +99,26 @@ impl Planner<'_> {
             let recover = handle.as_ref().map(|name| {
                 this.require_testkit();
                 let span = body.get_span();
-                format!(
-                    "defer {name}.Recover({}, {}, {})\n",
-                    span.file_id,
-                    span.byte_offset,
-                    span.byte_offset + span.byte_length,
-                )
+                let literal = |value: u32| GoExpression::literal(value.to_string());
+                LoweredStatement::Async {
+                    keyword: "defer".to_string(),
+                    call: GoExpression::call(
+                        GoExpression::selector(
+                            GoExpression::name(name.clone()),
+                            "Recover".to_string(),
+                        ),
+                        vec![
+                            literal(span.file_id),
+                            literal(span.byte_offset),
+                            literal(span.byte_offset + span.byte_length),
+                        ],
+                    ),
+                }
             });
 
             let return_info = this.lambda_return_info(ty, ctx);
-            let mut body_string = this.with_test_handle(handle, |this| {
-                this.emit_lambda_body_with_deferred(
+            let mut statements = this.with_test_handle(handle, |this| {
+                this.lower_lambda_body_with_deferred(
                     body,
                     &destructure_bindings,
                     &return_info.ctx,
@@ -115,14 +126,14 @@ impl Planner<'_> {
                 )
             });
             if let Some(recover) = recover {
-                body_string.insert_str(0, &recover);
+                statements.insert(0, recover);
             }
 
-            format!(
-                "func({}){} {{\n{}}}",
+            GoExpression::function_literal(
                 group_params(&param_pairs),
-                return_info.signature(),
-                body_string
+                return_info.signature().trim_start().to_string(),
+                LoweredBlock { statements },
+                FunctionLiteralLayout::MultiLine,
             )
         })
     }
@@ -200,24 +211,26 @@ impl Planner<'_> {
         }
     }
 
-    fn emit_lambda_body_with_deferred(
+    fn lower_lambda_body_with_deferred(
         &mut self,
         body: &Expression,
         destructure_bindings: &[LambdaParamDestructure<'_>],
         return_ctx: &ReturnContext,
         should_return: bool,
-    ) -> String {
-        let mut body_string = String::new();
+    ) -> Vec<LoweredStatement> {
+        let mut statements = Vec::new();
         for (temp_name, pattern, param_ty) in destructure_bindings {
-            let statements = self.lower_irrefutable_pattern_site(
+            statements.extend(self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(temp_name.clone()),
                 pattern,
                 param_ty,
-            );
-            Renderer.render_lowered_block(&mut body_string, &LoweredBlock { statements });
+            ));
         }
-        self.emit_function_body(&mut body_string, body, should_return, return_ctx);
-        body_string
+        let body = self.with_return_context(return_ctx.clone(), |this| {
+            this.lower_function_body(body, should_return)
+        });
+        statements.extend(body.statements);
+        statements
     }
 
     fn declare_type_param_go_names(

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,8 +1,11 @@
 use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
-use crate::abi::transition::render_lowered_result_return;
+use crate::abi::transition::emit_lowered_result_return;
+use crate::control_flow::propagation::plain_return;
 use crate::names::go_name;
 use crate::names::go_name::GO_IMPORT_PREFIX;
+use crate::plan::bodies::{LoweredStatement, define, expression_statement};
+use crate::plan::values::GoExpression;
 use crate::write_line;
 use ecow::EcoString;
 use rustc_hash::FxHashSet as HashSet;
@@ -332,14 +335,21 @@ impl Planner<'_> {
             } else {
                 go_name::unexported_method_go_name(&method.name)
             };
-            let inner_call = format!(
-                "{}.inner.{}({})",
-                receiver_name,
-                go_method_name,
-                param_names.join(", ")
+            let inner_call = GoExpression::call(
+                GoExpression::selector(
+                    GoExpression::selector(
+                        GoExpression::name(receiver_name.clone()),
+                        "inner".to_string(),
+                    ),
+                    go_method_name.clone(),
+                ),
+                param_names
+                    .iter()
+                    .map(|name| GoExpression::name(name.clone()))
+                    .collect(),
             );
 
-            let (go_ret, body) = this.build_adapter_body(method, &inner_call);
+            let (go_ret, body) = this.build_adapter_body(method, inner_call);
             write_method_header(
                 declaration,
                 &receiver_name,
@@ -381,24 +391,39 @@ impl Planner<'_> {
                 .code
     }
 
-    fn build_adapter_body(&mut self, method: &AdapterMethod, inner_call: &str) -> (String, String) {
+    fn build_adapter_body(
+        &mut self,
+        method: &AdapterMethod,
+        inner_call: GoExpression,
+    ) -> (String, String) {
+        let (go_ret, statements) = self.plan_adapter_body(method, inner_call);
+        (go_ret, crate::Renderer.render_setup(&statements))
+    }
+
+    fn plan_adapter_body(
+        &mut self,
+        method: &AdapterMethod,
+        inner_call: GoExpression,
+    ) -> (String, Vec<LoweredStatement>) {
         let user_abi = &method.user_abi;
         let interface_abi = &method.interface_abi;
         let return_type = &method.return_type;
 
         if method.user_returns_void != method.interface_returns_void {
             if method.interface_returns_void {
-                return (String::new(), format!("{}\n", inner_call));
+                return (String::new(), vec![expression_statement(inner_call)]);
             }
             let go_ret = self.use_go_type(return_type);
-            let (zero, packages) = self.zero_value(return_type);
-            self.require_packages(&packages);
-            return (go_ret, format!("{}\nreturn {}\n", inner_call, zero));
+            let zero = self.zero_value_expression(return_type);
+            return (
+                go_ret,
+                vec![expression_statement(inner_call), plain_return(zero)],
+            );
         }
 
         if !self.adapter_needs_conversion(method) {
             if method.interface_returns_void {
-                return (String::new(), format!("{}\n", inner_call));
+                return (String::new(), vec![expression_statement(inner_call)]);
             }
             let peeled = self.facts.peel_alias(return_type);
             let go_ret_abi = if abi_matches_type(interface_abi, &peeled) {
@@ -407,27 +432,31 @@ impl Planner<'_> {
                 user_abi
             };
             let go_ret = self.render_lowered_return_ty(go_ret_abi, return_type);
-            return (go_ret, format!("return {}\n", inner_call));
+            return (go_ret, vec![plain_return(inner_call)]);
         }
 
         let logical_ty = self.facts.peel_alias(return_type);
         let go_ret = self.render_lowered_return_ty(interface_abi, return_type);
         if interface_abi.is_passthrough() {
             let statements = self.lower_abi_to_tagged_return(inner_call, user_abi, &logical_ty);
-            return (go_ret, crate::Renderer.render_setup(&statements));
+            return (go_ret, statements);
         }
-        let (setup, tagged) = self.lower_abi_to_tagged(inner_call, user_abi, &logical_ty);
-        let mut body = crate::Renderer.render_setup(&setup);
+        let (mut statements, tagged) = self.lower_abi_to_tagged(inner_call, user_abi, &logical_ty);
         let subject = if user_abi.is_passthrough() {
             let res = self.fresh_var(Some("res"));
             self.declare(&res);
-            write_line!(body, "{} := {}", res, tagged);
-            res
+            statements.push(define(res.clone(), tagged));
+            GoExpression::name(res)
         } else {
             tagged
         };
-        render_lowered_result_return(self, &mut body, &subject, &logical_ty, interface_abi);
-        (go_ret, body)
+        statements.extend(emit_lowered_result_return(
+            self,
+            &subject,
+            &logical_ty,
+            interface_abi,
+        ));
+        (go_ret, statements)
     }
 }
 

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -3,6 +3,7 @@ use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_MET
 use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name::{self, prelude_qualifier};
+use crate::plan::values::GoExpression;
 use crate::types::go_type::render_conversion;
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use rustc_hash::FxHashSet;
@@ -473,9 +474,11 @@ impl Planner<'_> {
             .iter()
             .map(|f| {
                 let go_field = struct_field_go_name(f, attributes);
-                let lhs = format!("{receiver}.{go_field}");
-                let rhs = format!("{other}.{go_field}");
-                self.render_equality(&lhs, &rhs, &f.ty, generics)
+                let field = |base: &str| {
+                    GoExpression::selector(GoExpression::name(base.to_string()), go_field.clone())
+                };
+                self.equality_expression(field(&receiver), field(&other), &f.ty, generics)
+                    .rendered()
             })
             .collect();
         let body = if comparisons.is_empty() {

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -235,7 +235,7 @@ impl Planner<'_> {
             return None;
         }
         let raw_access = GoExpression::selector(base.clone(), field.to_string());
-        let raw_var = self.hoist_tmp_value_statement(setup, "raw", raw_access.as_str());
+        let raw_var = self.hoist_tmp_value_statement(setup, "raw", raw_access);
         let (coercion_setup, coerced) = coercion.lower(self, GoExpression::name(raw_var));
         setup.extend(coercion_setup);
         Some(coerced)
@@ -318,7 +318,7 @@ impl Planner<'_> {
             }
             match expression.unwrap_parens() {
                 Expression::Call { .. } => {
-                    GoExpression::name(self.hoist_tmp_value_statement(setup, "ref", base.as_str()))
+                    GoExpression::name(self.hoist_tmp_value_statement(setup, "ref", base))
                 }
                 Expression::StructCall { .. } => {
                     GoExpression::parenthesized(GoExpression::address_of(base))
@@ -340,10 +340,10 @@ impl Planner<'_> {
 
     pub(crate) fn try_emit_tuple_struct_field_access(
         &self,
-        expression_string: &str,
+        base: GoExpression,
         expression_ty: &Type,
         index: usize,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let deref_ty = expression_ty.strip_refs();
         let Type::Nominal { ref id, .. } = deref_ty else {
             return None;
@@ -361,7 +361,7 @@ impl Planner<'_> {
             return None;
         };
 
-        Some(format!("{}.F{}", expression_string, index))
+        Some(GoExpression::selector(base, format!("F{index}")))
     }
 
     fn try_resolve_cross_package_const(

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -148,17 +148,13 @@ impl Planner<'_> {
         {
             let base_expr = expression.deref_inner().unwrap_or(expression);
             if is_order_sensitive(base_expr) {
-                base = GoExpression::name(self.hoist_tmp_value_statement(
-                    &mut setup,
-                    "base",
-                    &base.rendered(),
-                ));
+                base = GoExpression::name(self.hoist_tmp_value_statement(&mut setup, "base", base));
             }
             let Some(end_expression) = end_value else {
                 let length = GoExpression::name(self.hoist_tmp_value_statement(
                     &mut setup,
                     "len",
-                    &format!("len({})", base.rendered()),
+                    GoExpression::call(GoExpression::name("len".to_string()), vec![base.clone()]),
                 ));
                 return ValuePlan::computed(
                     setup,
@@ -171,14 +167,14 @@ impl Planner<'_> {
                     GoExpression::name(self.hoist_tmp_value_statement(
                         &mut setup,
                         "start",
-                        &start_expression.rendered(),
+                        start_expression,
                     ))
                 });
             }
             let end_variable = GoExpression::name(self.hoist_tmp_value_statement(
                 &mut setup,
                 "end",
-                &end_expression.rendered(),
+                end_expression,
             ));
             return ValuePlan::computed(
                 setup,

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -9,10 +9,13 @@ use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
+use crate::control_flow::propagation::plain_return;
 use crate::definitions::enum_layout;
 use crate::go_name;
-use crate::plan::bodies::LoweredStatement;
-use crate::plan::go_expression::CompositeLayout;
+use crate::plan::bodies::{
+    LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign, discard,
+};
+use crate::plan::go_expression::{CompositeLayout, FunctionLiteralLayout};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::utils::is_order_sensitive;
 use syntax::program::AliasKind;
@@ -553,10 +556,36 @@ impl Planner<'_> {
             return GoExpression::empty_composite(format!("[{}]{}", len, elem_go));
         }
         let zero = self.lisette_zero(elem);
+        let array_type = format!("[{len}]{elem_go}");
+        let arr = || GoExpression::name("arr".to_string());
+        let index = || GoExpression::name("i".to_string());
         // Go has no syntax to repeat a value across all N slots, so fill each index.
-        GoExpression::opaque(format!(
-            "func() [{len}]{elem_go} {{ var arr [{len}]{elem_go}; for i := range arr {{ arr[i] = {zero} }}; return arr }}()"
-        ))
+        GoExpression::immediate_call(
+            array_type.clone(),
+            LoweredBlock {
+                statements: vec![
+                    LoweredStatement::VarDecl {
+                        name: "arr".to_string(),
+                        go_type: array_type,
+                        value: None,
+                    },
+                    LoweredStatement::Loop(LoopPlan {
+                        prologue: Vec::new(),
+                        kind: LoopKind::Generated { label: None },
+                        header: LoopHeader::Range {
+                            key: Some("i".to_string()),
+                            value: None,
+                            iterable: arr(),
+                        },
+                        body: LoweredBlock {
+                            statements: vec![assign(GoExpression::index(arr(), index()), zero)],
+                        },
+                    }),
+                    plain_return(arr()),
+                ],
+            },
+            FunctionLiteralLayout::MultiLine,
+        )
     }
 
     /// True when Go's zero for the element already matches Lisette's.
@@ -598,7 +627,7 @@ impl Planner<'_> {
         if !needs_pointer {
             return value;
         }
-        let temp = self.hoist_tmp_value_statement(statements, "ptr", value.as_str());
+        let temp = self.hoist_tmp_value_statement(statements, "ptr", value);
         GoExpression::address_of(GoExpression::name(temp))
     }
 
@@ -759,12 +788,13 @@ impl Planner<'_> {
         fields
             .into_iter()
             .map(|field| {
-                if field.has_observable_evaluation {
-                    let temp =
-                        self.hoist_tmp_value_statement(statements, "field", field.value.as_str());
-                    (field.name, GoExpression::name(temp))
+                let has_observable_evaluation = field.has_observable_evaluation;
+                let (name, value) = field.into_pair();
+                if has_observable_evaluation {
+                    let temp = self.hoist_tmp_value_statement(statements, "field", value);
+                    (name, GoExpression::name(temp))
                 } else {
-                    field.into_pair()
+                    (name, value)
                 }
             })
             .collect()
@@ -781,13 +811,13 @@ impl Planner<'_> {
         }
 
         let (mut statements, base_value) = base_staged.into_parts();
-        let tmp = self.hoist_tmp_value_statement(&mut statements, "copy", &base_value);
+        let tmp = self.hoist_tmp_value_statement(&mut statements, "copy", base_value);
 
         for (name, value) in fields {
-            statements.push(LoweredStatement::RawGo(format!(
-                "{}.{} = {}\n",
-                tmp, name, value
-            )));
+            statements.push(assign(
+                GoExpression::selector(GoExpression::name(tmp.clone()), name.clone()),
+                value.clone(),
+            ));
         }
 
         (statements, GoExpression::name(tmp))
@@ -818,7 +848,7 @@ impl Planner<'_> {
         } = base_staged;
 
         if carried.is_empty() {
-            statements.push(LoweredStatement::RawGo(format!("_ = {}\n", base_value)));
+            statements.push(discard(base_value));
             return (
                 statements,
                 emit_struct_literal(
@@ -834,7 +864,7 @@ impl Planner<'_> {
             GoExpression::name(self.hoist_tmp_value_statement(
                 &mut statements,
                 "spread",
-                base_value.as_str(),
+                base_value,
             ))
         } else {
             base_value

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -1,10 +1,11 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::analyze::facts::EmitFacts;
 use crate::calls::predicates::strip_negations;
 use crate::context::expression::ExpressionContext;
+use crate::control_flow::propagation::plain_return;
 use crate::names::go_name;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{LoweredBlock, LoweredStatement};
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::{
     CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, ValuePlan,
 };
@@ -152,14 +153,14 @@ impl Planner<'_> {
         let right_value = if right_staged.setup.is_empty() {
             right_staged.expression
         } else {
-            GoExpression::opaque_with_deferred_evaluation(
-                format!(
-                    "func() bool {{\n{}return {}\n}}()",
-                    Renderer.render_setup(&right_staged.setup),
-                    right_staged.expression
-                ),
-                true,
+            let mut statements = right_staged.setup;
+            statements.push(plain_return(right_staged.expression));
+            GoExpression::immediate_call(
+                "bool".to_string(),
+                LoweredBlock { statements },
+                FunctionLiteralLayout::MultiLine,
             )
+            .with_deferred_evaluation(true)
         };
 
         ValuePlan::computed(

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -3,7 +3,7 @@ use crate::abi::is_tagged_shape_fn_value;
 use crate::abi::transition::lower_arg_to_tagged;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{LoweredStatement, define};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::{
@@ -77,15 +77,15 @@ impl Planner<'_> {
 
         let staged = self.plan_operand(expression, ExpressionContext::value());
         let (mut setup, value) = staged.into_parts();
-        let temp_var = self.hoist_tmp_value_statement(&mut setup, prefix, &value);
+        let temp_var = self.hoist_tmp_value_statement(&mut setup, prefix, value);
         ValuePlan::captured(setup, temp_var)
     }
 
     /// Pin a staged operand's value into a temp so it evaluates before any
     /// later sibling.
     pub(crate) fn pin_staged(&mut self, staged: &mut ValuePlan, prefix: &str) {
-        let tmp =
-            self.hoist_tmp_value_statement(&mut staged.setup, prefix, staged.expression.as_str());
+        let value = mem::replace(&mut staged.expression, GoExpression::empty());
+        let tmp = self.hoist_tmp_value_statement(&mut staged.setup, prefix, value);
         staged.replace_with_pinned_name(tmp);
     }
 
@@ -114,15 +114,15 @@ impl Planner<'_> {
         expression: &Expression,
         prefix: &str,
         boundary: CaptureBoundary,
-    ) -> String {
+    ) -> GoExpression {
         let plan = self.lower_composite_value(expression, ExpressionContext::value());
         let requires_capture = boundary.requires_value_capture(plan.evaluation.stability);
-        let (value_setup, expression_string) = plan.into_parts();
+        let (value_setup, value) = plan.into_parts();
         setup.extend(value_setup);
         if requires_capture {
-            self.hoist_tmp_value_statement(setup, prefix, &expression_string)
+            GoExpression::name(self.hoist_tmp_value_statement(setup, prefix, value))
         } else {
-            expression_string
+            value
         }
     }
 
@@ -251,12 +251,12 @@ impl Planner<'_> {
                 .is_some()
         {
             return staged.map_expression_as_computed(|setup, value| {
-                let tagged = self.emit_lower_arg_to_tagged(
+                self.emit_lower_arg_to_tagged(
                     setup,
-                    value.as_str(),
+                    value,
                     param_ty.expect("detected lowering requires a parameter type"),
-                );
-                GoExpression::opaque_with_deferred_evaluation(tagged, true)
+                )
+                .with_deferred_evaluation(true)
             });
         }
 
@@ -290,16 +290,11 @@ impl Planner<'_> {
     pub(crate) fn emit_lower_arg_to_tagged(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
-        value: &str,
+        value: GoExpression,
         param_ty: &Type,
-    ) -> String {
+    ) -> GoExpression {
         let cb_var = self.hoist_tmp_value_statement(setup, "cb", value);
-        let mut buffer = String::new();
-        let tagged = lower_arg_to_tagged(self, &mut buffer, &cb_var, param_ty);
-        if !buffer.is_empty() {
-            setup.push(LoweredStatement::RawGo(buffer));
-        }
-        tagged
+        lower_arg_to_tagged(self, setup, GoExpression::name(cb_var), param_ty)
     }
 
     pub(crate) fn stage_native_method_args_from(
@@ -418,10 +413,7 @@ impl Planner<'_> {
             if pins[i] || (eager && s_non_literal) {
                 let tmp = self.fresh_var(Some(prefix));
                 self.declare(&tmp);
-                setup.push(LoweredStatement::TempBind {
-                    name: tmp.clone(),
-                    value: s_expression.rendered(),
-                });
+                setup.push(define(tmp.clone(), s_expression));
                 results.push(GoExpression::name(tmp));
             } else {
                 results.push(s_expression);

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -9,8 +9,9 @@ use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::abi::transition::emit_lisette_callback_wrapper;
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
-use crate::plan::bodies::{ExpressionStatementForm, LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{LoweredBlock, LoweredStatement, assign, discard, expression_statement};
 use crate::plan::calls::{CallPlan, CallableOrigin};
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, OperandForm, ValuePlan,
 };
@@ -64,14 +65,10 @@ impl Planner<'_> {
                 } else {
                     self.emit_go_fn_wrapper(&mut setup, expression, &callee.abi)
                 };
-                return ValuePlan::computed(
-                    setup,
-                    GoExpression::opaque(value),
-                    EvaluationEffect::Pure,
-                )
-                .stable_across_calls_if(
-                    self.identifier_immune_to_calls(expression.unwrap_parens()),
-                );
+                return ValuePlan::computed(setup, value, EvaluationEffect::Pure)
+                    .stable_across_calls_if(
+                        self.identifier_immune_to_calls(expression.unwrap_parens()),
+                    );
             }
         }
 
@@ -93,7 +90,7 @@ impl Planner<'_> {
                 .lower_value(expression, ctx)
                 .map_expression_as_observable_computed(|setup, call| {
                     if !call.is_empty() {
-                        setup.push(LoweredStatement::RawGo(format!("{call}\n")));
+                        setup.push(expression_statement(call));
                     }
                     GoExpression::empty_composite("struct{}".to_string())
                 });
@@ -157,9 +154,9 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         ty: &Type,
-        raw: String,
+        raw: GoExpression,
         ctx: ExpressionContext<'_>,
-    ) -> String {
+    ) -> GoExpression {
         if ctx.is_callee() || ctx.forces_tagged_go_function() {
             return raw;
         }
@@ -173,7 +170,7 @@ impl Planner<'_> {
         if self.classify_direct_emission(&f.return_type).is_none() {
             return raw;
         }
-        emit_lisette_callback_wrapper(self, setup, &raw, fn_ty)
+        emit_lisette_callback_wrapper(self, setup, raw, fn_ty)
     }
 
     /// Result ABI the slot expects from a Go function value, or `None` when
@@ -242,7 +239,7 @@ impl Planner<'_> {
                     &mut adapter_setup,
                     expression,
                     ty,
-                    plan.rendered(),
+                    plan.expression.clone(),
                     ctx,
                 );
                 if adapter_setup.is_empty() {
@@ -250,15 +247,12 @@ impl Planner<'_> {
                 } else {
                     plan.map_expression_as_computed(|setup, identifier| {
                         setup.extend(adapter_setup);
-                        GoExpression::opaque_with_deferred_evaluation(
-                            value,
-                            identifier.contains_deferred_evaluation(),
-                        )
+                        value.with_deferred_evaluation(identifier.contains_deferred_evaluation())
                     })
                 }
             }
             Expression::Call { ty, .. } => self.lower_call_value(expression, ty, ctx),
-            Expression::RawGo { text } => ValuePlan::opaque(text.clone()),
+            Expression::RawGo { text } => ValuePlan::verbatim(text.clone()),
             Expression::Unit { .. } => ValuePlan::computed(
                 Vec::new(),
                 GoExpression::empty_composite("struct{}".to_string()),
@@ -266,12 +260,22 @@ impl Planner<'_> {
             ),
             Expression::Lambda {
                 params, body, ty, ..
-            } => ValuePlan::opaque(self.emit_lambda(params, body, ty, ctx)),
+            } => ValuePlan::computed(
+                Vec::new(),
+                self.emit_lambda(params, body, ty, ctx),
+                EvaluationEffect::Pure,
+            ),
             Expression::Function {
                 params, body, ty, ..
             } => match body.definition() {
-                Some(body) => ValuePlan::opaque(self.emit_lambda(params, body, ty, ctx)),
-                None => ValuePlan::opaque(String::new()),
+                Some(body) => ValuePlan::computed(
+                    Vec::new(),
+                    self.emit_lambda(params, body, ty, ctx),
+                    EvaluationEffect::Pure,
+                ),
+                None => {
+                    ValuePlan::computed(Vec::new(), GoExpression::empty(), EvaluationEffect::Pure)
+                }
             },
             Expression::IfLet { ty, .. }
             | Expression::Match { ty, .. }
@@ -462,13 +466,13 @@ impl Planner<'_> {
             let staged = self.plan_operand(inner.unwrap_parens(), ExpressionContext::value());
             return staged.map_expression_as_observable_computed(|setup, staged_value| {
                 if !staged_value.is_empty() {
-                    setup.push(LoweredStatement::Expression(
-                        ExpressionStatementForm::Async {
-                            value: ValuePlan::opaque(staged_value.rendered()),
-                        },
-                    ));
+                    setup.push(expression_statement(staged_value));
                 }
-                let tmp = self.hoist_tmp_value_statement(setup, "ref", "struct{}{}");
+                let tmp = self.hoist_tmp_value_statement(
+                    setup,
+                    "ref",
+                    GoExpression::empty_composite("struct{}".to_string()),
+                );
                 GoExpression::address_of(GoExpression::name(tmp))
             });
         }
@@ -480,7 +484,7 @@ impl Planner<'_> {
             } else if self.is_go_unaddressable(inner)
                 || matches!(inner.get_type(), Type::Function(_))
             {
-                let tmp = self.hoist_tmp_value_statement(setup, "ref", emitted.as_str());
+                let tmp = self.hoist_tmp_value_statement(setup, "ref", emitted);
                 GoExpression::address_of(GoExpression::name(tmp))
             } else {
                 GoExpression::address_of(emitted)
@@ -533,7 +537,7 @@ impl Planner<'_> {
         let right_hand_side = literal_slot
             .unwrap_or_else(|| self.lower_composite_value(value, ExpressionContext::value()));
         let mut setup: Vec<LoweredStatement> = Vec::new();
-        let target_str = if is_order_sensitive(target) {
+        let target_place = if is_order_sensitive(target) {
             self.emit_left_value_capturing(&mut setup, target, Some(&right_hand_side))
         } else {
             self.emit_left_value(&mut setup, target)
@@ -553,17 +557,11 @@ impl Planner<'_> {
             if !coercion.is_identity() {
                 let (coercion_setup, unwrapped) = coercion.lower(self, rhs_value);
                 setup.extend(coercion_setup);
-                setup.push(LoweredStatement::RawGo(format!(
-                    "{} = {}\n",
-                    target_str, unwrapped
-                )));
+                setup.push(assign(target_place, unwrapped));
                 return setup;
             }
         }
-        setup.push(LoweredStatement::RawGo(format!(
-            "{} = {}\n",
-            target_str, rhs_value
-        )));
+        setup.push(assign(target_place, rhs_value));
         setup
     }
 
@@ -625,25 +623,27 @@ impl Planner<'_> {
         keyword: &str,
         expression: &Expression,
     ) -> ValuePlan {
+        let async_statement = |call: GoExpression| LoweredStatement::Async {
+            keyword: keyword.to_string(),
+            call,
+        };
+        let statement_plan = |setup: Vec<LoweredStatement>| {
+            ValuePlan::computed(setup, GoExpression::empty(), EvaluationEffect::Pure)
+        };
+        let immediate_call = |body: LoweredBlock| {
+            GoExpression::immediate_call(String::new(), body, FunctionLiteralLayout::MultiLine)
+        };
+
         if let Expression::Block { .. } = expression {
             let body =
                 self.with_isolated_function(|planner| planner.lower_block_as_body(expression));
-            let setup = vec![LoweredStatement::Expression(
-                ExpressionStatementForm::AsyncBlock {
-                    keyword: keyword.to_string(),
-                    body,
-                },
-            )];
-            return ValuePlan::computed(setup, GoExpression::empty(), EvaluationEffect::Pure);
+            return statement_plan(vec![async_statement(immediate_call(body))]);
         }
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
-        if let Some(call_str) = self.emit_go_call_discarded(&mut setup, expression) {
-            return ValuePlan::computed(
-                setup,
-                GoExpression::opaque(format!("{} {}", keyword, call_str)),
-                EvaluationEffect::Pure,
-            );
+        if let Some(call) = self.emit_go_call_discarded(&mut setup, expression) {
+            setup.push(async_statement(call));
+            return statement_plan(setup);
         }
 
         let plan = self.lower_value(
@@ -664,30 +664,21 @@ impl Planner<'_> {
                 .into_parts();
             let mut body_statements = Vec::new();
             if !inner.is_empty() {
-                let line = if expression.get_type().is_unit() {
-                    format!("{}\n", inner)
+                body_statements.push(if expression.get_type().is_unit() {
+                    expression_statement(inner)
                 } else {
-                    format!("_ = {}\n", inner)
-                };
-                body_statements.push(LoweredStatement::RawGo(line));
+                    discard(inner)
+                });
             }
             let body = LoweredBlock {
                 statements: body_statements,
             };
-            setup.push(LoweredStatement::Expression(
-                ExpressionStatementForm::AsyncBlock {
-                    keyword: keyword.to_string(),
-                    body,
-                },
-            ));
-            return ValuePlan::computed(setup, GoExpression::empty(), EvaluationEffect::Pure);
+            setup.push(async_statement(immediate_call(body)));
+            return statement_plan(setup);
         }
-        let (setup, inner) = plan.into_parts();
-        ValuePlan::computed(
-            setup,
-            GoExpression::opaque(format!("{} {}", keyword, inner)),
-            EvaluationEffect::Pure,
-        )
+        let (mut setup, inner) = plan.into_parts();
+        setup.push(async_statement(inner));
+        statement_plan(setup)
     }
 }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -42,7 +42,8 @@ use diagnostics::LisetteDiagnostic;
 use names::go_name::GeneratedPackage;
 use names::packages::{PackageRequirements, PackageUse};
 use plan::PackagePlan;
-use plan::bodies::{LoopId, LoweredBlock, LoweredStatement};
+use plan::bodies::{LoopId, LoweredBlock, LoweredStatement, define};
+use plan::values::GoExpression;
 use state::adapter_registry::AdapterRegistry;
 use state::file_namespace::FileNamespace;
 use state::package_state::{FunctionEmissionContext, PackageState};
@@ -478,41 +479,29 @@ impl<'a> Planner<'a> {
         self.scope.declare_go_name(go_name);
     }
 
-    /// Allocate a fresh Go temp, register it as declared, and emit
-    /// `tmp := value` into `output`.
-    fn hoist_tmp_value(&mut self, output: &mut String, hint: &str, value: &str) -> String {
-        let tmp = self.fresh_var(Some(hint));
-        self.declare(&tmp);
-        write_line!(output, "{} := {}", tmp, value);
-        tmp
-    }
-
     /// Bind `value` to a name that can be read more than once.
     fn stable_source(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         hint: &str,
-        value: &str,
-    ) -> String {
-        if go_name::is_plain_identifier(value) {
-            return value.to_string();
+        value: GoExpression,
+    ) -> GoExpression {
+        if go_name::is_plain_identifier(value.as_str()) {
+            return value;
         }
-        self.hoist_tmp_value_statement(statements, hint, value)
+        GoExpression::name(self.hoist_tmp_value_statement(statements, hint, value))
     }
 
-    /// Structured counterpart of `hoist_tmp_value`: push a `TempBind` leaf.
+    /// Allocate a fresh Go temp, register it as declared, and push `tmp := value`.
     fn hoist_tmp_value_statement(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         hint: &str,
-        value: &str,
+        value: GoExpression,
     ) -> String {
         let tmp = self.fresh_var(Some(hint));
         self.declare(&tmp);
-        setup.push(LoweredStatement::TempBind {
-            name: tmp.clone(),
-            value: value.to_string(),
-        });
+        setup.push(define(tmp.clone(), value));
         tmp
     }
 

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -3,9 +3,8 @@ use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate};
 use crate::patterns::decision_tree::{
     Check, PatternBinding, PatternInfo, SubjectRoot, render_condition,
 };
-use crate::plan::bodies::LoweredStatement;
-use crate::plan::placement::simple_assign;
-use crate::plan::values::{EvaluationEffect, ValuePlan};
+use crate::plan::bodies::{LoweredStatement, assign, define, define_many};
+use crate::plan::values::GoExpression;
 use crate::state::bindings::InlineExpr;
 use std::borrow::Cow;
 use syntax::ast::Expression;
@@ -28,24 +27,28 @@ pub(crate) fn apply_root_assertion<'s>(
         unreachable!("multi-type root assertions only reach match destructure paths")
     };
     planner.scope.record_go_use(subject);
-    let expression = format!("{}.({})", subject, go_type);
-    let var = planner.hoist_tmp_value_statement(statements, "asserted", &expression);
+    let expression =
+        GoExpression::type_assertion(GoExpression::name(subject.to_string()), go_type.clone());
+    let var = planner.hoist_tmp_value_statement(statements, "asserted", expression);
     Cow::Owned(var)
 }
 
 /// Hoist a root type assertion as comma-ok for refutable contexts (while-let,
-/// select arms, or-pattern let-else). Returns `(effective_subject, ok_var)`.
+/// select arms, or-pattern let-else). Returns `(effective_subject, ok_test)`.
 pub(crate) fn apply_refutable_root_assertion<'s>(
     planner: &mut Planner,
     statements: &mut Vec<LoweredStatement>,
     info: &PatternInfo,
     subject: &'s str,
-) -> (Cow<'s, str>, Option<String>) {
+) -> (Cow<'s, str>, Option<GoExpression>) {
     let Some(assertion) = info.root_assertion.as_ref() else {
         return (Cow::Borrowed(subject), None);
     };
     planner.scope.record_go_use(subject);
     let needs_asserted = info.requires_asserted_subject();
+    let assertion_of = |go_type: &String| {
+        GoExpression::type_assertion(GoExpression::name(subject.to_string()), go_type.clone())
+    };
     match assertion.go_types.as_slice() {
         [go_type] => {
             let asserted_lhs = if needs_asserted {
@@ -57,52 +60,53 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
             };
             let ok = planner.fresh_var(Some("ok"));
             planner.declare(&ok);
-            statements.push(LoweredStatement::RawGo(format!(
-                "{}, {} := {}.({})\n",
-                asserted_lhs, ok, subject, go_type
-            )));
+            statements.push(define_many(
+                vec![asserted_lhs.clone(), ok.clone()],
+                assertion_of(go_type),
+            ));
             let effective = if needs_asserted {
                 Cow::Owned(asserted_lhs)
             } else {
                 Cow::Borrowed(subject)
             };
-            (effective, Some(ok))
+            (effective, Some(GoExpression::name(ok)))
         }
         multiple => {
             // No-binding interface or-pattern (`A | B`): no single asserted
             // form is possible across types.
-            let oks: Vec<String> = multiple
+            let oks = multiple
                 .iter()
                 .map(|t| {
                     let ok = planner.fresh_var(Some("ok"));
                     planner.declare(&ok);
-                    statements.push(LoweredStatement::RawGo(format!(
-                        "_, {} := {}.({})\n",
-                        ok, subject, t
-                    )));
-                    ok
+                    statements.push(define_many(
+                        vec!["_".to_string(), ok.clone()],
+                        assertion_of(t),
+                    ));
+                    GoExpression::name(ok)
                 })
-                .collect();
+                .reduce(|left, right| GoExpression::binary(left, "||", right))
+                .expect("a multi-type assertion names at least one type");
             (
                 Cow::Borrowed(subject),
-                Some(format!("({})", oks.join(" || "))),
+                Some(GoExpression::parenthesized(oks)),
             )
         }
     }
 }
 
-/// Combine an optional `ok` variable with rendered checks into a guard
-/// condition; returns `"true"` when both are absent.
+/// Combine an optional `ok` test with the rendered checks into a guard
+/// condition; `true` when both are absent.
 pub(crate) fn compose_refutable_condition(
-    ok_var: Option<&str>,
+    ok_test: Option<&GoExpression>,
     checks: &[Check],
     effective_subject: &str,
-) -> String {
+) -> GoExpression {
     let condition = render_condition(checks, SubjectRoot::Var(effective_subject));
-    match ok_var {
+    match ok_test {
         None => condition,
-        Some(ok) if condition == "true" => ok.to_string(),
-        Some(ok) => format!("{} && {}", ok, condition),
+        Some(ok) if checks.is_empty() => ok.clone(),
+        Some(ok) => GoExpression::binary(ok.clone(), "&&", condition),
     }
 }
 
@@ -120,10 +124,7 @@ pub(crate) fn tree_binding_statements(
             continue;
         };
 
-        let access_expression = binding
-            .path
-            .render(SubjectRoot::Var(subject_var))
-            .rendered();
+        let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
 
         if analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline {
             let composable = binding
@@ -157,10 +158,7 @@ pub(crate) fn tree_binding_statements(
                 fresh
             }
         };
-        statements.push(LoweredStatement::TempBind {
-            name,
-            value: access_expression,
-        });
+        statements.push(define(name, access_expression));
     }
 }
 
@@ -198,9 +196,6 @@ pub(crate) fn tree_assignment_statements(
         let name = registered_name.to_string();
         planner.scope.record_go_use(subject_var);
         let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
-        statements.push(simple_assign(
-            &name,
-            ValuePlan::computed(Vec::new(), access_expression, EvaluationEffect::Pure),
-        ));
+        statements.push(assign(GoExpression::name(name), access_expression));
     }
 }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -10,9 +10,12 @@ use syntax::program::DefinitionBody;
 use syntax::types::{Type, unqualified_name};
 
 use crate::Planner;
+use crate::control_flow::propagation::plain_return;
 use crate::names::packages::PackageRequirements;
 use crate::names::{generics, go_name};
 use crate::patterns::binding_decls::emit_pattern_literal;
+use crate::plan::bodies::{LoweredBlock, define_many};
+use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::GoExpression;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -197,77 +200,102 @@ enum CheckPolarity {
 }
 
 impl Check {
-    pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> String {
+    pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> GoExpression {
         self.render_with_polarity(subject, CheckPolarity::Positive)
     }
 
-    pub(crate) fn render_negated(&self, subject: SubjectRoot<'_>) -> String {
+    pub(crate) fn render_negated(&self, subject: SubjectRoot<'_>) -> GoExpression {
         self.render_with_polarity(subject, CheckPolarity::Negative)
     }
 
-    fn render_with_polarity(&self, subject: SubjectRoot<'_>, polarity: CheckPolarity) -> String {
+    fn render_with_polarity(
+        &self,
+        subject: SubjectRoot<'_>,
+        polarity: CheckPolarity,
+    ) -> GoExpression {
         let negative = matches!(polarity, CheckPolarity::Negative);
+        let length_of = |path: &AccessPath| {
+            GoExpression::call(
+                GoExpression::name("len".to_string()),
+                vec![path.render(subject)],
+            )
+        };
         match self {
             Check::EnumTag { path, tag_constant } => {
-                let rendered_path = path.render(subject).rendered();
                 let operator = if negative { "!=" } else { "==" };
-                format!("{rendered_path}.Tag {operator} {tag_constant}")
+                GoExpression::binary(
+                    GoExpression::selector(path.render(subject), "Tag".to_string()),
+                    operator,
+                    GoExpression::name(tag_constant.clone()),
+                )
             }
             Check::Literal { path, go_literal } => {
-                let rendered_path = path.render(subject).rendered();
+                let rendered_path = path.render(subject);
                 match (go_literal.as_str(), negative) {
                     ("true", false) | ("false", true) => rendered_path,
-                    ("true", true) | ("false", false) => format!("!{rendered_path}"),
-                    (_, false) => format!("{rendered_path} == {go_literal}"),
-                    (_, true) => format!("{rendered_path} != {go_literal}"),
+                    ("true", true) | ("false", false) => GoExpression::unary("!", rendered_path),
+                    (_, false) => {
+                        GoExpression::binary(rendered_path, "==", label_expression(go_literal))
+                    }
+                    (_, true) => {
+                        GoExpression::binary(rendered_path, "!=", label_expression(go_literal))
+                    }
                 }
             }
             Check::SliceLenEq { path, length } => {
-                let rendered_path = path.render(subject).rendered();
                 let operator = if negative { "!=" } else { "==" };
-                format!("len({rendered_path}) {operator} {length}")
+                GoExpression::binary(
+                    length_of(path),
+                    operator,
+                    GoExpression::literal(length.to_string()),
+                )
             }
             Check::SliceLenGe { path, min_length } => {
-                let rendered_path = path.render(subject).rendered();
                 let operator = if negative { "<" } else { ">=" };
-                format!("len({rendered_path}) {operator} {min_length}")
+                GoExpression::binary(
+                    length_of(path),
+                    operator,
+                    GoExpression::literal(min_length.to_string()),
+                )
             }
             Check::Or { alternatives } if !negative => {
-                let alt_strs: Vec<String> = alternatives
+                let alternative_count = alternatives.len();
+                let joined = alternatives
                     .iter()
                     .map(|checks| {
                         if checks.len() == 1 {
                             checks[0].render(subject)
                         } else {
-                            format!(
-                                "({})",
-                                checks
-                                    .iter()
-                                    .map(|c| c.render(subject))
-                                    .collect::<Vec<_>>()
-                                    .join(" && ")
-                            )
+                            GoExpression::parenthesized(join_conditions(checks, subject))
                         }
                     })
-                    .collect();
-                let joined = alt_strs.join(" || ");
-                if alt_strs.len() > 1 {
-                    format!("({})", joined)
+                    .reduce(|left, right| GoExpression::binary(left, "||", right))
+                    .expect("an or-check has at least one alternative");
+                if alternative_count > 1 {
+                    GoExpression::parenthesized(joined)
                 } else {
                     joined
                 }
             }
-            Check::TypeAssert { path, go_type } if !negative => format!(
-                "func() bool {{ _, ok := {}.({}); return ok }}()",
-                path.render(subject).rendered(),
-                go_type,
+            Check::TypeAssert { path, go_type } if !negative => GoExpression::immediate_call(
+                "bool".to_string(),
+                LoweredBlock {
+                    statements: vec![
+                        define_many(
+                            vec!["_".to_string(), "ok".to_string()],
+                            GoExpression::type_assertion(path.render(subject), go_type.clone()),
+                        ),
+                        plain_return(GoExpression::name("ok".to_string())),
+                    ],
+                },
+                FunctionLiteralLayout::Inline,
             ),
-            Check::Or { .. } | Check::TypeAssert { .. } => {
-                format!(
-                    "!({})",
-                    self.render_with_polarity(subject, CheckPolarity::Positive)
-                )
-            }
+            Check::Or { .. } | Check::TypeAssert { .. } => GoExpression::unary(
+                "!",
+                GoExpression::parenthesized(
+                    self.render_with_polarity(subject, CheckPolarity::Positive),
+                ),
+            ),
         }
     }
 
@@ -1698,12 +1726,33 @@ fn extract_root_assertion(checks: &mut Vec<Check>) -> Option<TypeAssertion> {
     }
 }
 
-pub(super) fn render_condition(checks: &[Check], subject_var: SubjectRoot<'_>) -> String {
+pub(super) fn render_condition(checks: &[Check], subject_var: SubjectRoot<'_>) -> GoExpression {
     if checks.is_empty() {
-        return "true".to_string();
+        return GoExpression::literal("true".to_string());
     }
+    join_conditions(checks, subject_var)
+}
 
-    let conditions: Vec<String> = checks.iter().map(|c| c.render(subject_var)).collect();
+fn join_conditions(checks: &[Check], subject: SubjectRoot<'_>) -> GoExpression {
+    checks
+        .iter()
+        .map(|check| check.render(subject))
+        .reduce(|left, right| GoExpression::binary(left, "&&", right))
+        .expect("join_conditions requires at least one check")
+}
 
-    conditions.join(" && ")
+pub(crate) fn label_expression(label: &str) -> GoExpression {
+    let is_name = label
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_alphabetic() || first == '_')
+        && label
+            .chars()
+            .all(|character| character.is_alphanumeric() || character == '_' || character == '.')
+        && !matches!(label, "true" | "false" | "nil");
+    if is_name {
+        GoExpression::name(label.to_string())
+    } else {
+        GoExpression::literal(label.to_string())
+    }
 }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -3,8 +3,8 @@ use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
 use crate::calls::NativeMethodCall;
 use crate::calls::bounds::BoundsCheckedIndex;
 use crate::calls::comma_ok::CommaOkSource;
-use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairKind, header_call};
-use crate::calls::go_interop::NilGuard;
+use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairCondition, PairKind, header_call};
+use crate::calls::go_interop::{NilGuard, is_nil, non_nil, unexpected_nil_error};
 use crate::calls::slice_loop::FoundSink;
 use crate::calls::wrap_err::WrapMessage;
 use crate::context::expression::ExpressionContext;
@@ -12,7 +12,10 @@ use crate::names::go_name::is_plain_identifier;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::decision_tree;
 use crate::patterns::tree_emitter::{MatchSubject, TreePlanner};
-use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
+use crate::plan::bodies::{
+    Definition, ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan, assign, define,
+    discard, expression_statement,
+};
 use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
 use crate::state::scope::PairStatusKind;
@@ -56,7 +59,7 @@ enum BoundSource {
     Nullable {
         value: String,
         nil_guard: NilGuard,
-        initializer_call: Option<String>,
+        initializer_call: Option<GoExpression>,
     },
     Index {
         index: BoundsCheckedIndex,
@@ -70,11 +73,20 @@ enum BoundSource {
 
 impl BoundOption {
     /// The payload expression, valid once the some-condition holds.
-    pub(crate) fn value(&self) -> Option<&str> {
+    pub(crate) fn value(&self) -> Option<GoExpression> {
+        match &self.source {
+            BoundSource::Index { index, .. } => Some(index.element.clone()),
+            _ => self
+                .value_name()
+                .map(|name| GoExpression::name(name.to_string())),
+        }
+    }
+
+    pub(crate) fn value_name(&self) -> Option<&str> {
         match &self.source {
             BoundSource::Pair(pair) => pair.value.as_deref(),
             BoundSource::Nullable { value, .. } => Some(value),
-            BoundSource::Index { index, .. } => Some(&index.element),
+            BoundSource::Index { .. } => None,
             BoundSource::Found { value, .. } => value.as_deref(),
         }
     }
@@ -92,10 +104,7 @@ impl BoundOption {
         else {
             return None;
         };
-        Some(LoweredStatement::TempBind {
-            name: target.clone(),
-            value: index.element.clone(),
-        })
+        Some(define(target.clone(), index.element.clone()))
     }
 
     pub(super) fn discard_value(&mut self) {
@@ -105,21 +114,25 @@ impl BoundOption {
                 value: Some(value), ..
             } => {
                 self.statements
-                    .push(LoweredStatement::RawGo(format!("_ = {value}\n")));
+                    .push(discard(GoExpression::name(value.clone())));
             }
             _ => {}
         }
     }
 
-    pub(crate) fn some_condition(&self, planner: &mut Planner<'_>) -> String {
+    pub(crate) fn some_condition(&self, planner: &mut Planner<'_>) -> PairCondition {
         self.condition(planner, true)
     }
 
-    pub(crate) fn none_condition(&self, planner: &mut Planner<'_>) -> String {
+    pub(crate) fn none_condition(&self, planner: &mut Planner<'_>) -> PairCondition {
         self.condition(planner, false)
     }
 
-    fn condition(&self, planner: &mut Planner<'_>, success: bool) -> String {
+    fn condition(&self, planner: &mut Planner<'_>, success: bool) -> PairCondition {
+        let plain = |condition: GoExpression| PairCondition {
+            initializer: None,
+            condition,
+        };
         match &self.source {
             BoundSource::Pair(pair) if success => planner.pair_success_condition(pair),
             BoundSource::Pair(pair) => planner.pair_failure_condition(pair),
@@ -131,20 +144,26 @@ impl BoundOption {
                 if nil_guard.is_interface() {
                     planner.require_stdlib();
                 }
+                let tested = GoExpression::name(value.clone());
                 let test = if success {
-                    nil_guard.non_nil(value)
+                    nil_guard.non_nil(tested)
                 } else {
-                    nil_guard.is_nil(value)
+                    nil_guard.is_nil(tested)
                 };
-                match initializer_call {
-                    Some(call) => format!("{value} := {}; {test}", header_call(call)),
-                    None => test,
+                PairCondition {
+                    initializer: initializer_call.as_ref().map(|call| Definition {
+                        names: vec![value.clone()],
+                        value: header_call(call.clone()),
+                    }),
+                    condition: test,
                 }
             }
-            BoundSource::Index { index, .. } if success => index.in_bounds.clone(),
-            BoundSource::Index { index, .. } => index.out_of_bounds.clone(),
-            BoundSource::Found { flag, .. } if success => flag.clone(),
-            BoundSource::Found { flag, .. } => format!("!{flag}"),
+            BoundSource::Index { index, .. } if success => plain(index.in_bounds.clone()),
+            BoundSource::Index { index, .. } => plain(index.out_of_bounds.clone()),
+            BoundSource::Found { flag, .. } if success => plain(GoExpression::name(flag.clone())),
+            BoundSource::Found { flag, .. } => {
+                plain(GoExpression::unary("!", GoExpression::name(flag.clone())))
+            }
         }
     }
 }
@@ -174,10 +193,7 @@ impl OptionFusePlan<'_> {
                 let initializer_call = if opens_if {
                     Some(call)
                 } else {
-                    statements.push(LoweredStatement::TempBind {
-                        name: value.clone(),
-                        value: call,
-                    });
+                    statements.push(define(value.clone(), call));
                     None
                 };
                 BoundOption {
@@ -289,8 +305,14 @@ impl ResultFusePlan<'_> {
 
 #[derive(Clone, Copy)]
 pub(super) enum ArmBinding<'a> {
-    Alias { name: &'a str, go_name: &'a str },
-    Copy { name: &'a str, value: &'a str },
+    Alias {
+        name: &'a str,
+        go_name: &'a str,
+    },
+    Copy {
+        name: &'a str,
+        value: &'a GoExpression,
+    },
 }
 
 impl<'a> ArmBinding<'a> {
@@ -299,13 +321,15 @@ impl<'a> ArmBinding<'a> {
             .map(|(name, go_name)| Self::Alias { name, go_name })
     }
 
-    pub(super) fn copy(name: Option<&'a str>, value: Option<&'a str>) -> Option<Self> {
+    pub(super) fn copy(name: Option<&'a str>, value: Option<&'a GoExpression>) -> Option<Self> {
         name.zip(value)
             .map(|(name, value)| Self::Copy { name, value })
     }
 }
 
-const UNIT_VALUE: &str = "struct{}{}";
+fn unit_value() -> GoExpression {
+    GoExpression::empty_composite("struct{}".to_string())
+}
 
 struct ResultArm<'a> {
     arm: &'a MatchArm,
@@ -336,7 +360,7 @@ enum SubjectDeclaration {
     /// Composite path: `<var> := <expression>` if used, `_ = <expression>` if not.
     Deferred {
         var: String,
-        expression: String,
+        expression: GoExpression,
     },
     None,
 }
@@ -397,17 +421,14 @@ impl Planner<'_> {
         match declaration {
             SubjectDeclaration::PlainDiscard { var } => {
                 if !used {
-                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", var)));
+                    statements.push(discard(GoExpression::name(var)));
                 }
             }
             SubjectDeclaration::Deferred { var, expression } => {
                 if used {
-                    statements.push(LoweredStatement::RawGo(format!(
-                        "{} := {}\n",
-                        var, expression
-                    )));
+                    statements.push(define(var, expression));
                 } else {
-                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", expression)));
+                    statements.push(discard(expression));
                 }
             }
             SubjectDeclaration::None => {}
@@ -464,12 +485,11 @@ impl Planner<'_> {
 
         let mut names = Vec::with_capacity(elements.len());
         for ((value, tested), element) in sequenced.values.iter().zip(&tested).zip(elements) {
-            let rendered = value.rendered();
             // An untested element still runs, but nothing may name it.
             if !tested && !is_inert_value(element, value) {
-                statements.push(LoweredStatement::RawGo(format!("_ = {}\n", rendered)));
+                statements.push(discard(value.clone()));
             }
-            names.push(rendered);
+            names.push(value.rendered());
         }
 
         let block = self.lower_match_tree(arms, MatchSubject::Elements(names), subject_ty, place);
@@ -630,12 +650,11 @@ impl Planner<'_> {
         let fail_body = self.lower_block_as_body(arms.none_body);
         let late_binding = bound.late_binding();
         let mut statements = bound.statements;
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: none_condition,
-            then_body: fail_body,
-            else_arm: ElseArm::None,
-        }));
+        statements.push(LoweredStatement::If(pair_if(
+            none_condition,
+            fail_body,
+            ElseArm::None,
+        )));
         statements.extend(late_binding);
         Some(statements)
     }
@@ -705,10 +724,10 @@ impl Planner<'_> {
             && arm_body_is_noop(&err.arm.expression)
         {
             // Nothing reads the outcome, so keep the call and drop the test.
-            let (mut statements, call_str) = self
+            let (mut statements, call) = self
                 .lower_call(subject, None, ExpressionContext::value())
                 .into_parts();
-            statements.push(LoweredStatement::RawGo(format!("{call_str}\n")));
+            statements.push(expression_statement(call));
             return Some(statements);
         }
 
@@ -720,14 +739,15 @@ impl Planner<'_> {
             (None, None) => CommaOkValueSlot::Unused,
         };
         let (mut bound, wraps) = fuse.bind_wrapped(self, slot, err_name, err_name.is_some());
-        let error = bound.status().to_string();
+        let error = || GoExpression::name(bound.status().to_string());
 
+        let unit = unit_value();
         let then_body = destination.is_none().then(|| {
             // A call returning only `error` has no value, so `Ok(x)` takes unit.
             let ok_binding = if carries_payload {
                 ArmBinding::alias(ok_name, bound.value.as_deref())
             } else {
-                ArmBinding::copy(ok_name, Some(UNIT_VALUE))
+                ArmBinding::copy(ok_name, Some(&unit))
             };
             let (body, uses) = self.lower_fused_arm(&[ok_binding], &ok.arm.expression, place);
             (body, uses.first().copied().unwrap_or(false))
@@ -744,17 +764,20 @@ impl Planner<'_> {
         let err_read = err_used.first().copied().unwrap_or(false) || !wraps.is_empty();
         if has_nil_guard && err_read {
             self.require_errors();
-            let error = bound.status();
             else_body.statements.insert(
                 0,
-                LoweredStatement::RawGo(format!(
-                    "if {error} == nil {{\n{error} = errors.New(\"unexpected nil\")\n}}\n"
+                LoweredStatement::If(IfPlan::plain(
+                    is_nil(error()),
+                    LoweredBlock {
+                        statements: vec![assign(error(), unexpected_nil_error())],
+                    },
+                    ElseArm::None,
                 )),
             );
         }
         if !wraps.is_empty() {
-            let wrapped = self.wrap_error(&wraps, error.clone());
-            let prologue = vec![LoweredStatement::RawGo(format!("{error} = {wrapped}\n"))];
+            let wrapped = self.wrap_error(&wraps, error());
+            let prologue = vec![assign(error(), wrapped)];
             let after_nil_guard = usize::from(has_nil_guard);
             else_body
                 .statements
@@ -769,29 +792,22 @@ impl Planner<'_> {
         let mut statements = bound.statements;
 
         let Some(then_body) = then_body else {
-            statements.push(LoweredStatement::If(IfPlan {
-                condition_setup: Vec::new(),
-                condition: err_condition,
-                then_body: else_body,
-                else_arm: ElseArm::None,
-            }));
+            statements.push(LoweredStatement::If(pair_if(
+                err_condition,
+                else_body,
+                ElseArm::None,
+            )));
             return Some(statements);
         };
 
         let plan = if then_body.renders_empty() && !else_body.renders_empty() {
-            IfPlan {
-                condition_setup: Vec::new(),
-                condition: err_condition,
-                then_body: else_body,
-                else_arm: ElseArm::None,
-            }
+            pair_if(err_condition, else_body, ElseArm::None)
         } else {
-            IfPlan {
-                condition_setup: Vec::new(),
-                condition: ok_condition,
+            pair_if(
+                ok_condition,
                 then_body,
-                else_arm: ElseArm::from_body(else_body, false),
-            }
+                ElseArm::from_body(else_body, false),
+            )
         };
         statements.push(LoweredStatement::If(plan));
         Some(statements)
@@ -835,7 +851,7 @@ impl Planner<'_> {
         let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
         let nilable = self.partial_ok_is_nilable(&ok_ty);
 
-        let (mut statements, call_str) = self
+        let (mut statements, call) = self
             .lower_call(subject, None, ExpressionContext::value())
             .into_parts();
         let val_var = match ok_name.or(both_val) {
@@ -846,6 +862,7 @@ impl Planner<'_> {
         if val_var.as_deref() == Some(err_var.as_str()) {
             err_var = self.fresh_var(Some(&err_var));
         }
+        let err = || GoExpression::name(err_var.clone());
 
         let (ok_body, ok_uses) = self.lower_fused_arm(
             &[ArmBinding::alias(ok_name, val_var.as_deref())],
@@ -861,15 +878,18 @@ impl Planner<'_> {
             place,
         );
         let val_used = nilable || ok_uses[0] || both_uses[0];
-        let header = match val_var.as_deref().filter(|_| val_used) {
-            Some(v) => format!("{}, {} := {}", v, err_var, header_call(&call_str)),
-            None => format!("_, {} := {}", err_var, header_call(&call_str)),
+        let bound_value = match val_var.as_deref().filter(|_| val_used) {
+            Some(v) => v.to_string(),
+            None => "_".to_string(),
         };
-        let condition = format!("{header}; {} == nil", err_var);
+        let initializer = Definition {
+            names: vec![bound_value, err_var.clone()],
+            value: header_call(call),
+        };
 
         let nil_check = val_var
             .as_deref()
-            .and_then(|v| self.partial_ok_nil_check(&ok_ty, v));
+            .and_then(|v| self.partial_ok_nil_check(&ok_ty, GoExpression::name(v.to_string())));
 
         let else_arm = match nil_check {
             Some(check) => {
@@ -878,19 +898,19 @@ impl Planner<'_> {
                     &err_arm.expression,
                     place,
                 );
-                ElseArm::ElseIf(Box::new(IfPlan {
-                    condition_setup: Vec::new(),
-                    condition: check,
-                    then_body: err_body,
-                    else_arm: ElseArm::from_body(both_body, false),
-                }))
+                ElseArm::ElseIf(Box::new(IfPlan::plain(
+                    check,
+                    err_body,
+                    ElseArm::from_body(both_body, false),
+                )))
             }
             None => ElseArm::from_body(both_body, false),
         };
 
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition,
+            initializer: Some(initializer),
+            condition: is_nil(err()),
             then_body: ok_body,
             else_arm,
         }));
@@ -928,7 +948,7 @@ impl Planner<'_> {
         // A non-nilable value is always present, so its physical ABI has no
         // distinct Err state. The wildcard arm is therefore unconditional.
         if matches!(arms.variant, PartialVariant::Err) && nil_guard.is_none() {
-            statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+            statements.push(expression_statement(call));
             let fallback = self
                 .lower_fused_arm(&[], &arms.fallback.expression, place)
                 .0;
@@ -959,42 +979,46 @@ impl Planner<'_> {
             .0;
 
         if selected.renders_empty() && fallback.renders_empty() {
-            statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+            statements.push(expression_statement(call));
             return Some(statements);
         }
 
         let value_is_used = binding_uses.first().copied().unwrap_or(false);
         let value_slot = (condition_needs_value || value_is_used)
             .then(|| value.as_deref().expect("value use allocates a result slot"));
-        let result_slots = match value_slot {
-            Some(value) => format!("{value}, {error}"),
-            None => format!("_, {error}"),
+        let bound_value = match value_slot {
+            Some(value) => value.to_string(),
+            None => "_".to_string(),
         };
+        let err = || GoExpression::name(error.clone());
+        let guarded_value =
+            || GoExpression::name(value.clone().expect("nil guard captures the value"));
         let condition = match arms.variant {
-            PartialVariant::Ok => format!("{error} == nil"),
+            PartialVariant::Ok => is_nil(err()),
             PartialVariant::Both => match nil_guard {
                 Some(guard) => {
                     if guard.is_interface() {
                         self.require_stdlib();
                     }
-                    let value = value.as_deref().expect("nil guard captures the value");
-                    format!("{error} != nil && {}", guard.non_nil(value))
+                    GoExpression::binary(non_nil(err()), "&&", guard.non_nil(guarded_value()))
                 }
-                None => format!("{error} != nil"),
+                None => non_nil(err()),
             },
             PartialVariant::Err => {
                 let guard = nil_guard.expect("non-nilable Err returned above");
                 if guard.is_interface() {
                     self.require_stdlib();
                 }
-                let value = value.as_deref().expect("nil guard captures the value");
-                format!("{error} != nil && {}", guard.is_nil(value))
+                GoExpression::binary(non_nil(err()), "&&", guard.is_nil(guarded_value()))
             }
         };
-        let condition = format!("{result_slots} := {}; {condition}", header_call(&call));
         let selected_diverges = selected.ends_with_diverge();
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
+            initializer: Some(Definition {
+                names: vec![bound_value, error.clone()],
+                value: header_call(call),
+            }),
             condition,
             then_body: selected,
             else_arm: ElseArm::from_body(fallback, selected_diverges),
@@ -1027,10 +1051,11 @@ impl Planner<'_> {
         };
         let mut bound = fuse.bind(self, slot);
 
+        let element = bound.value();
         let some_binding = if bound.binds_value() {
-            ArmBinding::alias(arms.some_binding, bound.value())
+            ArmBinding::alias(arms.some_binding, bound.value_name())
         } else {
-            ArmBinding::copy(arms.some_binding, bound.value())
+            ArmBinding::copy(arms.some_binding, element.as_ref())
         };
         let (then_body, some_uses) = self.lower_fused_arm(&[some_binding], arms.some_body, place);
         let (else_body, _) = self.lower_fused_arm(&[], arms.none_body, place);
@@ -1045,19 +1070,9 @@ impl Planner<'_> {
             bound.some_condition(self)
         };
         let plan = if invert {
-            IfPlan {
-                condition_setup: Vec::new(),
-                condition,
-                then_body: else_body,
-                else_arm: ElseArm::None,
-            }
+            pair_if(condition, else_body, ElseArm::None)
         } else {
-            IfPlan {
-                condition_setup: Vec::new(),
-                condition,
-                then_body,
-                else_arm: ElseArm::from_body(else_body, false),
-            }
+            pair_if(condition, then_body, ElseArm::from_body(else_body, false))
         };
         let mut statements = bound.statements;
         statements.push(LoweredStatement::If(plan));
@@ -1071,7 +1086,7 @@ impl Planner<'_> {
         place: &PlacePlan,
     ) -> (LoweredBlock, Vec<bool>) {
         self.with_binding_frame(|this| {
-            let bound: Vec<Option<(String, Option<String>)>> = bindings
+            let bound: Vec<Option<(String, Option<GoExpression>)>> = bindings
                 .iter()
                 .map(|binding| {
                     binding.map(|binding| match binding {
@@ -1081,7 +1096,7 @@ impl Planner<'_> {
                         ArmBinding::Copy { name, value } => {
                             let go_name = this.scope.bind(name, name);
                             this.declare(&go_name);
-                            (go_name, Some(value.to_string()))
+                            (go_name, Some(value.clone()))
                         }
                     })
                 })
@@ -1104,10 +1119,7 @@ impl Planner<'_> {
                 if !is_used {
                     continue;
                 }
-                statements.push(LoweredStatement::TempBind {
-                    name: go_name.clone(),
-                    value: value.clone(),
-                });
+                statements.push(define(go_name.clone(), value.clone()));
             }
             statements.extend(body_block.statements);
             (LoweredBlock { statements }, binding_uses)
@@ -1137,25 +1149,23 @@ impl Planner<'_> {
             let staged = self.plan_operand(subject, ExpressionContext::value());
             let (subject_setup, value) = staged.into_parts();
             setup.extend(subject_setup);
-            return (value, SubjectDeclaration::None);
+            return (value.rendered(), SubjectDeclaration::None);
         }
         let staged = self.lower_composite_value(subject, ExpressionContext::value());
         let rests_in_stable_name = self.plan_rests_in_stable_name(&staged);
         let (subject_setup, value) = staged.into_parts();
         setup.extend(subject_setup);
-        let reads_in_place = is_plain_identifier(&value)
-            || self.field_path_reads_in_place(subject, &value, |root| {
+        let reads_in_place = is_plain_identifier(value.as_str())
+            || self.field_path_reads_in_place(subject, value.as_str(), |root| {
                 arms.iter()
                     .any(|arm| pattern_binds_name(&arm.pattern, root))
             });
         if !any_guard && reads_in_place {
-            return (value, SubjectDeclaration::None);
+            return (value.rendered(), SubjectDeclaration::None);
         }
         if any_guard && rests_in_stable_name {
-            return (
-                value.clone(),
-                SubjectDeclaration::PlainDiscard { var: value },
-            );
+            let var = value.rendered();
+            return (var.clone(), SubjectDeclaration::PlainDiscard { var });
         }
         let var = self.fresh_var(Some("subject"));
         self.declare(&var);
@@ -1164,6 +1174,16 @@ impl Planner<'_> {
             expression: value,
         };
         (var, declaration)
+    }
+}
+
+fn pair_if(test: PairCondition, then_body: LoweredBlock, else_arm: ElseArm) -> IfPlan {
+    IfPlan {
+        condition_setup: Vec::new(),
+        initializer: test.initializer,
+        condition: test.condition,
+        then_body,
+        else_arm,
     }
 }
 

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -5,7 +5,7 @@ use syntax::ast::{Expression, MatchArm, Pattern, Span};
 use syntax::types::Type;
 
 use crate::Planner;
-use crate::calls::comma_ok::CommaOkValueSlot;
+use crate::calls::comma_ok::{CommaOkValueSlot, PairCondition};
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
 use crate::patterns::binding_decls::pattern_binds_name;
@@ -16,11 +16,13 @@ use crate::patterns::binding_emit::{
 use crate::patterns::decision_tree::{self, PatternInfo, SubjectRoot, render_condition};
 use crate::patterns::matching::{ArmBinding, field_binding, ok_pattern_field, some_pattern_field};
 use crate::plan::bodies::{
-    ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
+    ElseArm, IfPlan, LoopHeader, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan, define,
+    discard, expression_statement,
 };
+use crate::plan::go_expression::CompositeLayout;
+use crate::plan::values::GoExpression;
 use crate::state::bindings::BindingValue;
 use crate::utils::wrap_if_struct_literal;
-use crate::write_line;
 
 #[derive(Clone, Copy)]
 pub(crate) struct AnnotatedPattern<'a> {
@@ -69,11 +71,16 @@ impl<'a> PatternSubject<'a> {
     }
 }
 
-/// For composite scrutinees, the declaration line is deferred so the caller can
+/// For composite scrutinees, the declaration is deferred so the caller can
 /// pick `var := expr` vs `_ = expr` based on body usage.
 enum ResolvedSubject {
-    Existing { var: String },
-    Composite { var: String, expression: String },
+    Existing {
+        var: String,
+    },
+    Composite {
+        var: String,
+        expression: GoExpression,
+    },
 }
 
 impl ResolvedSubject {
@@ -83,12 +90,12 @@ impl ResolvedSubject {
         }
     }
 
-    fn emit_declaration(self, output: &mut String, references: bool) {
+    fn push_declaration(self, statements: &mut Vec<LoweredStatement>, references: bool) {
         if let ResolvedSubject::Composite { var, expression } = self {
             if references {
-                write_line!(output, "{} := {}", var, expression);
+                statements.push(define(var, expression));
             } else {
-                write_line!(output, "_ = {}", expression);
+                statements.push(discard(expression));
             }
         }
     }
@@ -97,7 +104,7 @@ impl ResolvedSubject {
 struct RefutableAlternative<'s> {
     info: PatternInfo,
     subject: Cow<'s, str>,
-    ok_var: Option<String>,
+    ok_test: Option<GoExpression>,
 }
 
 /// The identifier under a chain of field accesses.
@@ -120,6 +127,14 @@ fn is_field_path(rendered: &str) -> bool {
     segments.next().is_some_and(go_name::is_plain_identifier)
         && rendered.contains('.')
         && segments.all(go_name::is_plain_identifier)
+}
+
+fn loop_break(planner: &Planner) -> LoweredStatement {
+    LoweredStatement::Break(
+        planner
+            .current_loop_id()
+            .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
+    )
 }
 
 impl Planner<'_> {
@@ -168,11 +183,13 @@ impl Planner<'_> {
                 let (op_setup, expression) = plan.into_parts();
                 setup.extend(op_setup);
                 if rests_in_stable_name
-                    || self.field_path_reads_in_place(scrutinee, &expression, |root| {
+                    || self.field_path_reads_in_place(scrutinee, expression.as_str(), |root| {
                         pattern_binds_name(pattern, root)
                     })
                 {
-                    return ResolvedSubject::Existing { var: expression };
+                    return ResolvedSubject::Existing {
+                        var: expression.rendered(),
+                    };
                 }
                 let var = self.fresh_var(temp_hint);
                 self.declare(&var);
@@ -200,15 +217,10 @@ impl Planner<'_> {
             tree_binding_statements(this, &mut body, &info.bindings, &effective, &[]);
             body
         });
-        let body_block = LoweredBlock { statements: body };
 
         let references = used.contains(resolved.var());
-        let mut declaration = String::new();
-        resolved.emit_declaration(&mut declaration, references);
-        if !declaration.is_empty() {
-            statements.push(LoweredStatement::RawGo(declaration));
-        }
-        statements.extend(body_block.statements);
+        resolved.push_declaration(&mut statements, references);
+        statements.extend(body);
         statements
     }
 
@@ -281,15 +293,10 @@ impl Planner<'_> {
                 this.lower_let_else_single_pattern(ap, subject, fail, subject_is_fixed)
             }
         });
-        let body_block = LoweredBlock { statements: body };
 
         let references = used.contains(resolved.var());
-        let mut declaration = String::new();
-        resolved.emit_declaration(&mut declaration, references);
-        if !declaration.is_empty() {
-            statements.push(LoweredStatement::RawGo(declaration));
-        }
-        statements.extend(body_block.statements);
+        resolved.push_declaration(&mut statements, references);
+        statements.extend(body);
         statements
     }
 
@@ -344,7 +351,7 @@ impl Planner<'_> {
     fn finish_fused_let_else(
         &mut self,
         mut statements: Vec<LoweredStatement>,
-        fail_condition: String,
+        fail_condition: PairCondition,
         binding: Option<(String, String)>,
         else_block: &Expression,
     ) -> Vec<LoweredStatement> {
@@ -352,7 +359,8 @@ impl Planner<'_> {
         let fail_body = self.lower_block_as_body(else_block);
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: fail_condition,
+            initializer: fail_condition.initializer,
+            condition: fail_condition.condition,
             then_body: fail_body,
             else_arm: ElseArm::None,
         }));
@@ -390,16 +398,13 @@ impl Planner<'_> {
         }
         let staged = self.plan_operand(scrutinee, ExpressionContext::value());
         let (mut setup, value) = staged.into_parts();
-        if self
-            .field_path_reads_in_place(scrutinee, &value, |root| pattern_binds_name(pattern, root))
-        {
-            return (value, setup);
+        if self.field_path_reads_in_place(scrutinee, value.as_str(), |root| {
+            pattern_binds_name(pattern, root)
+        }) {
+            return (value.rendered(), setup);
         }
         let var = self.fresh_var(Some("subject"));
-        setup.push(LoweredStatement::TempBind {
-            name: var.clone(),
-            value,
-        });
+        setup.push(define(var.clone(), value));
         (var, setup)
     }
 
@@ -416,9 +421,8 @@ impl Planner<'_> {
         let scrutinee_ty = scrutinee.get_type();
         let (subject_var, subject_setup) = self.while_let_subject(pattern, scrutinee);
 
-        // Or-patterns with bindings render an `if/else if` chain that closes its
-        // own `for`, so they cannot wrap in a structured `Loop`; bridge them as
-        // one `RawGo`.
+        // Or-patterns with bindings lower to an `if/else if` chain whose
+        // terminal `else` breaks the loop.
         if let Pattern::Or { patterns, .. } = pattern
             && pattern_has_bindings(pattern)
         {
@@ -434,7 +438,7 @@ impl Planner<'_> {
             );
             let plan = self.build_source_loop(
                 Vec::new(),
-                "for {\n".to_string(),
+                LoopHeader::Infinite,
                 LoweredBlock {
                     statements: loop_body,
                 },
@@ -447,9 +451,9 @@ impl Planner<'_> {
         let info = decision_tree::collect_pattern_info(self, pattern, &scrutinee_ty);
         self.require_packages(&info.packages);
         let mut loop_body = subject_setup;
-        let (effective, ok_var) =
+        let (effective, ok_test) =
             apply_refutable_root_assertion(self, &mut loop_body, &info, &subject_var);
-        let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
+        let condition = compose_refutable_condition(ok_test.as_ref(), &info.checks, &effective);
 
         let then_body = self.with_scope(|this| {
             let mut then_body: Vec<LoweredStatement> = Vec::new();
@@ -460,26 +464,22 @@ impl Planner<'_> {
             then_body
         });
 
-        loop_body.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
+        loop_body.push(LoweredStatement::If(IfPlan::plain(
             condition,
-            then_body: LoweredBlock {
+            LoweredBlock {
                 statements: then_body,
             },
-            else_arm: ElseArm::from_body(
+            ElseArm::from_body(
                 LoweredBlock {
-                    statements: vec![LoweredStatement::Break(
-                        self.current_loop_id()
-                            .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
-                    )],
+                    statements: vec![loop_break(self)],
                 },
                 false,
             ),
-        }));
+        )));
 
         let plan = self.build_source_loop(
             Vec::new(),
-            "for {\n".to_string(),
+            LoopHeader::Infinite,
             LoweredBlock {
                 statements: loop_body,
             },
@@ -508,22 +508,20 @@ impl Planner<'_> {
         };
         let bound = fuse.bind(self, slot);
         let none_condition = bound.none_condition(self);
-        let value = bound.value().map(str::to_string);
+        let value = bound.value();
 
         let mut loop_body = bound.statements;
         loop_body.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: none_condition,
+            initializer: none_condition.initializer,
+            condition: none_condition.condition,
             then_body: LoweredBlock {
-                statements: vec![LoweredStatement::Break(
-                    self.current_loop_id()
-                        .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
-                )],
+                statements: vec![loop_break(self)],
             },
             else_arm: ElseArm::None,
         }));
         let (body_block, _) = self.lower_fused_arm(
-            &[ArmBinding::copy(binding, value.as_deref())],
+            &[ArmBinding::copy(binding, value.as_ref())],
             body,
             &PlacePlan::Statement,
         );
@@ -531,7 +529,7 @@ impl Planner<'_> {
 
         let plan = self.build_source_loop(
             Vec::new(),
-            "for {\n".to_string(),
+            LoopHeader::Infinite,
             LoweredBlock {
                 statements: loop_body,
             },
@@ -553,16 +551,32 @@ impl Planner<'_> {
                 let testkit = testkit_qualifier();
                 let prelude = prelude_qualifier();
                 self.scope.record_go_use(subject_var);
-                let (file, lo, hi) = (
-                    span.file_id,
-                    span.byte_offset,
-                    span.byte_offset + span.byte_length,
+                let literal = |text: String| GoExpression::literal(text);
+                let operand = GoExpression::composite(
+                    Some(format!("{testkit}.Operand")),
+                    vec![(
+                        Some("Value".to_string()),
+                        GoExpression::call(
+                            GoExpression::name(format!("{prelude}.Debug")),
+                            vec![GoExpression::name(subject_var.to_string())],
+                        ),
+                    )],
+                    CompositeLayout::Inline { padded: false },
+                    false,
                 );
-                let call = format!(
-                    "{handle}.FailAssert({file}, {lo}, {hi}, \"let_assert\", \"pattern did not match\", {testkit}.Operand{{Value: {prelude}.Debug({subject_var})}})\n"
+                let call = GoExpression::call(
+                    GoExpression::name(format!("{handle}.FailAssert")),
+                    vec![
+                        literal(span.file_id.to_string()),
+                        literal(span.byte_offset.to_string()),
+                        literal((span.byte_offset + span.byte_length).to_string()),
+                        literal("\"let_assert\"".to_string()),
+                        literal("\"pattern did not match\"".to_string()),
+                        operand,
+                    ],
                 );
                 LoweredBlock {
-                    statements: vec![LoweredStatement::RawGo(call)],
+                    statements: vec![expression_statement(call)],
                 }
             }
         }
@@ -584,16 +598,18 @@ impl Planner<'_> {
         self.require_packages(&info.packages);
 
         let mut statements = Vec::new();
-        let (effective_subject, assert_ok_var) =
+        let (effective_subject, assert_ok) =
             apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
         if subject_is_fixed {
             info.checks.retain(|check| {
-                !self.is_condition_established(&check.render(SubjectRoot::Var(&effective_subject)))
+                !self.is_condition_established(
+                    check.render(SubjectRoot::Var(&effective_subject)).as_str(),
+                )
             });
         }
 
-        if info.checks.is_empty() && assert_ok_var.is_none() {
+        if info.checks.is_empty() && assert_ok.is_none() {
             tree_binding_statements(
                 self,
                 &mut statements,
@@ -604,29 +620,34 @@ impl Planner<'_> {
             return statements;
         }
 
-        let mut guard_parts: Vec<String> = Vec::new();
-        if let Some(ref ok) = assert_ok_var {
-            guard_parts.push(format!("!{}", ok));
+        let mut guard_parts: Vec<GoExpression> = Vec::new();
+        if let Some(ok) = assert_ok {
+            guard_parts.push(GoExpression::unary("!", ok));
         }
         if !info.checks.is_empty() {
             self.scope.record_go_use(effective_subject.as_ref());
             let negated = match info.checks.as_slice() {
                 [check] => check.render_negated(SubjectRoot::Var(&effective_subject)),
-                _ => format!(
-                    "!({})",
-                    render_condition(&info.checks, SubjectRoot::Var(&effective_subject))
+                _ => GoExpression::unary(
+                    "!",
+                    GoExpression::parenthesized(render_condition(
+                        &info.checks,
+                        SubjectRoot::Var(&effective_subject),
+                    )),
                 ),
             };
             guard_parts.push(wrap_if_struct_literal(negated));
         }
-        let guard = guard_parts.join(" || ");
+        let guard = guard_parts
+            .into_iter()
+            .reduce(|left, right| GoExpression::binary(left, "||", right))
+            .expect("a refutable pattern has a check or a type assertion");
         let fail_body = self.lower_refutable_fail(fail, subject_var);
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition: guard,
-            then_body: fail_body,
-            else_arm: ElseArm::None,
-        }));
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            guard,
+            fail_body,
+            ElseArm::None,
+        )));
 
         tree_binding_statements(
             self,
@@ -670,14 +691,14 @@ impl Planner<'_> {
             let RefutableAlternative {
                 info,
                 subject,
-                ok_var,
+                ok_test,
             } = alternative;
             let mut assigns = Vec::new();
             tree_assignment_statements(self, &mut assigns, &info.bindings, &subject);
             let body = LoweredBlock {
                 statements: assigns,
             };
-            if info.checks.is_empty() && ok_var.is_none() {
+            if info.checks.is_empty() && ok_test.is_none() {
                 if pieces.is_empty() {
                     statements.extend(body.statements);
                 } else {
@@ -688,7 +709,7 @@ impl Planner<'_> {
             if !info.checks.is_empty() {
                 self.scope.record_go_use(&subject);
             }
-            let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &subject);
+            let condition = compose_refutable_condition(ok_test.as_ref(), &info.checks, &subject);
             pieces.push((condition, body));
         }
         statements.push(assemble_if_else_chain(
@@ -708,12 +729,12 @@ impl Planner<'_> {
             .into_iter()
             .map(|info| {
                 self.require_packages(&info.packages);
-                let (subject, ok_var) =
+                let (subject, ok_test) =
                     apply_refutable_root_assertion(self, statements, &info, subject);
                 RefutableAlternative {
                     info,
                     subject,
-                    ok_var,
+                    ok_test,
                 }
             })
             .collect()
@@ -758,10 +779,9 @@ impl Planner<'_> {
             let RefutableAlternative {
                 info,
                 subject: effective,
-                ok_var,
+                ok_test,
             } = alternative;
-            let condition =
-                compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
+            let condition = compose_refutable_condition(ok_test.as_ref(), &info.checks, &effective);
 
             let branch = self.with_scope(|this| {
                 let mut branch = Vec::new();
@@ -782,10 +802,7 @@ impl Planner<'_> {
         }
 
         let terminal = LoweredBlock {
-            statements: vec![LoweredStatement::Break(
-                self.current_loop_id()
-                    .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
-            )],
+            statements: vec![loop_break(self)],
         };
         statements.push(assemble_if_else_chain(pieces, terminal));
     }
@@ -835,10 +852,10 @@ impl Planner<'_> {
         let info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
         self.require_packages(&info.packages);
         let mut statements = Vec::new();
-        let (effective, ok_var) =
+        let (effective, ok_test) =
             apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
-        if info.checks.is_empty() && ok_var.is_none() {
+        if info.checks.is_empty() && ok_test.is_none() {
             with_tree_bindings(
                 self,
                 &mut statements,
@@ -856,7 +873,7 @@ impl Planner<'_> {
         if !info.checks.is_empty() {
             self.scope.record_go_use(effective.as_ref());
         }
-        let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
+        let condition = compose_refutable_condition(ok_test.as_ref(), &info.checks, &effective);
         let mut then_body = Vec::new();
         with_tree_bindings(
             self,
@@ -873,14 +890,13 @@ impl Planner<'_> {
             Some(body) => ElseArm::from_body(body, false),
             None => ElseArm::None,
         };
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
+        statements.push(LoweredStatement::If(IfPlan::plain(
             condition,
-            then_body: LoweredBlock {
+            LoweredBlock {
                 statements: then_body,
             },
             else_arm,
-        }));
+        )));
         statements
     }
 }
@@ -955,24 +971,14 @@ impl Planner<'_> {
 /// nested if/else-if statement, built from the back. `pieces` must be
 /// non-empty.
 fn assemble_if_else_chain(
-    mut pieces: Vec<(String, LoweredBlock)>,
+    mut pieces: Vec<(GoExpression, LoweredBlock)>,
     terminal: LoweredBlock,
 ) -> LoweredStatement {
     let mut else_arm = ElseArm::from_body(terminal, false);
     while pieces.len() > 1 {
         let (condition, then_body) = pieces.pop().expect("len > 1");
-        else_arm = ElseArm::ElseIf(Box::new(IfPlan {
-            condition_setup: Vec::new(),
-            condition,
-            then_body,
-            else_arm,
-        }));
+        else_arm = ElseArm::ElseIf(Box::new(IfPlan::plain(condition, then_body, else_arm)));
     }
     let (condition, then_body) = pieces.pop().expect("pieces is non-empty");
-    LoweredStatement::If(IfPlan {
-        condition_setup: Vec::new(),
-        condition,
-        then_body,
-        else_arm,
-    })
+    LoweredStatement::If(IfPlan::plain(condition, then_body, else_arm))
 }

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -9,18 +9,20 @@ use crate::patterns::binding_emit::tree_binding_statements;
 use crate::patterns::decision_tree::{
     ChainTest, Decision, PatternBinding, SubjectRoot, SwitchBranch,
     SwitchKind as PatternSwitchKind, SwitchShape, compile_expanded_arms, decision_is_exhaustive,
-    expand_or_patterns, render_condition, tree_has_unguarded_terminal,
+    expand_or_patterns, label_expression, render_condition, tree_has_unguarded_terminal,
 };
 use crate::plan::bodies::{
-    ElseArm, IfPlan, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
-    SwitchCasePlan, SwitchKind, SwitchStatementPlan,
+    ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
+    PlacePlan, SwitchCasePlan, SwitchKind, SwitchStatementPlan,
 };
 use crate::plan::placement::unreachable_panic_if_needed;
+use crate::plan::values::GoExpression;
 use crate::state::bindings::InlineExpr;
+use crate::types::go_type::split_top_level_type_list;
 use crate::utils::wrap_if_struct_literal;
 
 struct FlatCase<'d> {
-    conditions: Vec<String>,
+    conditions: Vec<GoExpression>,
     bindings: &'d [PatternBinding],
     decision: &'d Decision,
 }
@@ -81,11 +83,18 @@ fn guard_renders_inline(guard: &Expression) -> bool {
     }
 }
 
+fn join_and(conditions: Vec<GoExpression>) -> GoExpression {
+    conditions
+        .into_iter()
+        .reduce(|left, right| GoExpression::binary(left, "&&", right))
+        .expect("join_and requires at least one condition")
+}
+
 #[derive(Clone, Copy)]
 struct ChainGroup<'a> {
     indices: &'a [usize],
     tests: &'a [ChainTest],
-    conditions: &'a [Option<String>],
+    conditions: &'a [Option<GoExpression>],
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -351,7 +360,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             if condition.is_some() {
                 self.record_subject_use();
             }
-            let condition = condition.as_deref().unwrap_or("true").to_string();
+            let condition = condition
+                .clone()
+                .unwrap_or_else(|| GoExpression::literal("true".to_string()));
             let walk_ctx = if matches!(test.decision, Decision::Guard { .. }) {
                 &guard_ctx
             } else {
@@ -438,7 +449,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
             kind: LoopKind::Generated { label: Some(label) },
-            header: "for {\n".to_string(),
+            header: LoopHeader::Infinite,
             body: LoweredBlock { statements: body },
         }));
     }
@@ -502,7 +513,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let cases = collected
             .into_iter()
             .map(|case| SwitchCasePlan {
-                labels: case.conditions.join(" && "),
+                labels: vec![join_and(case.conditions.clone())],
                 body: self.lower_flat_case_body(&case, place),
             })
             .collect::<Vec<_>>();
@@ -530,7 +541,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     fn collect_flat_cases<'d>(
         &mut self,
         decision: &'d Decision,
-        conditions: &mut Vec<String>,
+        conditions: &mut Vec<GoExpression>,
         out: &mut Vec<FlatCase<'d>>,
         tail: bool,
     ) -> bool {
@@ -594,7 +605,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 branches,
                 fallback,
             } => {
-                let rendered_path = path.render(self.subject.root()).rendered();
+                let rendered_path = path.render(self.subject.root());
                 let (cased, lifted) = split_with_default_lift(branches, fallback.as_deref());
                 for branch in cased {
                     self.record_subject_use();
@@ -623,7 +634,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         &mut self,
         arm_index: usize,
         bindings: &[PatternBinding],
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let lowered = self.with_binding_frame(|this| {
             this.install_path_overlays(bindings);
             this.lower_guard_condition(arm_index)
@@ -637,7 +648,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             .as_deref()
             .expect("a Guard decision has a guard expression");
         Some(if binds_looser_than_conjunction(guard) {
-            format!("({condition})")
+            GoExpression::parenthesized(condition)
         } else {
             condition
         })
@@ -739,7 +750,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             unreachable!("walk_switch requires a Switch decision");
         };
         let fallback = fallback.as_deref();
-        let rendered_path = path.render(self.subject.root()).rendered();
+        let rendered_path = path.render(self.subject.root());
         match shape {
             SwitchShape::TypeSwitch => {
                 self.record_subject_use();
@@ -766,10 +777,10 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 );
             }
             SwitchShape::Binary => {
-                let condition = format!(
-                    "{} == {}",
-                    render_switch_expression(&rendered_path, kind),
-                    branches[0].case_label
+                let condition = GoExpression::binary(
+                    render_switch_expression(rendered_path, kind),
+                    "==",
+                    label_expression(&branches[0].case_label),
                 );
                 self.walk_condition_branch(
                     statements,
@@ -789,16 +800,16 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                     apply_leaf_terminator(statements, ctx, body_diverges);
                     return;
                 };
-                let condition = format!(
-                    "{} == {}",
-                    render_switch_expression(&rendered_path, kind),
-                    branch.case_label
+                let condition = GoExpression::binary(
+                    render_switch_expression(rendered_path, kind),
+                    "==",
+                    label_expression(&branch.case_label),
                 );
                 self.walk_condition_branch(statements, condition, &branch.decision, fallback, ctx);
             }
             SwitchShape::Multi => {
                 self.record_subject_use();
-                let expr = render_switch_expression(&rendered_path, kind);
+                let expr = render_switch_expression(rendered_path, kind);
                 let plan = self.lower_value_switch(expr, branches, fallback, ctx.arm_place);
                 let body_diverges =
                     capture_diverge(vec![LoweredStatement::Switch(plan)], statements);
@@ -810,7 +821,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     fn walk_condition_branch(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        condition: String,
+        condition: GoExpression,
         then_branch: &Decision,
         else_branch: &Decision,
         ctx: &WalkCtx,
@@ -818,7 +829,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         self.record_subject_use();
         let inner = WalkCtx::switch_case(ctx.arm_place);
         let then_statements = self.with_scope(|this| {
-            this.planner.scope.establish_condition(condition.clone());
+            this.planner.scope.establish_condition(condition.rendered());
             let mut then_statements: Vec<LoweredStatement> = Vec::new();
             this.walk(&mut then_statements, then_branch, &inner);
             then_statements
@@ -828,12 +839,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         };
         let then_diverges = then_body.ends_with_diverge();
         let else_arm = self.lower_else_or_flat(else_branch, &inner, then_diverges);
-        let plan = IfPlan {
-            condition_setup: Vec::new(),
-            condition,
-            then_body,
-            else_arm,
-        };
+        let plan = IfPlan::plain(condition, then_body, else_arm);
         let body_diverges = capture_diverge(vec![LoweredStatement::If(plan)], statements);
         apply_leaf_terminator(statements, ctx, body_diverges);
     }
@@ -892,6 +898,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 };
                 guard_statements.push(LoweredStatement::If(IfPlan {
                     condition_setup,
+                    initializer: None,
                     condition,
                     then_body,
                     else_arm,
@@ -949,16 +956,16 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
     fn lower_value_switch(
         &mut self,
-        expr: String,
+        subject: GoExpression,
         branches: &[SwitchBranch],
         fallback: Option<&Decision>,
         place: &PlacePlan,
     ) -> SwitchStatementPlan {
         let (regular, default) = split_with_default_lift(branches, fallback);
-        let case_plans = self.lower_switch_cases(regular, place, Some(&expr));
+        let case_plans = self.lower_switch_cases(regular, place, Some(&subject));
         let default_block = self.lower_switch_default(default, place);
         SwitchStatementPlan {
-            kind: SwitchKind::Value { subject: expr },
+            kind: SwitchKind::Value { subject },
             cases: case_plans,
             default: default_block,
             postlude: switch_postlude(place, default.is_some()),
@@ -967,7 +974,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
     fn lower_type_switch(
         &mut self,
-        base: String,
+        subject: GoExpression,
         branches: &[SwitchBranch],
         fallback: Option<&Decision>,
         place: &PlacePlan,
@@ -975,6 +982,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let (regular, default) = split_with_default_lift(branches, fallback);
         let arms = self.arms;
         let subject_ty = self.subject_ty.clone();
+        let base = subject.rendered();
         let ((case_plans, default_block), used) = self.planner.capture_go_uses(|planner| {
             let mut nested =
                 TreePlanner::new(planner, arms, MatchSubject::Var(base.clone()), subject_ty);
@@ -989,10 +997,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let binding = references_base.then(|| base.clone());
 
         SwitchStatementPlan {
-            kind: SwitchKind::Type {
-                subject: base,
-                binding,
-            },
+            kind: SwitchKind::Type { subject, binding },
             cases: case_plans,
             default: default_block,
             postlude: switch_postlude(place, default.is_some()),
@@ -1003,7 +1008,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         &mut self,
         branches: &[SwitchBranch],
         place: &PlacePlan,
-        subject: Option<&str>,
+        subject: Option<&GoExpression>,
     ) -> Vec<SwitchCasePlan> {
         let ctx = WalkCtx::switch_case(place);
         let mut case_plans = Vec::with_capacity(branches.len());
@@ -1020,8 +1025,15 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 this.walk(&mut body, &branch.decision, &ctx);
                 body
             });
+            let labels = match subject {
+                Some(_) => vec![label_expression(&branch.case_label)],
+                None => split_top_level_type_list(&branch.case_label)
+                    .into_iter()
+                    .map(|go_type| GoExpression::type_name(go_type.to_string()))
+                    .collect(),
+            };
             case_plans.push(SwitchCasePlan {
-                labels: branch.case_label.clone(),
+                labels,
                 body: LoweredBlock { statements: body },
             });
         }
@@ -1107,12 +1119,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             self.record_subject_use();
         }
         match first_condition {
-            Some(condition) => statements.push(LoweredStatement::If(IfPlan {
-                condition_setup: Vec::new(),
-                condition: condition.clone(),
-                then_body: body,
-                else_arm: ElseArm::None,
-            })),
+            Some(condition) => statements.push(LoweredStatement::If(IfPlan::plain(
+                condition.clone(),
+                body,
+                ElseArm::None,
+            ))),
             None => statements.push(LoweredStatement::Block(body)),
         }
     }
@@ -1201,6 +1212,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                         });
                         statements.push(LoweredStatement::If(IfPlan {
                             condition_setup,
+                            initializer: None,
                             condition,
                             then_body: LoweredBlock {
                                 statements: then_body,
@@ -1277,7 +1289,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     fn lower_guard_condition(
         &mut self,
         arm_index: usize,
-    ) -> Option<(Vec<LoweredStatement>, String)> {
+    ) -> Option<(Vec<LoweredStatement>, GoExpression)> {
         let guard_expression = self.arms[arm_index].guard.as_deref()?;
         let plan = self
             .planner
@@ -1286,7 +1298,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         Some((setup, wrap_if_struct_literal(value)))
     }
 
-    fn render_chain_conditions(&self, tests: &[ChainTest]) -> Vec<Option<String>> {
+    fn render_chain_conditions(&self, tests: &[ChainTest]) -> Vec<Option<GoExpression>> {
         tests
             .iter()
             .map(|test| {
@@ -1327,25 +1339,27 @@ fn split_with_default_lift<'t>(
 }
 
 fn switch_branch_condition(
-    rendered_path: &str,
+    rendered_path: &GoExpression,
     kind: &PatternSwitchKind,
     shape: &SwitchShape,
     case_label: &str,
-) -> String {
+) -> GoExpression {
     if matches!(shape, SwitchShape::Bool) && case_label == "true" {
-        return wrap_if_struct_literal(rendered_path.to_string());
+        return wrap_if_struct_literal(rendered_path.clone());
     }
-    format!(
-        "{} == {}",
-        render_switch_expression(rendered_path, kind),
-        case_label
+    GoExpression::binary(
+        render_switch_expression(rendered_path.clone(), kind),
+        "==",
+        label_expression(case_label),
     )
 }
 
-fn render_switch_expression(rendered_path: &str, kind: &PatternSwitchKind) -> String {
+fn render_switch_expression(rendered_path: GoExpression, kind: &PatternSwitchKind) -> GoExpression {
     match kind {
-        PatternSwitchKind::EnumTag => wrap_if_struct_literal(format!("{}.Tag", rendered_path)),
-        PatternSwitchKind::Value => wrap_if_struct_literal(rendered_path.to_string()),
+        PatternSwitchKind::EnumTag => {
+            wrap_if_struct_literal(GoExpression::selector(rendered_path, "Tag".to_string()))
+        }
+        PatternSwitchKind::Value => wrap_if_struct_literal(rendered_path),
         PatternSwitchKind::TypeSwitch => unreachable!("TypeSwitch handled separately"),
     }
 }
@@ -1392,10 +1406,10 @@ fn bindings_are_hoistable(tests: &[ChainTest], indices: &[usize]) -> bool {
     })
 }
 
-fn group_chain_tests_by_condition(conditions: &[Option<String>]) -> Vec<(&str, Vec<usize>)> {
+fn group_chain_tests_by_condition(conditions: &[Option<GoExpression>]) -> Vec<(&str, Vec<usize>)> {
     let mut groups: Vec<(&str, Vec<usize>)> = Vec::new();
     for (i, condition) in conditions.iter().enumerate() {
-        let key = condition.as_deref().unwrap_or("");
+        let key = condition.as_ref().map_or("", GoExpression::as_str);
         if let Some((last_key, indices)) = groups.last_mut()
             && *last_key == key
         {
@@ -1409,7 +1423,7 @@ fn group_chain_tests_by_condition(conditions: &[Option<String>]) -> Vec<(&str, V
 
 /// One non-catchall branch of a pattern chain: its condition and lowered body.
 struct ChainBranch {
-    condition: String,
+    condition: GoExpression,
     body: LoweredBlock,
 }
 
@@ -1420,23 +1434,17 @@ fn build_chain_plan(branches: Vec<ChainBranch>, trailing: ElseArm) -> IfPlan {
     let head = branches.remove(0);
     let mut else_arm = trailing;
     for branch in branches.into_iter().rev() {
-        else_arm = ElseArm::ElseIf(Box::new(IfPlan {
-            condition_setup: Vec::new(),
-            condition: branch.condition,
-            then_body: branch.body,
+        else_arm = ElseArm::ElseIf(Box::new(IfPlan::plain(
+            branch.condition,
+            branch.body,
             else_arm,
-        }));
+        )));
     }
-    IfPlan {
-        condition_setup: Vec::new(),
-        condition: head.condition,
-        then_body: head.body,
-        else_arm,
-    }
+    IfPlan::plain(head.condition, head.body, else_arm)
 }
 
 /// Build the post-switch unreachable panic (when the place requires a tail
-/// return and the switch is non-exhaustive), as a `RawGo` postlude.
+/// return and the switch is non-exhaustive) as the switch postlude.
 fn switch_postlude(place: &PlacePlan, has_default: bool) -> Vec<LoweredStatement> {
     unreachable_panic_if_needed(place, has_default)
         .into_iter()

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -1,8 +1,35 @@
 //! Lowered body IR: the typed vocabulary `plan::lower` produces and `render/`
-//! consumes. `RawGo` is a transitional node holding pre-rendered Go.
+//! consumes.
 
-use crate::plan::values::{GoExpression, ValuePlan};
+use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
 use syntax::types::Type;
+
+pub(crate) fn define(name: String, value: GoExpression) -> LoweredStatement {
+    LoweredStatement::Define(Definition::single(name, value))
+}
+
+pub(crate) fn define_many(names: Vec<String>, value: GoExpression) -> LoweredStatement {
+    LoweredStatement::Define(Definition { names, value })
+}
+
+pub(crate) fn discard(value: GoExpression) -> LoweredStatement {
+    LoweredStatement::Discard(value)
+}
+
+pub(crate) fn expression_statement(expression: GoExpression) -> LoweredStatement {
+    LoweredStatement::ExpressionStatement {
+        expression,
+        diverges: false,
+    }
+}
+
+pub(crate) fn assign(target: GoExpression, value: GoExpression) -> LoweredStatement {
+    LoweredStatement::Assign(AssignForm::Simple {
+        target_capture: Vec::new(),
+        target,
+        value: ValuePlan::computed(Vec::new(), value, EvaluationEffect::Pure),
+    })
+}
 
 /// Destination for a lowered block's tail. The enclosing function's return
 /// context (for nested `return`/`?`) is read from the scope stack via
@@ -11,7 +38,7 @@ pub(crate) enum PlacePlan<'a> {
     Statement,
     Return,
     Assign {
-        local: &'a str,
+        local: &'a GoExpression,
         target_ty: Option<&'a Type>,
     },
 }
@@ -22,6 +49,7 @@ impl PlacePlan<'_> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LoweredBlock {
     pub(crate) statements: Vec<LoweredStatement>,
 }
@@ -29,6 +57,7 @@ pub(crate) struct LoweredBlock {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct LoopId(pub(crate) u32);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LoopTransfer {
     Unlabeled,
     Source(LoopId),
@@ -46,6 +75,40 @@ pub(crate) fn directed(directive: String, stmt: LoweredStatement) -> LoweredStat
     }
 }
 
+pub(crate) fn directed_first(
+    directive: String,
+    statements: Vec<LoweredStatement>,
+) -> Vec<LoweredStatement> {
+    if directive.is_empty() {
+        return statements;
+    }
+    let mut statements = statements.into_iter();
+    let first = statements.next().unwrap_or_else(|| {
+        LoweredStatement::Body(LoweredBlock {
+            statements: Vec::new(),
+        })
+    });
+    let mut directed_statements = vec![directed(directive, first)];
+    directed_statements.extend(statements);
+    directed_statements
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Definition {
+    pub(crate) names: Vec<String>,
+    pub(crate) value: GoExpression,
+}
+
+impl Definition {
+    pub(crate) fn single(name: String, value: GoExpression) -> Self {
+        Self {
+            names: vec![name],
+            value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LoweredStatement {
     If(IfPlan),
     Loop(LoopPlan),
@@ -59,45 +122,41 @@ pub(crate) enum LoweredStatement {
     BreakValue(BreakValuePlan),
     Let(LetPlan),
     Assign(AssignForm),
-    Expression(ExpressionStatementForm),
+    Async {
+        keyword: String,
+        call: GoExpression,
+    },
     Select(SelectStatementPlan),
     Switch(SwitchStatementPlan),
     WhileLet(LoweredBlock),
-    /// Eval-order temp capture: `name := value`.
-    TempBind {
-        name: String,
-        value: String,
+    Define(Definition),
+    AssignMany {
+        targets: Vec<GoExpression>,
+        value: GoExpression,
     },
     /// `var name go_type` (with `= value` when `value` is set).
     VarDecl {
         name: String,
         go_type: String,
-        value: Option<String>,
+        value: Option<GoExpression>,
     },
-    /// `name := <closure_open><body><closure_close>` (try-block IIFE,
-    /// recover-block closure). `closure_open`/`close` are opaque Go text.
-    ClosureBind {
-        name: String,
-        closure_open: String,
-        body: LoweredBlock,
-        closure_close: String,
+    Discard(GoExpression),
+    ExpressionStatement {
+        expression: GoExpression,
+        diverges: bool,
     },
     /// A statement preceded by a sourcemap `//line` directive.
     Directed {
         directive: String,
         inner: Box<LoweredStatement>,
     },
-    RawGo(String),
-    /// Raw Go whose tail diverges (a never-typed call such as `panic(...)`).
-    /// Tracked separately from `RawGo` so divergence is structural rather than
-    /// re-derived by scanning text.
-    DivergingRawGo(String),
     /// `panic("unreachable")` tail after a non-exhaustive branch in return
     /// position: a structured diverging leaf.
     UnreachablePanic,
 }
 
 /// A source `const` (or `var` when the value is not Go-const-eligible).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ConstPlan {
     pub(crate) is_const: bool,
     pub(crate) name: String,
@@ -106,6 +165,7 @@ pub(crate) struct ConstPlan {
 }
 
 /// A source `return expr` statement, classified by `ReturnForm`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ReturnForm {
     Plain {
         value: ValuePlan,
@@ -117,7 +177,7 @@ pub(crate) enum ReturnForm {
     },
     /// `return v0, v1, ...` for a lowered multi-value ABI return.
     Multi {
-        values: Vec<String>,
+        values: Vec<GoExpression>,
     },
     /// An already-lowered return sequence.
     Body {
@@ -127,6 +187,7 @@ pub(crate) enum ReturnForm {
 
 /// A `break value` statement. A diverged value terminates on its own; all
 /// other values carry the action and transfer needed to finish the break.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BreakValuePlan {
     Diverged {
         value: ValuePlan,
@@ -139,6 +200,7 @@ pub(crate) enum BreakValuePlan {
 }
 
 /// What to do with a non-diverging `break value` after its setup has run.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BreakValueAction {
     /// Inside a loop with a result slot, when the value is a unit-typed
     /// call: emit `<value>` as a side-effect statement (skipped if value
@@ -153,6 +215,7 @@ pub(crate) enum BreakValueAction {
 }
 
 /// A lowered `let` binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LetPlan {
     /// Optional `var X T` emitted before a never-typed value so dead code can
     /// still reference the binding.
@@ -161,21 +224,23 @@ pub(crate) struct LetPlan {
 }
 
 /// An assignment statement, structured by shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AssignForm {
     /// `target++`, `target--`, or `target op= rhs`.
     Compound {
         target_capture: Vec<LoweredStatement>,
-        target_str: String,
+        target: GoExpression,
         kind: CompoundKind,
     },
     /// `target = value`.
     Simple {
         target_capture: Vec<LoweredStatement>,
-        target_str: String,
+        target: GoExpression,
         value: ValuePlan,
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompoundKind {
     Increment,
     Decrement,
@@ -188,17 +253,9 @@ pub(crate) enum CompoundKind {
     },
 }
 
-/// A bare expression statement.
-pub(crate) enum ExpressionStatementForm {
-    /// `go <value>` / `defer <value>` at statement position.
-    Async { value: ValuePlan },
-    /// `<keyword> func() { <body> }()` IIFE wrapper for Task/Defer block
-    /// forms and inner expressions requiring an IIFE (`needs_iife_for_async`).
-    AsyncBlock { keyword: String, body: LoweredBlock },
-}
-
 /// A `switch` statement (value or type switch). The renderer owns the
 /// `switch`/`case`/`default:` syntax.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SwitchStatementPlan {
     pub(crate) kind: SwitchKind,
     pub(crate) cases: Vec<SwitchCasePlan>,
@@ -207,23 +264,25 @@ pub(crate) struct SwitchStatementPlan {
     pub(crate) postlude: Vec<LoweredStatement>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SwitchKind {
     Conditional,
     /// `switch <subject> {`
     Value {
-        subject: String,
+        subject: GoExpression,
     },
     /// `switch <binding> := <subject>.(type) {` when `binding` is set,
     /// otherwise `switch <subject>.(type) {`.
     Type {
-        subject: String,
+        subject: GoExpression,
         binding: Option<String>,
     },
 }
 
 /// A single `case <labels>:` plus its body.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SwitchCasePlan {
-    pub(crate) labels: String,
+    pub(crate) labels: Vec<GoExpression>,
     pub(crate) body: LoweredBlock,
 }
 
@@ -239,6 +298,7 @@ impl SwitchStatementPlan {
 /// ordered set of arms, plus hoisted setup and a trailing postlude (e.g. an
 /// unreachable panic). The renderer owns the `for`/`select`/`case`/`default:`
 /// syntax.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SelectStatementPlan {
     /// Side-effecting setup hoisted before the `select` (channel/value temps).
     pub(crate) setup: Vec<LoweredStatement>,
@@ -250,17 +310,19 @@ pub(crate) struct SelectStatementPlan {
 }
 
 /// A single `select` arm: a `case`/`default:` header plus its body block.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SelectArmPlan {
     /// `case <receive_vars> := <-<channel>:`, or `case <-<channel>:` when
     /// `receive_vars` is `None`.
     Receive {
         receive_vars: Option<String>,
-        channel: String,
+        channel: GoExpression,
         body: LoweredBlock,
     },
-    /// `case <operation>:` where `operation` is `ch <- val` or `<-ch`.
+    /// `case <channel> <- <value>:`
     Send {
-        operation: GoExpression,
+        channel: GoExpression,
+        value: GoExpression,
         body: LoweredBlock,
     },
     /// `default:`
@@ -299,16 +361,33 @@ impl SelectArmPlan {
 }
 
 /// A statement-position loop. `prologue` is pre-loop setup (a for-loop's
-/// iterable capture); `header` is the rendered Go loop opener through the body's
-/// opening brace; its kind records whether transfers inside it can target an
-/// enclosing source loop.
+/// iterable capture); its kind records whether transfers inside it can target
+/// an enclosing source loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LoopPlan {
     pub(crate) prologue: Vec<LoweredStatement>,
     pub(crate) kind: LoopKind,
-    pub(crate) header: String,
+    pub(crate) header: LoopHeader,
     pub(crate) body: LoweredBlock,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LoopHeader {
+    Infinite,
+    While(GoExpression),
+    Range {
+        key: Option<String>,
+        value: Option<String>,
+        iterable: GoExpression,
+    },
+    Counted {
+        variable: String,
+        start: GoExpression,
+        condition: Option<GoExpression>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LoopKind {
     Source { label: Option<String> },
     Generated { label: Option<String> },
@@ -322,15 +401,34 @@ impl LoopKind {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IfPlan {
     /// Side-effecting setup hoisted before the `if` condition (temps from a
     /// condition that lowered to statements).
     pub(crate) condition_setup: Vec<LoweredStatement>,
-    pub(crate) condition: String,
+    pub(crate) initializer: Option<Definition>,
+    pub(crate) condition: GoExpression,
     pub(crate) then_body: LoweredBlock,
     pub(crate) else_arm: ElseArm,
 }
 
+impl IfPlan {
+    pub(crate) fn plain(
+        condition: GoExpression,
+        then_body: LoweredBlock,
+        else_arm: ElseArm,
+    ) -> Self {
+        Self {
+            condition_setup: Vec::new(),
+            initializer: None,
+            condition,
+            then_body,
+            else_arm,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ElseArm {
     None,
     ElseIf(Box<IfPlan>),
@@ -377,9 +475,11 @@ impl LoweredStatement {
     pub(crate) fn bound_name(&self) -> Option<&str> {
         match self {
             LoweredStatement::Directed { inner, .. } => inner.bound_name(),
-            LoweredStatement::TempBind { name, .. }
-            | LoweredStatement::ClosureBind { name, .. }
-            | LoweredStatement::VarDecl {
+            LoweredStatement::Define(Definition { names, .. }) => match names.as_slice() {
+                [name] => Some(name),
+                _ => None,
+            },
+            LoweredStatement::VarDecl {
                 name,
                 value: Some(_),
                 ..
@@ -396,9 +496,11 @@ impl LoweredStatement {
     pub(crate) fn rename_bound_name(&mut self, go_name: &str) -> bool {
         let bound = match self {
             LoweredStatement::Directed { inner, .. } => return inner.rename_bound_name(go_name),
-            LoweredStatement::TempBind { name, .. }
-            | LoweredStatement::ClosureBind { name, .. }
-            | LoweredStatement::VarDecl {
+            LoweredStatement::Define(Definition { names, .. }) => match names.as_mut_slice() {
+                [name] => name,
+                _ => return false,
+            },
+            LoweredStatement::VarDecl {
                 name,
                 value: Some(_),
                 ..
@@ -419,9 +521,11 @@ impl LoweredStatement {
             | LoweredStatement::Const(_)
             | LoweredStatement::Select(_)
             | LoweredStatement::Switch(_)
-            | LoweredStatement::TempBind { .. }
+            | LoweredStatement::Async { .. }
+            | LoweredStatement::Define(_)
             | LoweredStatement::VarDecl { .. }
-            | LoweredStatement::ClosureBind { .. }
+            | LoweredStatement::Discard(_)
+            | LoweredStatement::AssignMany { .. }
             | LoweredStatement::UnreachablePanic => true,
             LoweredStatement::Body(body) => !body.renders_empty(),
             LoweredStatement::Return(plan) => match plan {
@@ -440,18 +544,10 @@ impl LoweredStatement {
             LoweredStatement::Assign(plan) => match plan {
                 AssignForm::Compound { .. } | AssignForm::Simple { .. } => true,
             },
-            LoweredStatement::Expression(plan) => match plan {
-                ExpressionStatementForm::Async { value } => {
-                    !value.is_empty() || value.setup.iter().any(LoweredStatement::emits_output)
-                }
-                ExpressionStatementForm::AsyncBlock { .. } => true,
-            },
             LoweredStatement::WhileLet(body) => !body.renders_empty(),
+            LoweredStatement::ExpressionStatement { expression, .. } => !expression.is_empty(),
             LoweredStatement::Directed { directive, inner } => {
                 !directive.is_empty() || inner.emits_output()
-            }
-            LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
-                !code.is_empty()
             }
         }
     }
@@ -470,19 +566,17 @@ impl LoweredStatement {
             LoweredStatement::Assign(plan) => match plan {
                 AssignForm::Compound { .. } | AssignForm::Simple { .. } => false,
             },
-            LoweredStatement::Expression(plan) => match plan {
-                ExpressionStatementForm::Async { .. }
-                | ExpressionStatementForm::AsyncBlock { .. } => false,
-            },
+            LoweredStatement::Async { .. } => false,
             LoweredStatement::Select(plan) => plan.ends_with_diverge(),
             LoweredStatement::Switch(plan) => plan.ends_with_diverge(),
             LoweredStatement::WhileLet(body) => body.ends_with_diverge(),
-            LoweredStatement::TempBind { .. }
+            LoweredStatement::Define(_)
             | LoweredStatement::VarDecl { .. }
-            | LoweredStatement::ClosureBind { .. } => false,
+            | LoweredStatement::Discard(_)
+            | LoweredStatement::AssignMany { .. } => false,
+            LoweredStatement::ExpressionStatement { diverges, .. } => *diverges,
             LoweredStatement::Directed { inner, .. } => inner.ends_with_diverge(),
-            LoweredStatement::RawGo(_) => false,
-            LoweredStatement::DivergingRawGo(_) | LoweredStatement::UnreachablePanic => true,
+            LoweredStatement::UnreachablePanic => true,
         }
     }
 

--- a/crates/emit/src/plan/go_expression.rs
+++ b/crates/emit/src/plan/go_expression.rs
@@ -1,6 +1,9 @@
 //! The Go expression tree behind `GoExpression`.
 
+use crate::plan::bodies::LoweredBlock;
+use crate::render::Renderer;
 use crate::types::go_type::render_conversion;
+use std::slice;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum GoExpressionNode {
@@ -58,11 +61,23 @@ pub(crate) enum GoExpressionNode {
         go_type: String,
         operand: Box<GoExpressionNode>,
     },
-    Receive(Box<GoExpressionNode>),
     /// A variadic argument, `values...`.
     Spread(Box<GoExpressionNode>),
-    /// Go text that is not yet a node.
-    Raw(String),
+    FunctionLiteral {
+        parameters: String,
+        result: String,
+        body: LoweredBlock,
+        layout: FunctionLiteralLayout,
+    },
+    Empty,
+    /// Go source the program supplied through `@rawgo`.
+    Verbatim(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FunctionLiteralLayout {
+    Inline,
+    MultiLine,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,9 +118,11 @@ impl GoExpressionNode {
 
     fn write(&self, output: &mut String) {
         match self {
-            Self::Identifier(text) | Self::Literal(text) | Self::Type(text) | Self::Raw(text) => {
-                output.push_str(text)
-            }
+            Self::Identifier(text)
+            | Self::Literal(text)
+            | Self::Type(text)
+            | Self::Verbatim(text) => output.push_str(text),
+            Self::Empty => {}
             Self::CompositeLiteral {
                 go_type,
                 elements,
@@ -237,13 +254,51 @@ impl GoExpressionNode {
             Self::Conversion { go_type, operand } => {
                 output.push_str(&render_conversion(go_type, &operand.print()));
             }
-            Self::Receive(channel) => {
-                output.push_str("<-");
-                channel.write(output);
-            }
             Self::Spread(operand) => {
                 operand.write(output);
                 output.push_str("...");
+            }
+            Self::FunctionLiteral {
+                parameters,
+                result,
+                body,
+                layout,
+            } => {
+                output.push_str("func(");
+                output.push_str(parameters);
+                output.push(')');
+                if !result.is_empty() {
+                    output.push(' ');
+                    output.push_str(result);
+                }
+                output.push_str(" {");
+                let lines: Vec<String> = body
+                    .statements
+                    .iter()
+                    .map(|statement| Renderer.render_setup(slice::from_ref(statement)))
+                    .collect();
+                let single_line = lines
+                    .iter()
+                    .all(|line| line.trim_end_matches('\n').lines().count() <= 1);
+                if matches!(layout, FunctionLiteralLayout::Inline) && single_line {
+                    let joined = lines
+                        .iter()
+                        .map(|line| line.trim_end_matches('\n'))
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    if !joined.is_empty() {
+                        output.push(' ');
+                        output.push_str(&joined);
+                        output.push(' ');
+                    }
+                    output.push('}');
+                } else {
+                    output.push('\n');
+                    for line in &lines {
+                        output.push_str(line);
+                    }
+                    output.push('}');
+                }
             }
         }
     }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -1,6 +1,6 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
+use crate::calls::comma_ok::PairCondition;
 use crate::calls::predicates::strip_negations;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
@@ -10,9 +10,10 @@ use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_cont
 use crate::expressions::{flip_comparison, flip_preserves_nan};
 use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
 use crate::plan::bodies::{
-    ElseArm, ExpressionStatementForm, IfPlan, LoopKind, LoopPlan, LoopTransfer, LoweredBlock,
-    LoweredStatement, PlacePlan, directed,
+    ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
+    PlacePlan, define, directed, directed_first, expression_statement,
 };
+use crate::plan::go_expression::CompositeLayout;
 use crate::plan::placement::{collapse_declared_temp, requires_temp_var, try_elide_tail_let};
 use crate::plan::values::{GoExpression, OperandForm, ValuePlan};
 use crate::utils::wrap_if_struct_literal;
@@ -76,10 +77,11 @@ impl Planner<'_> {
         ty: &Type,
     ) -> ValuePlan {
         let (result_var, declaration) = self.operand_temp_declaration(ty);
+        let target = GoExpression::name(result_var.clone());
         let block = self.lower_branching_to_block(
             expression,
             &PlacePlan::Assign {
-                local: &result_var,
+                local: &target,
                 target_ty: Some(ty),
             },
         );
@@ -102,7 +104,7 @@ impl Planner<'_> {
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty);
         let plan = self.with_loop(result_var.clone(), |this| {
-            this.lower_loop_with_header("for {\n".to_string(), body)
+            this.lower_loop_with_header(LoopHeader::Infinite, body)
         });
         ValuePlan::captured(vec![declaration, LoweredStatement::Loop(plan)], result_var)
     }
@@ -167,19 +169,14 @@ impl Planner<'_> {
             && let Some(return_ty) = return_ctx.ty().filter(|ty| !ty.is_unit())
         {
             let return_ty = return_ty.clone();
-            let (zero, packages) = self.zero_value(&return_ty);
-            self.require_packages(&packages);
+            let zero = self.zero_value_expression(&return_ty);
             statements.push(plain_return(zero));
         }
 
         LoweredBlock { statements }
     }
 
-    /// Lower a single statement. Structured variants are produced where lowering
-    /// has reached the construct; everything else captures the existing emitter
-    /// output as `RawGo`. `return_ctx` is the enclosing function/lambda/try/
-    /// recover return context, threaded so nested `return` lowering has an
-    /// explicit context.
+    /// Lower a single statement in the enclosing return context.
     pub(crate) fn lower_statement(&mut self, expression: &Expression) -> LoweredStatement {
         match expression {
             Expression::If {
@@ -293,23 +290,12 @@ impl Planner<'_> {
             }
             Expression::WhileLet { .. } => self.lower_while_let_statement(expression),
             Expression::Assert { .. } => self.lower_assert_statement(expression),
-            // Top-level items (Struct/Enum/etc) shouldn't appear inside
-            // function bodies, but dispatch handles them defensively. They
-            // carry their own directive (via `emit_top_item`) so the wrapper
-            // does not add one.
             Expression::Struct { .. }
             | Expression::Enum { .. }
             | Expression::TypeAlias { .. }
             | Expression::Interface { .. }
             | Expression::ImplBlock { .. } => {
-                let directive = self.maybe_line_directive(&expression.get_span());
-                let code = self.emit_top_item(expression);
-                let mut buffer = directive;
-                if !code.is_empty() {
-                    buffer.push_str(&code);
-                    buffer.push('\n');
-                }
-                LoweredStatement::RawGo(buffer)
+                unreachable!("the parser rejects item definitions inside function bodies")
             }
             Expression::Call { .. } if self.is_test_log_call(expression) => {
                 self.lower_test_log_statement(expression)
@@ -335,7 +321,9 @@ impl Planner<'_> {
             Expression::Task { .. } | Expression::Defer { .. }
         ) {
             let value = self.plan_operand(unwrapped, ExpressionContext::value());
-            LoweredStatement::Expression(ExpressionStatementForm::Async { value })
+            LoweredStatement::Body(LoweredBlock {
+                statements: value.setup,
+            })
         } else if let Expression::Propagate {
             expression: inner, ..
         } = unwrapped
@@ -388,11 +376,25 @@ impl Planner<'_> {
             .current_test_handle()
             .expect("assert without a test handle should be rejected by semantics");
         let span = operand.get_span();
-        let test = LoweredStatement::RawGo(format!(
-            "if {failure_condition} {{\n{handle}.FailAssert({}, {}, {}, \"{kind}\", \"{message}\"{operands})\n}}\n",
-            span.file_id,
-            span.byte_offset,
-            span.byte_offset + span.byte_length,
+        let literal = |text: String| GoExpression::literal(text);
+        let mut arguments = vec![
+            literal(span.file_id.to_string()),
+            literal(span.byte_offset.to_string()),
+            literal((span.byte_offset + span.byte_length).to_string()),
+            literal(format!("\"{kind}\"")),
+            literal(format!("\"{message}\"")),
+        ];
+        arguments.extend(operands);
+        let fail = GoExpression::call(
+            GoExpression::name(format!("{handle}.FailAssert")),
+            arguments,
+        );
+        let test = LoweredStatement::If(IfPlan::plain(
+            failure_condition,
+            LoweredBlock {
+                statements: vec![expression_statement(fail)],
+            },
+            ElseArm::None,
         ));
         // The block exists only to scope the temps.
         if statements.is_empty() {
@@ -427,7 +429,7 @@ impl Planner<'_> {
 
     fn lower_test_log_statement(&mut self, expression: &Expression) -> LoweredStatement {
         let (mut statements, call) = self.lower_test_log_call(expression);
-        statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+        statements.push(expression_statement(call));
         LoweredStatement::Block(LoweredBlock { statements })
     }
 
@@ -502,7 +504,7 @@ impl Planner<'_> {
         AssertShape {
             failure_condition: match flipped {
                 Some(_) => condition,
-                None => format!("!({condition})"),
+                None => negate_parenthesized(condition),
             },
             kind: "relation",
             message: format!("expected {operator}"),
@@ -520,7 +522,8 @@ impl Planner<'_> {
         self.require_stdlib();
         let recv_ty = recv.get_type();
         let (lhs, rhs) = self.stage_assert_operands(recv, arg, LiteralInlining::Denied, statements);
-        let failure_condition = self.render_inequality(&lhs.rendered, &rhs.rendered, &recv_ty, &[]);
+        let failure_condition =
+            self.inequality_expression(lhs.rendered.clone(), rhs.rendered.clone(), &recv_ty, &[]);
         AssertShape {
             failure_condition,
             kind: "labeled",
@@ -550,7 +553,7 @@ impl Planner<'_> {
             // its parentheses.
             let (setup, condition) = self.lower_condition(operand);
             statements.extend(setup);
-            format!("!({condition})")
+            negate_parenthesized(condition)
         } else {
             let (setup, condition) = self.plan_unary_not(operand, ctx).into_parts();
             statements.extend(setup);
@@ -560,7 +563,7 @@ impl Planner<'_> {
             failure_condition,
             kind: "bare",
             message: "assertion failed".to_string(),
-            operands: String::new(),
+            operands: Vec::new(),
         }
     }
 
@@ -647,15 +650,12 @@ impl Planner<'_> {
                     value: Some(value),
                 }
             } else {
-                LoweredStatement::TempBind {
-                    name: name.clone(),
-                    value,
-                }
+                define(name.clone(), value)
             },
         );
         AssertOperand {
             expression: temp_identifier(&name, expression),
-            rendered: name,
+            rendered: GoExpression::name(name),
         }
     }
 
@@ -709,21 +709,30 @@ impl Planner<'_> {
 
     fn lower_infinite_loop(&mut self, body: &Expression) -> LoopPlan {
         self.with_loop("_", |this| {
-            this.lower_loop_with_header("for {\n".to_string(), body)
+            this.lower_loop_with_header(LoopHeader::Infinite, body)
         })
     }
 
-    fn lower_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, String) {
+    fn lower_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, GoExpression) {
         let plan = self.plan_operand(condition, ExpressionContext::value().condition());
         plan.into_parts()
     }
 
-    fn lower_if_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, String) {
+    fn lower_if_condition(
+        &mut self,
+        condition: &Expression,
+    ) -> (Vec<LoweredStatement>, PairCondition) {
         if let Some(fused) = self.lower_fused_predicate_condition(condition) {
             return fused;
         }
         let (setup, rendered) = self.lower_condition(condition);
-        (setup, wrap_if_struct_literal(rendered))
+        (
+            setup,
+            PairCondition {
+                initializer: None,
+                condition: wrap_if_struct_literal(rendered),
+            },
+        )
     }
 
     fn lower_while(&mut self, condition: &Expression, body: &Expression) -> LoopPlan {
@@ -731,32 +740,58 @@ impl Planner<'_> {
             let (target, negated) = strip_negations(condition);
             if let Some(exit) = this.lower_fused_predicate_value(target, !negated) {
                 let (setup, failure) = exit.into_parts();
-                let setup_text = Renderer.render_setup(&setup);
-                let header = format!("for {{\n{setup_text}if {failure} {{ break }}\n");
-                return this.lower_loop_with_header(header, body);
+                return this.lower_loop_with_exit_test(setup, failure, body);
             }
             let (setup, rendered) = this.lower_condition(condition);
-            let header = if !setup.is_empty() {
-                let setup_text = Renderer.render_setup(&setup);
-                format!("for {{\n{}if !({}) {{ break }}\n", setup_text, rendered)
-            } else if matches!(
+            if !setup.is_empty() {
+                let exit = GoExpression::unary("!", GoExpression::parenthesized(rendered));
+                return this.lower_loop_with_exit_test(setup, exit, body);
+            }
+            let header = if matches!(
                 condition.unwrap_parens(),
                 Expression::Literal {
                     literal: Literal::Boolean(true),
                     ..
                 }
             ) {
-                "for {\n".to_string()
+                LoopHeader::Infinite
             } else {
-                format!("for {} {{\n", wrap_if_struct_literal(rendered))
+                LoopHeader::While(wrap_if_struct_literal(rendered))
             };
             this.lower_loop_with_header(header, body)
         })
     }
 
+    fn lower_loop_with_exit_test(
+        &mut self,
+        setup: Vec<LoweredStatement>,
+        exit: GoExpression,
+        body: &Expression,
+    ) -> LoopPlan {
+        let mut statements = setup;
+        statements.push(LoweredStatement::If(IfPlan::plain(
+            exit,
+            LoweredBlock {
+                statements: vec![LoweredStatement::Break(LoopTransfer::Unlabeled)],
+            },
+            ElseArm::None,
+        )));
+        let lowered_body = self.with_scope(|this| this.lower_block_as_body(body));
+        statements.extend(lowered_body.statements);
+        self.build_source_loop(
+            Vec::new(),
+            LoopHeader::Infinite,
+            LoweredBlock { statements },
+        )
+    }
+
     /// Shared loop lowering once the header is known. The caller must have an
     /// active loop context.
-    pub(crate) fn lower_loop_with_header(&mut self, header: String, body: &Expression) -> LoopPlan {
+    pub(crate) fn lower_loop_with_header(
+        &mut self,
+        header: LoopHeader,
+        body: &Expression,
+    ) -> LoopPlan {
         let lowered_body = self.with_scope(|this| this.lower_block_as_body(body));
         self.build_source_loop(Vec::new(), header, lowered_body)
     }
@@ -764,7 +799,7 @@ impl Planner<'_> {
     pub(crate) fn build_source_loop(
         &mut self,
         prologue: Vec<LoweredStatement>,
-        header: String,
+        header: LoopHeader,
         mut body: LoweredBlock,
     ) -> LoopPlan {
         let target = self
@@ -855,7 +890,7 @@ impl Planner<'_> {
     fn lower_block_to_assign(
         &mut self,
         expression: &Expression,
-        local: &str,
+        local: &GoExpression,
         target_ty: Option<&Type>,
     ) -> LoweredBlock {
         if expression.get_type().is_result() || expression.get_type().is_option() {
@@ -890,7 +925,7 @@ impl Planner<'_> {
 
     /// Lower a single tail expression in return position to its return
     /// statements. Shared by branch-arm return lowering and function-body
-    /// lowering; only leaf values and lowered-ABI returns become `RawGo`,
+    /// lowering; leaf values and lowered-ABI returns become `Return` leaves,
     /// `if`/`if let`/`match`/`select` tails recurse structurally with a `Return` place.
     fn lower_return_tail(&mut self, last: &Expression) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
@@ -923,23 +958,18 @@ impl Planner<'_> {
                 statements.push(directed(directive, statement));
             }
             Expression::IfLet { .. } | Expression::Match { .. } => {
-                if !directive.is_empty() {
-                    statements.push(LoweredStatement::RawGo(directive));
-                }
                 let block = self.lower_branching_to_block(last, &PlacePlan::Return);
-                statements.extend(block.statements);
+                statements.extend(directed_first(directive, block.statements));
             }
             _ => {
-                if !directive.is_empty() {
-                    statements.push(LoweredStatement::RawGo(directive));
-                }
-                if let Some(tail) = try_emit_lowered_tail_return(self, last) {
-                    statements.extend(tail);
+                let tail = if let Some(tail) = try_emit_lowered_tail_return(self, last) {
+                    tail
                 } else if let Some(wrapped) = self.lower_wrapped_return(last) {
-                    statements.extend(wrapped);
+                    wrapped
                 } else {
-                    statements.extend(self.lower_plain_return_tail(last));
-                }
+                    self.lower_plain_return_tail(last)
+                };
+                statements.extend(directed_first(directive, tail));
             }
         }
 
@@ -952,19 +982,13 @@ impl Planner<'_> {
         return_span: &Span,
     ) -> Vec<LoweredStatement> {
         let directive = self.maybe_line_directive(return_span);
-        let mut statements: Vec<LoweredStatement> = Vec::new();
-        if !directive.is_empty() {
-            statements.push(LoweredStatement::RawGo(directive));
-        }
-        statements.push(self.lower_statement(last));
+        let mut statements = vec![self.lower_statement(last)];
         if !is_go_never(last) && !is_breakless_loop(last) {
             statements.push(LoweredStatement::UnreachablePanic);
         }
-        statements
+        directed_first(directive, statements)
     }
 
-    /// Kept as `RawGo`, not `ReturnForm::Plain`: a structured `Return` would
-    /// flatten the enclosing `else` for a multi-line return value.
     fn lower_plain_return_tail(&mut self, last: &Expression) -> Vec<LoweredStatement> {
         if requires_temp_var(last) {
             let staged = self.plan_operand(last, ExpressionContext::value());
@@ -976,13 +1000,9 @@ impl Planner<'_> {
         } else {
             let (mut statements, expression) = self.lower_tail_value(last);
             let return_ctx = self.return_ctx();
-            let mut coercion = String::new();
             let expression =
-                self.apply_type_coercion(&mut coercion, return_ctx.ty(), last, expression);
-            if !coercion.is_empty() {
-                statements.push(LoweredStatement::RawGo(coercion));
-            }
-            statements.push(plain_return(expression.rendered()));
+                self.apply_type_coercion(&mut statements, return_ctx.ty(), last, expression);
+            statements.push(plain_return(expression));
             statements
         }
     }
@@ -1003,7 +1023,8 @@ impl Planner<'_> {
 
         IfPlan {
             condition_setup,
-            condition,
+            initializer: condition.initializer,
+            condition: condition.condition,
             then_body,
             else_arm,
         }
@@ -1043,7 +1064,8 @@ impl Planner<'_> {
                     );
                     ElseArm::ElseIf(Box::new(IfPlan {
                         condition_setup,
-                        condition,
+                        initializer: condition.initializer,
+                        condition: condition.condition,
                         then_body,
                         else_arm: inner,
                     }))
@@ -1058,7 +1080,8 @@ impl Planner<'_> {
                 );
                 ElseArm::ElseIf(Box::new(IfPlan {
                     condition_setup,
-                    condition,
+                    initializer: condition.initializer,
+                    condition: condition.condition,
                     then_body,
                     else_arm: inner,
                 }))
@@ -1075,19 +1098,23 @@ impl Planner<'_> {
 }
 
 /// The lowered pieces of an `assert`: the condition under which it fails, the
-/// record kind, and any `, Operand{...}` arguments appended to the failure call.
+/// record kind, and any `Operand{...}` arguments appended to the failure call.
 struct AssertShape {
-    failure_condition: String,
+    failure_condition: GoExpression,
     kind: &'static str,
     message: String,
-    operands: String,
+    operands: Vec<GoExpression>,
 }
 
-/// An `assert` operand: the expression the test reads, and the Go text the
+/// An `assert` operand: the expression the test reads, and the Go value the
 /// failure call reports.
 struct AssertOperand {
     expression: Expression,
-    rendered: String,
+    rendered: GoExpression,
+}
+
+fn negate_parenthesized(condition: GoExpression) -> GoExpression {
+    GoExpression::unary("!", GoExpression::parenthesized(condition))
 }
 
 /// The equals lowering can read its left operand as a method receiver, where a
@@ -1098,11 +1125,29 @@ enum LiteralInlining {
     Denied,
 }
 
-fn paired_operands(lhs: &str, rhs: &str) -> String {
+fn paired_operands(lhs: &GoExpression, rhs: &GoExpression) -> Vec<GoExpression> {
     let (test_kit, prelude) = (testkit_qualifier(), prelude_qualifier());
-    format!(
-        ", {test_kit}.Operand{{Label: \"left\", Value: {prelude}.Debug({lhs})}}, {test_kit}.Operand{{Label: \"right\", Value: {prelude}.Debug({rhs})}}"
-    )
+    let operand = |label: &str, value: &GoExpression| {
+        GoExpression::composite(
+            Some(format!("{test_kit}.Operand")),
+            vec![
+                (
+                    Some("Label".to_string()),
+                    GoExpression::literal(format!("\"{label}\"")),
+                ),
+                (
+                    Some("Value".to_string()),
+                    GoExpression::call(
+                        GoExpression::name(format!("{prelude}.Debug")),
+                        vec![value.clone()],
+                    ),
+                ),
+            ],
+            CompositeLayout::Inline { padded: false },
+            false,
+        )
+    };
+    vec![operand("left", lhs), operand("right", rhs)]
 }
 
 /// A typed identifier for an already-bound temp, so the rebuilt comparison casts as usual.

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -8,8 +8,8 @@ use crate::expressions::staging::SpreadSequenceOptions;
 use crate::names::go_name::is_plain_identifier;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::plan::bodies::{
-    AssignForm, BreakValueAction, BreakValuePlan, ElseArm, LoopTransfer, LoweredBlock,
-    LoweredStatement, PlacePlan,
+    AssignForm, BreakValueAction, BreakValuePlan, ElseArm, LoopHeader, LoopTransfer, LoweredBlock,
+    LoweredStatement, PlacePlan, define, discard, expression_statement,
 };
 use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
@@ -54,10 +54,10 @@ pub(crate) fn is_unit_call(expression: &Expression) -> bool {
 }
 
 /// A `target = value` assignment with no lvalue capture.
-pub(crate) fn simple_assign(target_var: &str, value: ValuePlan) -> LoweredStatement {
+pub(crate) fn simple_assign(target: &GoExpression, value: ValuePlan) -> LoweredStatement {
     LoweredStatement::Assign(AssignForm::Simple {
         target_capture: Vec::new(),
-        target_str: target_var.to_string(),
+        target: target.clone(),
         value,
     })
 }
@@ -73,8 +73,6 @@ pub(crate) fn rebind_trailing_temp(
         .is_some_and(|statement| statement.binds_name(temp) && statement.rename_bound_name(name))
 }
 
-/// Collapse `var x T` + one unconditional `x = v` into `x := v`, when `:=`
-/// infers T identically (a `float64` context can hold an untyped int literal).
 /// Collapse `var x T` plus the one statement that fills it into `x := value`.
 pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, name: &str) {
     let [
@@ -94,21 +92,21 @@ pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, nam
     let value = match filler {
         LoweredStatement::Assign(AssignForm::Simple {
             target_capture,
-            target_str,
+            target,
             value,
         }) => {
             if !matches!(go_type.as_str(), "int" | "string" | "bool")
-                || target_str != name
+                || target.as_str() != name
                 || !target_capture.is_empty()
                 || !value.setup.is_empty()
                 || value.expression.contains_deferred_evaluation()
             {
                 return;
             }
-            value.expression.rendered()
+            value.expression.clone()
         }
         LoweredStatement::If(plan) => {
-            if go_type != "bool" || !plan.condition_setup.is_empty() {
+            if go_type != "bool" || !plan.condition_setup.is_empty() || plan.initializer.is_some() {
                 return;
             }
             let ElseArm::Else {
@@ -132,60 +130,63 @@ pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, nam
         _ => return,
     };
     statements.pop();
-    statements[0] = LoweredStatement::TempBind {
-        name: name.to_string(),
-        value,
-    };
+    statements[0] = define(name.to_string(), value);
 }
 
-/// The rendered value of a body that is exactly one plain `name = value`.
-fn single_simple_assign_value(body: &LoweredBlock, name: &str) -> Option<String> {
+/// The value of a body that is exactly one plain `name = value`.
+fn single_simple_assign_value(body: &LoweredBlock, name: &str) -> Option<GoExpression> {
     let [LoweredStatement::Assign(assign)] = body.statements.as_slice() else {
         return None;
     };
     let AssignForm::Simple {
         target_capture,
-        target_str,
+        target,
         value,
     } = assign
     else {
         return None;
     };
-    (target_str == name
+    (target.as_str() == name
         && target_capture.is_empty()
         && value.setup.is_empty()
         && !value.expression.contains_deferred_evaluation())
-    .then(|| value.expression.rendered())
+    .then(|| value.expression.clone())
 }
 
-fn join_boolean_branches(condition: &str, then_value: &str, else_value: &str) -> Option<String> {
-    Some(match (then_value, else_value) {
-        ("true", "false") => condition.to_string(),
+fn join_boolean_branches(
+    condition: &GoExpression,
+    then_value: &GoExpression,
+    else_value: &GoExpression,
+) -> Option<GoExpression> {
+    let and = |left: GoExpression, right: GoExpression| GoExpression::binary(left, "&&", right);
+    let or = |left: GoExpression, right: GoExpression| GoExpression::binary(left, "||", right);
+    Some(match (then_value.as_str(), else_value.as_str()) {
+        ("true", "false") => condition.clone(),
         ("false", "true") => negate_condition(condition),
         // Both-literal same-value arms would drop the condition's evaluation.
         ("true", "true") | ("false", "false") => return None,
-        (value, "false") => format!("{} && {}", and_operand(condition), and_operand(value)),
-        ("true", value) => format!("{} || {}", condition, value),
-        ("false", value) => format!("{} && {}", negate_condition(condition), and_operand(value)),
-        (value, "true") => format!("{} || {}", negate_condition(condition), value),
+        (_, "false") => and(and_operand(condition), and_operand(then_value)),
+        ("true", _) => or(condition.clone(), else_value.clone()),
+        ("false", _) => and(negate_condition(condition), and_operand(else_value)),
+        (_, "true") => or(negate_condition(condition), then_value.clone()),
         _ => return None,
     })
 }
 
-fn negate_condition(condition: &str) -> String {
-    if is_plain_identifier(condition) {
-        format!("!{}", condition)
+fn negate_condition(condition: &GoExpression) -> GoExpression {
+    if is_plain_identifier(condition.as_str()) {
+        GoExpression::unary("!", condition.clone())
     } else {
-        format!("!({})", condition)
+        GoExpression::unary("!", GoExpression::parenthesized(condition.clone()))
     }
 }
 
 /// Parenthesize a synthesized `&&` operand, keeping bare identifiers bare.
-fn and_operand(operand: &str) -> String {
-    if is_plain_identifier(operand) {
-        operand.to_string()
+fn and_operand(operand: &GoExpression) -> GoExpression {
+    if is_plain_identifier(operand.as_str()) {
+        operand.clone()
     } else {
-        format!("({})", operand)
+        GoExpression::parenthesized(operand.clone())
     }
 }
 
@@ -319,15 +320,13 @@ impl Planner<'_> {
             let (mut statements, staged_value) = staged.into_parts();
             if !staged_value.is_empty() {
                 if matches!(unwrapped, Expression::Call { .. }) {
-                    let line = format!("{}\n", staged_value);
                     // A never-typed call (e.g. `panic(...)`) diverges.
-                    statements.push(if value_ty.is_never() {
-                        LoweredStatement::DivergingRawGo(line)
-                    } else {
-                        LoweredStatement::RawGo(line)
+                    statements.push(LoweredStatement::ExpressionStatement {
+                        expression: staged_value,
+                        diverges: value_ty.is_never(),
                     });
                 } else {
-                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", staged_value)));
+                    statements.push(discard(staged_value));
                 }
             }
             return statements;
@@ -335,29 +334,33 @@ impl Planner<'_> {
 
         if let Expression::Call { .. } = unwrapped {
             let mut statements: Vec<LoweredStatement> = Vec::new();
-            if let Some(raw) = self.emit_go_call_discarded(&mut statements, unwrapped) {
-                statements.push(LoweredStatement::RawGo(format!("{}\n", raw)));
+            if let Some(call) = self.emit_go_call_discarded(&mut statements, unwrapped) {
+                statements.push(expression_statement(call));
                 return statements;
             }
         }
 
         let staged = self.plan_operand(value, ExpressionContext::value());
         let (mut statements, staged_value) = staged.into_parts();
-        statements.push(LoweredStatement::RawGo(format!("_ = {}\n", staged_value)));
+        statements.push(discard(staged_value));
         statements
     }
 
     /// Emit a unit-typed call as a statement, then store `struct{}{}` into
-    /// `var`.
-    fn lower_unit_call_into_var(&mut self, value: &Expression, var: &str) -> Vec<LoweredStatement> {
-        let (mut statements, call_str) = self
+    /// `target`.
+    fn lower_unit_call_into_var(
+        &mut self,
+        value: &Expression,
+        target: &GoExpression,
+    ) -> Vec<LoweredStatement> {
+        let (mut statements, call) = self
             .lower_value(value, ExpressionContext::value())
             .into_parts();
-        if !call_str.is_empty() {
-            statements.push(LoweredStatement::RawGo(format!("{call_str}\n")));
+        if !call.is_empty() {
+            statements.push(expression_statement(call));
         }
         statements.push(simple_assign(
-            var,
+            target,
             ValuePlan::computed(
                 Vec::new(),
                 GoExpression::empty_composite("struct{}".to_string()),
@@ -370,18 +373,18 @@ impl Planner<'_> {
     pub(crate) fn lower_assign(
         &mut self,
         expression: &Expression,
-        var: &str,
+        target: &GoExpression,
         target_ty: Option<&Type>,
     ) -> Vec<LoweredStatement> {
         let ty = expression.get_type();
         let is_fallible = ty.is_result() || ty.is_option();
         if is_fallible {
-            return self.lower_option_result_assignment(var, target_ty, expression);
+            return self.lower_option_result_assignment(target, target_ty, expression);
         }
 
         if let Expression::Loop { body, .. } = expression {
-            let plan = self.with_loop(var, |this| {
-                this.lower_loop_with_header("for {\n".to_string(), body)
+            let plan = self.with_loop(target.as_str(), |this| {
+                this.lower_loop_with_header(LoopHeader::Infinite, body)
             });
             return vec![LoweredStatement::Loop(plan)];
         }
@@ -389,29 +392,29 @@ impl Planner<'_> {
         if let Expression::Block { items, .. } = expression
             && items.len() > 1
         {
-            let statements = self.lower_block_to_var(expression, var, target_ty, true);
+            let statements = self.lower_block_to_var(expression, target, target_ty, true);
             return vec![LoweredStatement::Block(LoweredBlock { statements })];
         }
 
-        self.lower_block_to_var(expression, var, target_ty, false)
+        self.lower_block_to_var(expression, target, target_ty, false)
     }
 
     fn lower_plain_assign(
         &mut self,
-        target_var: &str,
+        target: &GoExpression,
         expression: &Expression,
     ) -> Vec<LoweredStatement> {
         let value = self.plan_operand(expression, ExpressionContext::value());
-        vec![simple_assign(target_var, value)]
+        vec![simple_assign(target, value)]
     }
 
-    /// Assign an `Option`/`Result`-typed expression into `target_var`.
+    /// Assign an `Option`/`Result`-typed expression into `target`.
     /// `Ok`/`Err`/`Some`/`None` constructors become a structured `Simple`
     /// assignment of the constructor call; everything else falls back to a plain
     /// assign or `lower_block_to_var`.
     pub(crate) fn lower_option_result_assignment(
         &mut self,
-        target_var: &str,
+        target: &GoExpression,
         target_ty: Option<&Type>,
         expression: &Expression,
     ) -> Vec<LoweredStatement> {
@@ -420,7 +423,7 @@ impl Planner<'_> {
             .filter(|t| t.is_option() || t.is_result())
             .unwrap_or_else(|| self.facts.peel_alias(&expression.get_type()));
         let Some(fallible) = Fallible::from_type(&ty) else {
-            return self.lower_plain_assign(target_var, expression);
+            return self.lower_plain_assign(target, expression);
         };
 
         let actual_expression = if let Expression::Block { items, .. } = expression {
@@ -451,7 +454,7 @@ impl Planner<'_> {
                     ),
                     Some(ConstructorKind::Failure) => (fallible.err_constructor(), None),
                     None => {
-                        return self.lower_plain_assign(target_var, expression);
+                        return self.lower_plain_assign(target, expression);
                     }
                 };
                 if let Some(constructor_arg) = constructor_arg {
@@ -472,14 +475,14 @@ impl Planner<'_> {
                         call,
                         EvaluationEffect::PureCall.combine(argument_effect),
                     );
-                    vec![simple_assign(target_var, value)]
+                    vec![simple_assign(target, value)]
                 } else {
                     let call = {
                         let mut fe = FalliblePlanner::new(self, &fallible);
                         fe.format_constructor_call(constructor_name, None)
                     };
                     vec![simple_assign(
-                        target_var,
+                        target,
                         ValuePlan::computed(Vec::new(), call, EvaluationEffect::Pure),
                     )]
                 }
@@ -493,24 +496,24 @@ impl Planner<'_> {
                         fe.format_constructor_call(fallible.err_constructor(), None)
                     };
                     vec![simple_assign(
-                        target_var,
+                        target,
                         ValuePlan::computed(Vec::new(), call, EvaluationEffect::Pure),
                     )]
                 } else {
-                    self.lower_plain_assign(target_var, expression)
+                    self.lower_plain_assign(target, expression)
                 }
             }
-            _ => self.lower_block_to_var(expression, target_var, None, false),
+            _ => self.lower_block_to_var(expression, target, None, false),
         }
     }
 
-    /// Lower a block (or single expression) that assigns its tail into `var`.
+    /// Lower a block (or single expression) that assigns its tail into `target`.
     /// `has_go_braces` selects the scope discipline: a full Go-brace scope when
     /// the caller wraps the result in `{ }`, otherwise a binding frame.
     pub(crate) fn lower_block_to_var(
         &mut self,
         expression: &Expression,
-        var: &str,
+        target: &GoExpression,
         target_ty: Option<&Type>,
         has_go_braces: bool,
     ) -> Vec<LoweredStatement> {
@@ -525,12 +528,12 @@ impl Planner<'_> {
             let Some((last, rest)) = items.split_last() else {
                 return Vec::new();
             };
-            this.with_assign_target(var, |this| {
+            this.with_assign_target(target.as_str(), |this| {
                 let mut statements = Vec::new();
                 for item in rest {
                     statements.push(this.lower_statement(item));
                 }
-                statements.extend(this.lower_assign_tail(last, var, target_ty));
+                statements.extend(this.lower_assign_tail(last, target, target_ty));
                 statements
             })
         })
@@ -552,11 +555,11 @@ impl Planner<'_> {
         }
     }
 
-    /// Lower a single tail expression in assign position into `var`.
+    /// Lower a single tail expression in assign position into `target`.
     fn lower_assign_tail(
         &mut self,
         last: &Expression,
-        var: &str,
+        target: &GoExpression,
         target_ty: Option<&Type>,
     ) -> Vec<LoweredStatement> {
         if matches!(
@@ -580,9 +583,9 @@ impl Planner<'_> {
             return statements;
         }
         if is_unit_call(last) {
-            return self.lower_unit_call_into_var(last, var);
+            return self.lower_unit_call_into_var(last, target);
         }
-        if let Some(statements) = self.lower_slice_growth_to_var(var, last) {
+        if let Some(statements) = self.lower_slice_growth_to_var(target, last) {
             return statements;
         }
         if matches!(
@@ -593,7 +596,7 @@ impl Planner<'_> {
                 | Expression::Select { .. }
         ) {
             let place = PlacePlan::Assign {
-                local: var,
+                local: target,
                 target_ty,
             };
             return self.lower_branching_to_block(last, &place).statements;
@@ -601,21 +604,16 @@ impl Planner<'_> {
         let value = self.lower_value(last, ExpressionContext::value());
         let value = value.map_expression_as_computed(|setup, expression| {
             let contains_deferred_evaluation = expression.contains_deferred_evaluation();
-            let mut coercion_buffer = String::new();
-            let expression =
-                self.apply_type_coercion(&mut coercion_buffer, target_ty, last, expression);
-            if !coercion_buffer.is_empty() {
-                setup.push(LoweredStatement::RawGo(coercion_buffer));
-            }
+            let expression = self.apply_type_coercion(setup, target_ty, last, expression);
             expression.with_deferred_evaluation(contains_deferred_evaluation)
         });
-        vec![simple_assign(var, value)]
+        vec![simple_assign(target, value)]
     }
 
     /// `None` when `last` is not a slice `append` or `reserve` call.
     fn lower_slice_growth_to_var(
         &mut self,
-        var: &str,
+        target: &GoExpression,
         last: &Expression,
     ) -> Option<Vec<LoweredStatement>> {
         let Expression::Call {
@@ -639,15 +637,20 @@ impl Planner<'_> {
             let receiver_lv =
                 self.emit_left_value_capturing(&mut capture, unwrapped, Some(&ordering));
             let grows = !arguments.is_empty();
-            let receiver = if grows && receiver_lv != var {
-                let clippable = if is_clip_safe_path(&receiver_lv) && ordering.setup.is_empty() {
-                    receiver_lv
-                } else {
-                    self.hoist_tmp_value_statement(&mut capture, "recv", &receiver_lv)
-                };
-                clip_shared_capacity(GoExpression::opaque(clippable))
+            let receiver = if grows && receiver_lv.as_str() != target.as_str() {
+                let clippable =
+                    if is_clip_safe_path(receiver_lv.as_str()) && ordering.setup.is_empty() {
+                        receiver_lv
+                    } else {
+                        GoExpression::name(self.hoist_tmp_value_statement(
+                            &mut capture,
+                            "recv",
+                            receiver_lv,
+                        ))
+                    };
+                clip_shared_capacity(clippable)
             } else {
-                GoExpression::opaque(receiver_lv)
+                receiver_lv
             };
             capture.extend(ordering.setup);
             let value = if method == "reserve" {
@@ -669,7 +672,7 @@ impl Planner<'_> {
         };
 
         statements.push(simple_assign(
-            var,
+            target,
             ValuePlan::computed(Vec::new(), value, EvaluationEffect::Pure),
         ));
         Some(statements)
@@ -748,7 +751,8 @@ impl Planner<'_> {
             }
             let (result_var, declaration) = self.operand_temp_declaration(ty);
             let needs_braces = items.len() > 1;
-            let body = self.lower_block_to_var(expression, &result_var, None, needs_braces);
+            let target = GoExpression::name(result_var.clone());
+            let body = self.lower_block_to_var(expression, &target, None, needs_braces);
             let mut statements = vec![declaration];
             if needs_braces {
                 statements.push(LoweredStatement::Block(LoweredBlock { statements: body }));
@@ -762,7 +766,8 @@ impl Planner<'_> {
         }
         let (result_var, declaration) = self.operand_temp_declaration(ty);
         let mut statements = vec![declaration];
-        statements.extend(self.lower_assign(expression, &result_var, Some(ty)));
+        let target = GoExpression::name(result_var.clone());
+        statements.extend(self.lower_assign(expression, &target, Some(ty)));
         ValuePlan::captured(statements, result_var)
     }
 

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -1,8 +1,10 @@
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
-use crate::plan::bodies::LoweredStatement;
-use crate::plan::go_expression::{CompositeElement, CompositeLayout, GoExpressionNode};
+use crate::plan::bodies::{LoweredBlock, LoweredStatement};
+use crate::plan::go_expression::{
+    CompositeElement, CompositeLayout, FunctionLiteralLayout, GoExpressionNode,
+};
 use std::fmt::{self, Display, Formatter};
 use syntax::ast::Expression;
 use syntax::types::SimpleKind;
@@ -122,22 +124,19 @@ impl GoExpression {
         )
     }
 
-    pub(crate) fn opaque(rendered: String) -> Self {
-        Self::opaque_with_deferred_evaluation(rendered, false)
+    pub(crate) fn nil() -> Self {
+        Self::literal("nil".to_string())
     }
 
     /// The value of a lowering that produced only statements.
     pub(crate) fn empty() -> Self {
-        Self::opaque(String::new())
+        Self::new(GoExpressionNode::Empty, false, false, OperandForm::Other)
     }
 
-    pub(crate) fn opaque_with_deferred_evaluation(
-        rendered: String,
-        contains_deferred_evaluation: bool,
-    ) -> Self {
+    pub(crate) fn verbatim(source: String) -> Self {
         Self::new(
-            GoExpressionNode::Raw(rendered),
-            contains_deferred_evaluation,
+            GoExpressionNode::Verbatim(source),
+            false,
             false,
             OperandForm::Other,
         )
@@ -270,6 +269,36 @@ impl GoExpression {
         )
     }
 
+    pub(crate) fn function_literal(
+        parameters: String,
+        result: String,
+        body: LoweredBlock,
+        layout: FunctionLiteralLayout,
+    ) -> Self {
+        Self::new(
+            GoExpressionNode::FunctionLiteral {
+                parameters,
+                result,
+                body,
+                layout,
+            },
+            false,
+            false,
+            OperandForm::Other,
+        )
+    }
+
+    pub(crate) fn immediate_call(
+        result: String,
+        body: LoweredBlock,
+        layout: FunctionLiteralLayout,
+    ) -> Self {
+        Self::call(
+            Self::function_literal(String::new(), result, body, layout),
+            Vec::new(),
+        )
+    }
+
     pub(crate) fn call(callee: GoExpression, arguments: Vec<GoExpression>) -> Self {
         let node = GoExpressionNode::Call {
             callee: Box::new(callee.node),
@@ -279,15 +308,6 @@ impl GoExpression {
                 .collect(),
         };
         Self::new(node, true, false, OperandForm::Call)
-    }
-
-    pub(crate) fn receive(channel: GoExpression) -> Self {
-        Self::new(
-            GoExpressionNode::Receive(Box::new(channel.node)),
-            true,
-            false,
-            OperandForm::Other,
-        )
     }
 
     pub(crate) fn binary(
@@ -525,12 +545,14 @@ impl EvaluationFacts {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ValuePlan {
     pub setup: Vec<LoweredStatement>,
     pub expression: GoExpression,
     pub evaluation: EvaluationFacts,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SequencedValues {
     pub setup: Vec<LoweredStatement>,
     pub values: Vec<GoExpression>,
@@ -538,16 +560,6 @@ pub(crate) struct SequencedValues {
 }
 
 impl SequencedValues {
-    pub(crate) fn into_rendered(self) -> (Vec<LoweredStatement>, Vec<String>) {
-        (
-            self.setup,
-            self.values
-                .into_iter()
-                .map(|value| value.rendered())
-                .collect(),
-        )
-    }
-
     pub(crate) fn contains_deferred_evaluation(&self) -> bool {
         self.values
             .iter()
@@ -664,10 +676,10 @@ impl ValuePlan {
         )
     }
 
-    pub(crate) fn opaque(value: String) -> Self {
+    pub(crate) fn verbatim(source: String) -> Self {
         Self::computed(
             Vec::new(),
-            GoExpression::opaque(value),
+            GoExpression::verbatim(source),
             EvaluationEffect::Pure,
         )
     }
@@ -778,8 +790,8 @@ impl ValuePlan {
         self.expression.is_empty()
     }
 
-    pub(crate) fn into_parts(self) -> (Vec<LoweredStatement>, String) {
-        (self.setup, self.expression.rendered())
+    pub(crate) fn into_parts(self) -> (Vec<LoweredStatement>, GoExpression) {
+        (self.setup, self.expression)
     }
 
     pub(crate) fn parenthesized(mut self) -> Self {

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -1,12 +1,19 @@
 use crate::plan::bodies::{
-    AssignForm, BreakValueAction, BreakValuePlan, CompoundKind, ConstPlan, ElseArm,
-    ExpressionStatementForm, IfPlan, LetPlan, LoopPlan, LoopTransfer, LoweredBlock,
-    LoweredStatement, ReturnForm, SelectArmPlan, SelectStatementPlan, SwitchKind,
-    SwitchStatementPlan,
+    AssignForm, BreakValueAction, BreakValuePlan, CompoundKind, ConstPlan, Definition, ElseArm,
+    IfPlan, LetPlan, LoopHeader, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
+    ReturnForm, SelectArmPlan, SelectStatementPlan, SwitchKind, SwitchStatementPlan,
 };
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{GoExpression, ValuePlan};
 use crate::render::Renderer;
 use crate::write_line;
+
+fn join_expressions(values: &[GoExpression]) -> String {
+    values
+        .iter()
+        .map(GoExpression::as_str)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 impl Renderer {
     /// Render a slice of setup statements to a fresh `String`.
@@ -66,7 +73,7 @@ impl Renderer {
             } => write_line!(output, "switch {}.(type) {{", subject),
         }
         for case in &plan.cases {
-            write_line!(output, "case {}:", case.labels);
+            write_line!(output, "case {}:", join_expressions(&case.labels));
             self.render_lowered_block(output, &case.body);
         }
         if let Some(default_body) = &plan.default {
@@ -92,8 +99,12 @@ impl Renderer {
                 }
                 self.render_lowered_block(output, body);
             }
-            SelectArmPlan::Send { operation, body } => {
-                write_line!(output, "case {}:", operation.rendered());
+            SelectArmPlan::Send {
+                channel,
+                value,
+                body,
+            } => {
+                write_line!(output, "case {} <- {}:", channel, value);
                 self.render_lowered_block(output, body);
             }
             SelectArmPlan::Default { body } => {
@@ -101,6 +112,12 @@ impl Renderer {
                 self.render_lowered_block(output, body);
             }
         }
+    }
+
+    fn render_definition(&self, output: &mut String, definition: &Definition) {
+        output.push_str(&definition.names.join(", "));
+        output.push_str(" := ");
+        output.push_str(definition.value.as_str());
     }
 
     fn render_statement(&self, output: &mut String, statement: &LoweredStatement) {
@@ -130,16 +147,17 @@ impl Renderer {
             LoweredStatement::Assign(plan) => {
                 self.render_assign_statement(output, plan);
             }
-            LoweredStatement::Expression(plan) => {
-                self.render_expression_statement(output, plan);
+            LoweredStatement::Async { keyword, call } => {
+                write_line!(output, "{} {}", keyword, call);
             }
             LoweredStatement::Select(plan) => self.render_select(output, plan),
             LoweredStatement::Switch(plan) => self.render_switch(output, plan),
             LoweredStatement::WhileLet(body) => {
                 self.render_lowered_block(output, body);
             }
-            LoweredStatement::TempBind { name, value } => {
-                write_line!(output, "{} := {}", name, value);
+            LoweredStatement::Define(definition) => {
+                self.render_definition(output, definition);
+                output.push('\n');
             }
             LoweredStatement::VarDecl {
                 name,
@@ -149,45 +167,20 @@ impl Renderer {
                 Some(value) => write_line!(output, "var {} {} = {}", name, go_type, value),
                 None => write_line!(output, "var {} {}", name, go_type),
             },
-            LoweredStatement::ClosureBind {
-                name,
-                closure_open,
-                body,
-                closure_close,
-            } => {
-                write_line!(
-                    output,
-                    "{} := {}",
-                    name,
-                    closure_open.trim_end_matches('\n')
-                );
-                self.render_lowered_block(output, body);
-                output.push_str(closure_close);
+            LoweredStatement::Discard(value) => write_line!(output, "_ = {}", value),
+            LoweredStatement::AssignMany { targets, value } => {
+                write_line!(output, "{} = {}", join_expressions(targets), value);
+            }
+            LoweredStatement::ExpressionStatement { expression, .. } => {
+                if !expression.is_empty() {
+                    write_line!(output, "{}", expression);
+                }
             }
             LoweredStatement::Directed { directive, inner } => {
                 output.push_str(directive);
                 self.render_statement(output, inner);
             }
-            LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
-                output.push_str(code)
-            }
             LoweredStatement::UnreachablePanic => output.push_str("panic(\"unreachable\")\n"),
-        }
-    }
-
-    fn render_expression_statement(&self, output: &mut String, plan: &ExpressionStatementForm) {
-        match plan {
-            ExpressionStatementForm::Async { value } => {
-                let value_text = self.render_value(output, value);
-                if !value_text.is_empty() {
-                    write_line!(output, "{}", value_text);
-                }
-            }
-            ExpressionStatementForm::AsyncBlock { keyword, body } => {
-                write_line!(output, "{} func() {{", keyword);
-                self.render_lowered_block(output, body);
-                output.push_str("}()\n");
-            }
         }
     }
 
@@ -202,13 +195,13 @@ impl Renderer {
         match plan {
             AssignForm::Compound {
                 target_capture,
-                target_str,
+                target,
                 kind,
             } => {
                 self.render_capture_statements(output, target_capture);
                 match kind {
-                    CompoundKind::Increment => write_line!(output, "{}++", target_str),
-                    CompoundKind::Decrement => write_line!(output, "{}--", target_str),
+                    CompoundKind::Increment => write_line!(output, "{}++", target),
+                    CompoundKind::Decrement => write_line!(output, "{}--", target),
                     CompoundKind::OpAssign {
                         op_text,
                         rhs,
@@ -216,16 +209,18 @@ impl Renderer {
                     } => {
                         let rhs_text = self.render_value(output, rhs);
                         match pinned_left {
-                            Some(left) => write_line!(
-                                output,
-                                "{} = {} {} {}",
-                                target_str,
-                                left,
-                                op_text,
-                                rhs_text
-                            ),
+                            Some(left) => {
+                                write_line!(
+                                    output,
+                                    "{} = {} {} {}",
+                                    target,
+                                    left,
+                                    op_text,
+                                    rhs_text
+                                )
+                            }
                             None => {
-                                write_line!(output, "{} {}= {}", target_str, op_text, rhs_text)
+                                write_line!(output, "{} {}= {}", target, op_text, rhs_text)
                             }
                         }
                     }
@@ -233,18 +228,17 @@ impl Renderer {
             }
             AssignForm::Simple {
                 target_capture,
-                target_str,
+                target,
                 value,
             } => {
                 self.render_capture_statements(output, target_capture);
                 let value_text = self.render_value(output, value);
-                write_line!(output, "{} = {}", target_str, value_text);
+                write_line!(output, "{} = {}", target, value_text);
             }
         }
     }
 
-    /// Render a sequence of capture statements (order-sensitive lvalue
-    /// setup). The statements are `RawGo` today.
+    /// Render a sequence of capture statements (order-sensitive lvalue setup).
     fn render_capture_statements(&self, output: &mut String, statements: &[LoweredStatement]) {
         for statement in statements {
             self.render_statement(output, statement);
@@ -264,7 +258,7 @@ impl Renderer {
                 output.push_str("return\n");
             }
             ReturnForm::Multi { values } => {
-                write_line!(output, "return {}", values.join(", "));
+                write_line!(output, "return {}", join_expressions(values));
             }
             ReturnForm::Body { body } => {
                 self.render_lowered_block(output, body);
@@ -340,20 +334,59 @@ impl Renderer {
     }
 
     fn render_loop(&self, output: &mut String, plan: &LoopPlan) {
-        debug_assert!(!plan.header.is_empty(), "loop header must not be empty");
         output.push_str(&self.render_setup(&plan.prologue));
         if let Some(label) = plan.kind.label() {
             write_line!(output, "{}:", label);
         }
-        output.push_str(&plan.header);
+        match &plan.header {
+            LoopHeader::Infinite => output.push_str("for {\n"),
+            LoopHeader::While(condition) => write_line!(output, "for {} {{", condition),
+            LoopHeader::Range {
+                key,
+                value,
+                iterable,
+            } => match (key, value) {
+                (None, None) => write_line!(output, "for range {} {{", iterable),
+                (Some(key), None) => write_line!(output, "for {} := range {} {{", key, iterable),
+                (key, Some(value)) => write_line!(
+                    output,
+                    "for {}, {} := range {} {{",
+                    key.as_deref().unwrap_or("_"),
+                    value,
+                    iterable
+                ),
+            },
+            LoopHeader::Counted {
+                variable,
+                start,
+                condition,
+            } => write_line!(
+                output,
+                "for {} := {}; {}; {}++ {{",
+                variable,
+                start,
+                condition.as_ref().map_or("", GoExpression::as_str),
+                variable
+            ),
+        }
         self.render_lowered_block(output, &plan.body);
         output.push_str("}\n");
     }
 
-    fn render_if(&self, output: &mut String, plan: &IfPlan) {
+    fn render_if_header(&self, output: &mut String, plan: &IfPlan) {
         debug_assert!(!plan.condition.is_empty(), "if condition must not be empty");
+        output.push_str("if ");
+        if let Some(initializer) = &plan.initializer {
+            self.render_definition(output, initializer);
+            output.push_str("; ");
+        }
+        output.push_str(plan.condition.as_str());
+        output.push_str(" {\n");
+    }
+
+    fn render_if(&self, output: &mut String, plan: &IfPlan) {
         output.push_str(&self.render_setup(&plan.condition_setup));
-        write_line!(output, "if {} {{", plan.condition);
+        self.render_if_header(output, plan);
         self.render_lowered_block(output, &plan.then_body);
         self.render_else_arm(output, &plan.else_arm);
     }
@@ -362,19 +395,16 @@ impl Renderer {
         match arm {
             ElseArm::None => output.push_str("}\n"),
             ElseArm::ElseIf(plan) => {
-                debug_assert!(
-                    !plan.condition.is_empty(),
-                    "else-if condition must not be empty"
-                );
                 if !plan.condition_setup.is_empty() {
                     output.push_str("} else {\n");
                     output.push_str(&self.render_setup(&plan.condition_setup));
-                    write_line!(output, "if {} {{", plan.condition);
+                    self.render_if_header(output, plan);
                     self.render_lowered_block(output, &plan.then_body);
                     self.render_else_arm(output, &plan.else_arm);
                     output.push_str("}\n");
                 } else {
-                    write_line!(output, "}} else if {} {{", plan.condition);
+                    output.push_str("} else ");
+                    self.render_if_header(output, plan);
                     self.render_lowered_block(output, &plan.then_body);
                     self.render_else_arm(output, &plan.else_arm);
                 }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -5,7 +5,7 @@ use crate::context::expression::ExpressionContext;
 use crate::expressions::staging::LaterStages;
 use crate::is_order_sensitive;
 use crate::names::go_name;
-use crate::plan::bodies::{AssignForm, CompoundKind, LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{AssignForm, CompoundKind, LoweredBlock, LoweredStatement, define};
 use crate::plan::values::{GoExpression, ValuePlan};
 use crate::state::bindings::BindingValue;
 use syntax::ast::Literal;
@@ -66,7 +66,7 @@ impl Planner<'_> {
                 ExpressionContext::value().with_retired_receiver(target),
             )
         });
-        let (target_capture, target_str) =
+        let (target_capture, target_place) =
             self.capture_assignment_target(target, Some(&right_hand_side));
         let coercion = if is_literal_slot {
             CoercionPlan::Identity
@@ -84,7 +84,7 @@ impl Planner<'_> {
         });
         LoweredStatement::Assign(AssignForm::Simple {
             target_capture,
-            target_str,
+            target: target_place,
             value,
         })
     }
@@ -105,26 +105,23 @@ impl Planner<'_> {
             } else {
                 CompoundKind::Decrement
             };
-            let (target_capture, target_str) = self.capture_assignment_target(target, None);
+            let (target_capture, target_place) = self.capture_assignment_target(target, None);
             return AssignForm::Compound {
                 target_capture,
-                target_str,
+                target: target_place,
                 kind,
             };
         }
 
         let right_hand_side = self.plan_operand(rhs, ExpressionContext::value());
-        let (mut target_capture, target_str) =
+        let (mut target_capture, target_place) =
             self.capture_assignment_target(target, Some(&right_hand_side));
         let needs_left_pin =
             later_stages(Some(&right_hand_side)).can_change(self.place_read_stability(target));
         let pinned_left = needs_left_pin.then(|| {
             let tmp = self.fresh_var(Some("left"));
             self.declare(&tmp);
-            target_capture.push(LoweredStatement::TempBind {
-                name: tmp.clone(),
-                value: target_str.clone(),
-            });
+            target_capture.push(define(tmp.clone(), target_place.clone()));
             tmp
         });
         let parenthesize_rhs =
@@ -148,7 +145,7 @@ impl Planner<'_> {
         };
         AssignForm::Compound {
             target_capture,
-            target_str,
+            target: target_place,
             kind,
         }
     }
@@ -159,14 +156,14 @@ impl Planner<'_> {
         &mut self,
         target: &Expression,
         right_hand_side: Option<&ValuePlan>,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let mut target_capture: Vec<LoweredStatement> = Vec::new();
-        let target_str = if is_order_sensitive(target) {
+        let target = if is_order_sensitive(target) {
             self.emit_left_value_capturing(&mut target_capture, target, right_hand_side)
         } else {
             self.emit_left_value(&mut target_capture, target)
         };
-        (target_capture, target_str)
+        (target_capture, target)
     }
 
     fn target_binds_to_discard(&self, target: &Expression) -> bool {
@@ -184,14 +181,15 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-    ) -> String {
+    ) -> GoExpression {
         let expression = expression.unwrap_parens();
         match expression {
-            Expression::Identifier { value, .. } => self
-                .scope
-                .resolve_binding_go_name(value)
-                .unwrap_or(value)
-                .to_string(),
+            Expression::Identifier { value, .. } => GoExpression::name(
+                self.scope
+                    .resolve_binding_go_name(value)
+                    .unwrap_or(value)
+                    .to_string(),
+            ),
             Expression::DotAccess {
                 expression,
                 member,
@@ -199,21 +197,21 @@ impl Planner<'_> {
                 ..
             } => {
                 let base = expression.deref_inner().unwrap_or(expression);
-                let base_str = self.capture_operand_into(setup, base);
+                let base = self.capture_operand_into(setup, base);
                 let expression_ty = expression.get_type();
-                self.format_dot_access_lvalue(&base_str, &expression_ty, member, resolution)
+                self.format_dot_access_lvalue(base, &expression_ty, member, resolution)
             }
             Expression::IndexedAccess {
                 expression, index, ..
             } => {
-                let expression_string = if let Some(inner) = expression.deref_inner() {
-                    let inner_str = self.capture_operand_into(setup, inner);
-                    format!("(*{})", inner_str)
+                let base = if let Some(inner) = expression.deref_inner() {
+                    let inner = self.capture_operand_into(setup, inner);
+                    GoExpression::parenthesized(GoExpression::dereference(inner))
                 } else {
                     self.capture_operand_into(setup, expression)
                 };
-                let index_str = self.capture_operand_into(setup, index);
-                format!("{}[{}]", expression_string, index_str)
+                let index = self.capture_operand_into(setup, index);
+                GoExpression::index(base, index)
             }
             Expression::Unary {
                 operator: UnaryOperator::Deref,
@@ -221,10 +219,10 @@ impl Planner<'_> {
                 ..
             } => self.emit_deref_lvalue(setup, expression, None),
             Expression::Call { .. } if expression.get_type().is_ref() => {
-                let call_str = self.capture_operand_into(setup, expression);
-                self.hoist_tmp_value_statement(setup, "ref", &call_str)
+                let call = self.capture_operand_into(setup, expression);
+                GoExpression::name(self.hoist_tmp_value_statement(setup, "ref", call))
             }
-            _ => "_".to_string(),
+            _ => GoExpression::name("_".to_string()),
         }
     }
 
@@ -236,17 +234,17 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         pointee: &Expression,
         right_hand_side: Option<&ValuePlan>,
-    ) -> String {
+    ) -> GoExpression {
         let pointee_plan = self.plan_operand(pointee, ExpressionContext::value());
         let needs_capture = matches!(pointee.unwrap_parens(), Expression::Call { .. })
             || later_stages(right_hand_side).can_change(pointee_plan.evaluation.stability);
-        let (pointee_setup, pointee_string) = pointee_plan.into_parts();
+        let (pointee_setup, pointee_value) = pointee_plan.into_parts();
         setup.extend(pointee_setup);
         if needs_capture {
-            let tmp = self.hoist_tmp_value_statement(setup, "ref", &pointee_string);
-            return format!("*{}", tmp);
+            let tmp = self.hoist_tmp_value_statement(setup, "ref", pointee_value);
+            return GoExpression::dereference(GoExpression::name(tmp));
         }
-        format!("*{}", pointee_string)
+        GoExpression::dereference(pointee_value)
     }
 
     /// Format a dot-access lvalue (struct field or tuple element) onto the
@@ -254,18 +252,19 @@ impl Planner<'_> {
     /// tuple-struct field helper (newtype unwrap) or positional `Fi` fallback.
     fn format_dot_access_lvalue(
         &mut self,
-        base_str: &str,
+        base: GoExpression,
         expression_ty: &Type,
         member: &str,
         resolution: &DotAccessResolution,
-    ) -> String {
+    ) -> GoExpression {
         if let Ok(index) = member.parse::<usize>() {
-            let access = self.try_emit_tuple_struct_field_access(base_str, expression_ty, index);
+            let access =
+                self.try_emit_tuple_struct_field_access(base.clone(), expression_ty, index);
             if let Some(access) = access {
                 return access;
             }
             let field = TUPLE_FIELDS.get(index).expect("oversize tuple arity");
-            return format!("{}.{}", base_str, field);
+            return GoExpression::selector(base, field.to_string());
         }
         let field = if resolution_exports_field(resolution)
             || self.struct_field_is_exported(expression_ty, member)
@@ -276,7 +275,7 @@ impl Planner<'_> {
         } else {
             go_name::unexported_method_go_name(member)
         };
-        format!("{}.{}", base_str, field)
+        GoExpression::selector(base, field)
     }
 
     /// Emit a left-value, capturing side-effecting subexpressions (index, base)
@@ -287,7 +286,7 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
         right_hand_side: Option<&ValuePlan>,
-    ) -> String {
+    ) -> GoExpression {
         let expression = expression.unwrap_parens();
         match expression {
             Expression::IndexedAccess {
@@ -296,10 +295,10 @@ impl Planner<'_> {
                 ..
             } => {
                 if assignment_requires_target_capture(right_hand_side) {
-                    let base_str = self.emit_indexed_base_lvalue(setup, base, right_hand_side);
-                    let index_str =
+                    let base = self.emit_indexed_base_lvalue(setup, base, right_hand_side);
+                    let index =
                         self.capture_assignment_operand(setup, index, "idx", right_hand_side);
-                    format!("{}[{}]", base_str, index_str)
+                    GoExpression::index(base, index)
                 } else {
                     self.emit_indexed_lvalue_inline(setup, base, index)
                 }
@@ -310,7 +309,7 @@ impl Planner<'_> {
                 resolution,
                 ..
             } => {
-                let base_str = if let Some(inner) = base.deref_inner() {
+                let base_value = if let Some(inner) = base.deref_inner() {
                     self.capture_assignment_operand(setup, inner, "ref", right_hand_side)
                 } else if is_order_sensitive(base) {
                     self.emit_left_value_capturing(setup, base, right_hand_side)
@@ -320,7 +319,7 @@ impl Planner<'_> {
                     self.emit_left_value(setup, base)
                 };
                 let expression_ty = base.get_type();
-                self.format_dot_access_lvalue(&base_str, &expression_ty, member, resolution)
+                self.format_dot_access_lvalue(base_value, &expression_ty, member, resolution)
             }
             Expression::Unary {
                 operator: UnaryOperator::Deref,
@@ -336,7 +335,7 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         base: &Expression,
         index: &Expression,
-    ) -> String {
+    ) -> GoExpression {
         let base_staged = self.stage_base_with_deref(base);
         let (seq_setup, value) = self
             .sequence_indexed_access(base, base_staged, index, "base")
@@ -350,10 +349,10 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         base: &Expression,
         right_hand_side: Option<&ValuePlan>,
-    ) -> String {
+    ) -> GoExpression {
         if let Some(inner) = base.deref_inner() {
-            let inner_str = self.capture_assignment_operand(setup, inner, "base", right_hand_side);
-            format!("(*{})", inner_str)
+            let inner = self.capture_assignment_operand(setup, inner, "base", right_hand_side);
+            GoExpression::parenthesized(GoExpression::dereference(inner))
         } else {
             self.capture_assignment_operand(setup, base, "base", right_hand_side)
         }
@@ -365,13 +364,13 @@ impl Planner<'_> {
         expression: &Expression,
         prefix: &str,
         right_hand_side: Option<&ValuePlan>,
-    ) -> String {
+    ) -> GoExpression {
         let plan = self.lower_composite_value(expression, ExpressionContext::value());
         let pin = later_stages(right_hand_side).can_change(plan.evaluation.stability);
         let (value_setup, value) = plan.into_parts();
         setup.extend(value_setup);
         if pin {
-            self.hoist_tmp_value_statement(setup, prefix, &value)
+            GoExpression::name(self.hoist_tmp_value_statement(setup, prefix, value))
         } else {
             value
         }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -6,12 +6,15 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::Fallible;
 use crate::escape_reserved;
 use crate::patterns::sites::{AnnotatedPattern, PatternSubject};
-use crate::plan::bodies::{LetPlan, LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{
+    LetPlan, LoweredBlock, LoweredStatement, define, define_many, expression_statement,
+};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::placement::{
     collapse_declared_temp, expression_contains_binding, is_unit_call, rebind_trailing_temp,
     requires_temp_var,
 };
+use crate::plan::values::GoExpression;
 use syntax::ast::{Binding, Expression, Pattern};
 use syntax::types::Type;
 
@@ -190,26 +193,21 @@ impl Planner<'_> {
         let (mut statements, value_expression) = self
             .lower_value(value, ExpressionContext::value())
             .into_parts();
-        statements.push(LoweredStatement::RawGo(format!("{}\n", value_expression)));
+        statements.push(expression_statement(value_expression));
         let Some(raw_go_name) = raw_go_name else {
             return statements;
         };
+        let unit = || GoExpression::empty_composite("struct{}".to_string());
         let escaped = escape_reserved(raw_go_name);
         if self.shadows_declaration(&escaped) {
             let fresh = self.fresh_var(Some(identifier));
             self.declare(&fresh);
-            statements.push(LoweredStatement::TempBind {
-                name: fresh.clone(),
-                value: "struct{}{}".to_string(),
-            });
+            statements.push(define(fresh.clone(), unit()));
             self.scope.bind(identifier, &fresh);
         } else {
             let go_identifier = self.scope.bind(identifier, raw_go_name);
             self.try_declare(&go_identifier);
-            statements.push(LoweredStatement::TempBind {
-                name: go_identifier,
-                value: "struct{}{}".to_string(),
-            });
+            statements.push(define(go_identifier, unit()));
         }
         statements
     }
@@ -239,7 +237,6 @@ impl Planner<'_> {
         let constant_needs_type =
             coercion.is_identity() && self.constant_needs_go_type(constant, binding_ty).is_some();
         let (coercion_setup, value_expression) = coercion.lower(self, plan.expression);
-        let value_expression = value_expression.rendered();
         statements.extend(coercion_setup);
 
         let bound = self.scope.bind(identifier, raw_go_name);
@@ -263,15 +260,14 @@ impl Planner<'_> {
             return statements;
         }
         // A temp no source binding answers to has no other reader to break.
-        if !self.scope.has_binding_for_go_name(&value_expression)
-            && rebind_trailing_temp(&mut statements, &go_identifier, &value_expression)
+        if !self
+            .scope
+            .has_binding_for_go_name(value_expression.as_str())
+            && rebind_trailing_temp(&mut statements, &go_identifier, value_expression.as_str())
         {
             return statements;
         }
-        statements.push(LoweredStatement::TempBind {
-            name: go_identifier,
-            value: value_expression,
-        });
+        statements.push(define(go_identifier, value_expression));
         statements
     }
 
@@ -326,7 +322,11 @@ impl Planner<'_> {
             }
             self.try_declare(name);
         }
-        statements.extend(self.lower_assign(value, name, Some(binding_ty)));
+        statements.extend(self.lower_assign(
+            value,
+            &GoExpression::name(name.to_string()),
+            Some(binding_ty),
+        ));
         collapse_declared_temp(&mut statements, name);
         statements
     }
@@ -599,7 +599,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             })
             .collect();
 
-        let (mut statements, call_str) = self
+        let (mut statements, call) = self
             .planner
             .lower_call(self.value, None, ExpressionContext::value())
             .into_parts();
@@ -609,13 +609,14 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             self.planner.try_declare(go_name);
         }
 
-        let op = if any_new { ":=" } else { "=" };
-        statements.push(LoweredStatement::RawGo(format!(
-            "{} {} {}\n",
-            go_vars.join(", "),
-            op,
-            call_str
-        )));
+        statements.push(if any_new {
+            define_many(go_vars, call)
+        } else {
+            LoweredStatement::AssignMany {
+                targets: go_vars.into_iter().map(GoExpression::name).collect(),
+                value: call,
+            }
+        });
         LoweredBlock { statements }
     }
 }

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -3,6 +3,7 @@ use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::definitions::structs::struct_field_go_name;
 use crate::names::go_name;
 use crate::names::packages::{PackageRequirements, PackageUse};
+use crate::plan::values::GoExpression;
 use crate::types::native::NativeGoType;
 use crate::types::prelude::PreludeType;
 use syntax::ast::ResolvedCallTypeArguments;
@@ -407,14 +408,22 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn zero_value(&self, ty: &Type) -> (String, PackageRequirements) {
+    pub(crate) fn zero_value(&self, ty: &Type) -> (GoExpression, PackageRequirements) {
         let mut packages = PackageRequirements::default();
         if self.facts.is_interface(ty) {
-            return ("nil".to_string(), packages);
+            return (GoExpression::literal("nil".to_string()), packages);
         }
 
         let go_ty = self.go_type(ty);
         packages.extend(go_ty.requirements());
+
+        let literal = |text: &str| GoExpression::literal(text.to_string());
+        let dereferenced_new = |code: &str| {
+            GoExpression::dereference(GoExpression::call(
+                GoExpression::name("new".to_string()),
+                vec![GoExpression::type_name(code.to_string())],
+            ))
+        };
 
         let layout = self.value_layout(ty, SlotOrigin::Lisette);
         let value = match layout {
@@ -431,16 +440,14 @@ impl Planner<'_> {
                 | SimpleKind::Uint64
                 | SimpleKind::Uintptr
                 | SimpleKind::Byte
-                | SimpleKind::Rune => "0".to_string(),
-                SimpleKind::Float32 | SimpleKind::Float64 => "0.0".to_string(),
-                SimpleKind::Bool => "false".to_string(),
-                SimpleKind::String => "\"\"".to_string(),
-                SimpleKind::Unit => "struct{}{}".to_string(),
-                SimpleKind::Complex64 | SimpleKind::Complex128 => {
-                    format!("*new({})", go_ty.code)
-                }
+                | SimpleKind::Rune => literal("0"),
+                SimpleKind::Float32 | SimpleKind::Float64 => literal("0.0"),
+                SimpleKind::Bool => literal("false"),
+                SimpleKind::String => literal("\"\""),
+                SimpleKind::Unit => GoExpression::empty_composite("struct{}".to_string()),
+                SimpleKind::Complex64 | SimpleKind::Complex128 => dereferenced_new(&go_ty.code),
             },
-            ValueLayout::Array { .. } => format!("{}{{}}", go_ty.code),
+            ValueLayout::Array { .. } => GoExpression::empty_composite(go_ty.code),
             ValueLayout::Slice { .. }
             | ValueLayout::Map { .. }
             | ValueLayout::Function { .. }
@@ -454,9 +461,9 @@ impl Planner<'_> {
                     | CompoundKind::Sender
                     | CompoundKind::Receiver,
                 ..
-            }) => "nil".to_string(),
+            }) => literal("nil"),
             ValueLayout::Tuple { .. } | ValueLayout::TaggedOption { .. } => {
-                format!("{}{{}}", go_ty.code)
+                GoExpression::empty_composite(go_ty.code)
             }
             ValueLayout::Plain(Type::Nominal { id, .. })
                 if self
@@ -469,11 +476,17 @@ impl Planner<'_> {
                         )
                     }) =>
             {
-                format!("{}{{}}", go_ty.code)
+                GoExpression::empty_composite(go_ty.code)
             }
-            _ => format!("*new({})", go_ty.code),
+            _ => dereferenced_new(&go_ty.code),
         };
         (value, packages)
+    }
+
+    pub(crate) fn zero_value_expression(&mut self, ty: &Type) -> GoExpression {
+        let (zero, packages) = self.zero_value(ty);
+        self.require_packages(&packages);
+        zero
     }
 
     /// Render a `#[go(anon_struct)]` stand-in as inline `struct{...}`: its name
@@ -514,6 +527,25 @@ fn build_go_import_typed(code: String, package: PackageUse, param_types: &[GoTyp
     let mut result = GoType::with_package(code, package);
     result.merge_all(param_types);
     result
+}
+
+pub(crate) fn split_top_level_type_list(list: &str) -> Vec<&str> {
+    let mut entries = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+    for (i, c) in list.char_indices() {
+        match c {
+            '[' | '(' => depth += 1,
+            ']' | ')' => depth -= 1,
+            ',' if depth == 0 => {
+                entries.push(list[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    entries.push(list[start..].trim());
+    entries
 }
 
 /// Split a recipe like `Map<K, V>, K, V` on commas outside angle brackets, so a

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::plan::values::GoExpression;
 use syntax::ast::{Expression, Literal};
 use syntax::program::{DotAccessKind, ReceiverCoercion};
 use syntax::types::Type;
@@ -9,9 +10,9 @@ macro_rules! write_line {
 }
 pub(crate) use write_line;
 
-pub(crate) fn wrap_if_struct_literal(condition: String) -> String {
-    if condition.contains('{') {
-        format!("({})", condition)
+pub(crate) fn wrap_if_struct_literal(condition: GoExpression) -> GoExpression {
+    if condition.as_str().contains('{') {
+        GoExpression::parenthesized(condition)
     } else {
         condition
     }


### PR DESCRIPTION
Every emitted Go statement is now a typed node whose operands are `GoExpressionNode` trees, so `RawGo` and the other text-holding statement forms are removed and the later emit stages can rewrite statements without parsing Go text. 

Follow-up to #1431