### PR TITLE
refactor: derive pins, imports, and uses from `GoExpressionNode`

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -136,12 +136,10 @@ impl CoercionPlan {
             Self::Identity => value,
             Self::WrapAsInterface(plan) => {
                 let adapter_name = planner.ensure_adapter_type(plan);
-                let deferred = value.contains_deferred_evaluation();
                 GoExpression::composite(
                     Some(adapter_name),
-                    vec![(Some("inner".to_string()), value)],
+                    vec![(Some(GoExpression::name("inner".to_string())), value)],
                     CompositeLayout::Inline { padded: false },
-                    deferred,
                 )
             }
             Self::WrapNewtype { ty } => {

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -9,6 +9,7 @@ use crate::control_flow::fallible::{
     OPTION_SOME_TAG, PARTIAL_ERR_TAG, PARTIAL_OK_TAG, RESULT_OK_TAG,
 };
 use crate::control_flow::propagation::plain_return;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     Definition, ElseArm, IfPlan, LoweredBlock, LoweredStatement, ReturnForm, define, define_many,
 };
@@ -52,7 +53,7 @@ fn has_tag(value: &GoExpression, tag: &str) -> GoExpression {
     GoExpression::binary(
         GoExpression::selector(value.clone(), "Tag".to_string()),
         "==",
-        GoExpression::name(tag.to_string()),
+        GoExpression::generated(GeneratedPackage::Prelude, tag),
     )
 }
 
@@ -179,7 +180,6 @@ pub(crate) fn emit_lowered_result_return(
     return_ty: &Type,
     shape: &CallableReturnAbi,
 ) -> Vec<LoweredStatement> {
-    planner.require_stdlib();
     let p = result_value;
     let ok_ty = || planner.facts.peel_alias(return_ty).ok_type();
     match shape {
@@ -378,7 +378,6 @@ fn emit_return_adapter(
     let return_type = lisette_return_type;
 
     if return_type.is_result() {
-        planner.require_stdlib();
         let shape = if return_type.ok_type().is_unit() {
             CallableReturnAbi::BareError
         } else {
@@ -395,7 +394,6 @@ fn emit_return_adapter(
         ));
     }
     if return_type.is_partial() {
-        planner.require_stdlib();
         let shape = CallableReturnAbi::Partial {
             payload: PayloadLayout::Packed,
         };
@@ -408,7 +406,6 @@ fn emit_return_adapter(
         ));
     }
     if return_type.is_option() {
-        planner.require_stdlib();
         let encoding = if planner.facts.is_nilable_go_type(&return_type.ok_type()) {
             OptionReturnAbi::Nullable
         } else {
@@ -426,7 +423,6 @@ fn emit_return_adapter(
         ));
     }
     if return_type.tuple_arity().is_some_and(|n| n >= 2) {
-        planner.require_stdlib();
         return emit_tuple_return_adapter(planner, inner_call, return_type);
     }
     None
@@ -799,8 +795,6 @@ fn lower_nullable_slot_value(
     let value = planner.lower_value(expression, ExpressionContext::value());
     let inner = planner.use_go_type(&slot_ty.ok_type());
     value.map_expression_as_computed(|setup, value| {
-        planner
-            .plan_option_projection(setup, value, "unwrap", &inner, false)
-            .with_deferred_evaluation(true)
+        planner.plan_option_projection(setup, value, "unwrap", &inner, false)
     })
 }

--- a/crates/emit/src/calls/clone.rs
+++ b/crates/emit/src/calls/clone.rs
@@ -3,7 +3,7 @@ use syntax::types::{CompoundKind, Type};
 
 use crate::Planner;
 use crate::control_flow::propagation::plain_return;
-use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{LoweredBlock, LoweredStatement, assign};
 use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::GoExpression;
@@ -11,46 +11,32 @@ use crate::plan::values::GoExpression;
 impl Planner<'_> {
     pub(crate) fn clone_expression(&mut self, value: GoExpression, ty: &Type) -> GoExpression {
         let peeled = self.facts.peel_alias(ty);
+        let prelude = |name: &str| GoExpression::generated(GeneratedPackage::Prelude, name);
         let (function, closure) = match &peeled {
             Type::Compound {
                 kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
                 args,
                 ..
             } => match args.first().and_then(|elem| self.element_clone(elem)) {
-                Some(clone) => {
-                    self.require_stdlib();
-                    (
-                        format!("{}.SliceCloneFunc", go_name::GO_STDLIB_PKG),
-                        Some(clone),
-                    )
-                }
-                None => {
-                    self.require_slices();
-                    ("slices.Clone".to_string(), None)
-                }
+                Some(clone) => (prelude("SliceCloneFunc"), Some(clone)),
+                None => (
+                    GoExpression::generated(GeneratedPackage::Slices, "Clone"),
+                    None,
+                ),
             },
             Type::Compound {
                 kind: CompoundKind::Map,
                 args,
                 ..
             } => match args.get(1).and_then(|v| self.element_clone(v)) {
-                Some(clone) => {
-                    self.require_stdlib();
-                    (
-                        format!("{}.MapCloneFunc", go_name::GO_STDLIB_PKG),
-                        Some(clone),
-                    )
-                }
-                None => {
-                    self.require_stdlib();
-                    (format!("{}.MapClone", go_name::GO_STDLIB_PKG), None)
-                }
+                Some(clone) => (prelude("MapCloneFunc"), Some(clone)),
+                None => (prelude("MapClone"), None),
             },
             _ => return value,
         };
         let mut arguments = vec![value];
         arguments.extend(closure);
-        GoExpression::call(GoExpression::name(function), arguments)
+        GoExpression::call(function, arguments)
     }
 
     fn element_clone(&mut self, ty: &Type) -> Option<GoExpression> {

--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -357,9 +357,6 @@ impl Planner<'_> {
         let condition = match pair.nil_guard {
             None => status,
             Some(guard) => {
-                if guard.is_interface() {
-                    self.require_stdlib();
-                }
                 let value = GoExpression::name(
                     pair.value
                         .clone()

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -12,6 +12,7 @@ use crate::calls::native::{native_method_is_pure, native_method_lowers_to_plain_
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign, define,
 };
@@ -401,7 +402,6 @@ impl<'a> Planner<'a> {
             .collect();
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "entry");
         let effect = sequenced.effect;
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
         let mut values = sequenced.values.into_iter();
 
@@ -425,13 +425,13 @@ impl<'a> Planner<'a> {
             } else {
                 coerced_value
             };
-            lowered.push((Some(coerced_key.rendered()), coerced_value));
+            lowered.push((Some(coerced_key), coerced_value));
         }
 
         let layout = CompositeLayout::for_elements(lowered.len(), widest);
         Some(ValuePlan::computed(
             setup,
-            GoExpression::composite(Some(map_ty), lowered, layout, contains_deferred_evaluation),
+            GoExpression::composite(Some(map_ty), lowered, layout),
             self.native_constructor_effect(ctx, effect),
         ))
     }
@@ -631,24 +631,9 @@ impl<'a> Planner<'a> {
         let plain_call = !matches!(origin, CallableOrigin::NativeConstructor(_))
             && native_method_lowers_to_plain_call(ctx.native_type, ctx.method, receiver_arity);
         let mut plan = if plain_call {
-            ValuePlan::plain_call(
-                result.setup,
-                result.value.with_deferred_evaluation(true),
-                effect,
-            )
+            ValuePlan::plain_call(result.setup, result.value, effect)
         } else {
-            let contains_deferred_evaluation = match ctx.method {
-                "byte_at" | "enumerate" => result.arguments_contain_deferred_evaluation,
-                "append" if receiver_arity == 0 => result.arguments_contain_deferred_evaluation,
-                _ => true,
-            };
-            ValuePlan::computed(
-                result.setup,
-                result
-                    .value
-                    .with_deferred_evaluation(contains_deferred_evaluation),
-                effect,
-            )
+            ValuePlan::computed(result.setup, result.value, effect)
         };
         if reads_fixed_length {
             plan.evaluation.stability = Stability::Fixed;
@@ -719,7 +704,6 @@ impl<'a> Planner<'a> {
             .collect();
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "arg");
         let effect = EvaluationEffect::PureCall.combine(sequenced.effect);
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
 
         let mut field_pairs = Vec::with_capacity(target.field_tys.len());
@@ -739,12 +723,7 @@ impl<'a> Planner<'a> {
 
         Some(ValuePlan::computed(
             setup,
-            emit_struct_literal(
-                &target.go_ty,
-                field_pairs,
-                ctx,
-                contains_deferred_evaluation,
-            ),
+            emit_struct_literal(&target.go_ty, field_pairs, ctx),
             effect,
         ))
     }
@@ -818,12 +797,11 @@ impl<'a> Planner<'a> {
             }
             None => (Vec::new(), Vec::new()),
         };
-        self.require_stdlib();
         (
             setup,
             GoExpression::call(
                 GoExpression::instantiation(
-                    GoExpression::name(format!("{}.AssertType", go_name::GO_STDLIB_PKG)),
+                    GoExpression::generated(GeneratedPackage::Prelude, "AssertType"),
                     format!("[{target_ty}]"),
                 ),
                 arguments,

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -8,6 +8,7 @@ use crate::abi::callable::{CallableAbi, CallableReturnAbi, OptionReturnAbi};
 use crate::abi::coercion::{CoercionPlan, LayoutBridge, resolve_layout_bridge};
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{LoweredStatement, define_many};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{GoExpression, ValuePlan};
@@ -43,7 +44,7 @@ impl Planner<'_> {
             return call.map_expression_as_observable_computed(|setup, call| {
                 let (bridge_setup, value) = bridge.lower(self, call);
                 setup.extend(bridge_setup);
-                value.with_deferred_evaluation(false)
+                value
             });
         }
 
@@ -150,16 +151,11 @@ impl Planner<'_> {
             | CallableReturnAbi::Tuple { .. } => {
                 unreachable!("direct and tuple results do not use a scalar wrapper")
             }
-            CallableReturnAbi::BareError => {
-                self.require_stdlib();
-                self.lower_bare_error_wrapping(call, result_ty, target)
-            }
+            CallableReturnAbi::BareError => self.lower_bare_error_wrapping(call, result_ty, target),
             CallableReturnAbi::Result { payload } => {
-                self.require_stdlib();
                 self.lower_result_wrapping(call, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Partial { payload } => {
-                self.require_stdlib();
                 self.lower_partial_wrapping(call, result_ty, *payload, payload_bridge, target)
             }
             CallableReturnAbi::Option(OptionReturnAbi::CommaOk { payload }) => {
@@ -261,18 +257,17 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         values: Vec<GoExpression>,
     ) -> GoExpression {
-        let constructor = build_tuple_literal(self, values);
+        let constructor = build_tuple_literal(values);
         GoExpression::name(self.hoist_tmp_value_statement(statements, "tup", constructor))
     }
 }
 
-pub(super) fn build_tuple_literal(
-    planner: &mut Planner,
-    values: Vec<GoExpression>,
-) -> GoExpression {
-    planner.require_stdlib();
+pub(super) fn build_tuple_literal(values: Vec<GoExpression>) -> GoExpression {
     GoExpression::call(
-        GoExpression::name(format!("lisette.MakeTuple{}", values.len())),
+        GoExpression::generated(
+            GeneratedPackage::Prelude,
+            format!("MakeTuple{}", values.len()),
+        ),
         values,
     )
 }

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -7,7 +7,8 @@ use crate::calls::go_interop::wrappers::{
     WrapperOutcome, WrapperTarget, is_nil, is_nil_interface, leaf_block, non_nil,
 };
 use crate::context::expression::ExpressionContext;
-use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG, generic_call};
+use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG, prelude_call};
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign,
     define_many,
@@ -20,7 +21,7 @@ fn is_some(option: GoExpression) -> GoExpression {
     GoExpression::binary(
         GoExpression::selector(option, "Tag".to_string()),
         "==",
-        GoExpression::name(OPTION_SOME_TAG.to_string()),
+        GoExpression::generated(GeneratedPackage::Prelude, OPTION_SOME_TAG),
     )
 }
 
@@ -69,14 +70,13 @@ impl Planner<'_> {
         }
         let inner = self.lower_composite_value(inner, ExpressionContext::value());
         Some(inner.map_expression_as_computed(|setup, value| {
-            let contains_deferred_evaluation = value.contains_deferred_evaluation();
             let value = if payload.is_identity() {
                 value
             } else {
                 self.plan_layout_bridge(setup, value, payload)
             };
             let Some(pointee) = pointee else {
-                return value.with_deferred_evaluation(contains_deferred_evaluation);
+                return value;
             };
             let go_type = pointee.go_type(self);
             let go_type = self.use_rendered_go_type(go_type);
@@ -88,7 +88,6 @@ impl Planner<'_> {
                 value: Some(value),
             });
             GoExpression::address_of(GoExpression::name(copy))
-                .with_deferred_evaluation(contains_deferred_evaluation)
         }))
     }
 
@@ -100,13 +99,12 @@ impl Planner<'_> {
         sentinel: i64,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
-        self.require_stdlib();
         let mut statements = Vec::new();
         let raw = self.hoist_tmp_value_statement(&mut statements, "ret", call);
         let raw = || GoExpression::name(raw.clone());
         let inner_ty_str = self.use_go_type(&option_ty.ok_type());
-        let value = generic_call(
-            "lisette.OptionFromCommaOk",
+        let value = prelude_call(
+            "OptionFromCommaOk",
             format!("[{}]", inner_ty_str),
             vec![
                 raw(),
@@ -128,7 +126,6 @@ impl Planner<'_> {
         payload_bridge: Option<&LayoutBridge>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
-        self.require_stdlib();
         let mut statements = Vec::new();
 
         let inner_ty = option_ty.ok_type();
@@ -141,8 +138,8 @@ impl Planner<'_> {
 
         if !needs_complex {
             let inner_ty_str = self.use_go_type(&inner_ty);
-            let value = generic_call(
-                "lisette.OptionFromCommaOk",
+            let value = prelude_call(
+                "OptionFromCommaOk",
                 format!("[{}]", inner_ty_str),
                 vec![call],
             );
@@ -172,7 +169,7 @@ impl Planner<'_> {
                 .iter()
                 .map(|var| GoExpression::name(var.clone()))
                 .collect();
-            build_tuple_literal(self, values)
+            build_tuple_literal(values)
         } else {
             first_val.clone()
         };
@@ -234,7 +231,6 @@ impl Planner<'_> {
         option_ty: &Type,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
-        self.require_stdlib();
         let mut statements = Vec::new();
         let inner_ty = option_ty.ok_type();
         let inner_ty_str = self.use_go_type(&inner_ty);
@@ -243,8 +239,8 @@ impl Planner<'_> {
         } else {
             is_nil(raw_value.clone())
         };
-        let value = generic_call(
-            "lisette.OptionFromNilable",
+        let value = prelude_call(
+            "OptionFromNilable",
             format!("[{}]", inner_ty_str),
             vec![raw_value, is_nil_check],
         );
@@ -269,7 +265,6 @@ impl Planner<'_> {
             value: None,
         });
 
-        self.require_stdlib();
         let payload = some_payload(option.clone());
         let payload = if address {
             GoExpression::address_of(payload)
@@ -294,10 +289,9 @@ impl Planner<'_> {
         pointer: GoExpression,
         option_ty: &Type,
     ) -> GoExpression {
-        self.require_stdlib();
         let inner_ty_str = self.use_go_type(&option_ty.ok_type());
-        let value = generic_call(
-            "lisette.OptionFromPointer",
+        let value = prelude_call(
+            "OptionFromPointer",
             format!("[{}]", inner_ty_str),
             vec![pointer],
         );
@@ -466,7 +460,6 @@ impl Planner<'_> {
         payload_bridge: &LayoutBridge,
         pointer: bool,
     ) -> GoExpression {
-        self.require_stdlib();
         let source = self.stable_source(statements, "raw", raw_value);
         let fallible = Fallible::from_type(option_type).expect("Option type expected");
         let option_type_string = {
@@ -536,7 +529,6 @@ impl Planner<'_> {
         let target_layout: &ValueLayout = target;
         let element_bridge: &LayoutBridge = element;
         let key_bridge = key.as_deref();
-        self.require_stdlib();
         let source = self.stable_source(statements, "src", value);
         let direction = key_bridge
             .and_then(LayoutBridge::direction)

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -4,17 +4,19 @@ use crate::abi::coercion::{LayoutBridge, resolve_layout_bridge};
 use crate::abi::layout::{FunctionLayout, ValueLayout};
 use crate::abi::transition::multi_value_return;
 use crate::control_flow::fallible::{
-    Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR, generic_call,
+    Fallible, FalliblePlanner, PARTIAL_BOTH_CTOR, PARTIAL_ERR_CTOR, PARTIAL_OK_CTOR, prelude_call,
 };
 use crate::control_flow::propagation::plain_return;
 use crate::is_order_sensitive;
 use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoweredBlock, LoweredStatement, assign, define, define_many,
     expression_statement,
 };
 use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::GoExpression;
+use crate::types::go_type::GoType;
 use syntax::ast::Expression;
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::{FunctionParameter, Type};
@@ -29,7 +31,7 @@ pub(crate) fn non_nil(value: GoExpression) -> GoExpression {
 
 pub(crate) fn is_nil_interface(value: GoExpression) -> GoExpression {
     GoExpression::call(
-        GoExpression::name("lisette.IsNilInterface".to_string()),
+        GoExpression::generated(GeneratedPackage::Prelude, "IsNilInterface"),
         vec![value],
     )
 }
@@ -55,10 +57,6 @@ impl NilGuard {
             NilGuard::Pointer => non_nil(value),
             NilGuard::Interface => GoExpression::unary("!", is_nil_interface(value)),
         }
-    }
-
-    pub(crate) fn is_interface(self) -> bool {
-        matches!(self, NilGuard::Interface)
     }
 }
 
@@ -225,7 +223,6 @@ impl Planner<'_> {
             CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let raw = self.hoist_tmp_value_statement(statements, "raw", call);
                 let condition = if self.is_interface_option(source.result.logical_type()) {
-                    self.require_stdlib();
                     is_nil_interface(GoExpression::name(raw.clone()))
                 } else {
                     is_nil(GoExpression::name(raw.clone()))
@@ -427,7 +424,6 @@ impl Planner<'_> {
         let err_ty = partial_ty.err_type();
         let ok_ty_str = self.use_go_type(&ok_ty);
         let err_ty_str = self.use_go_type(&err_ty);
-        let pkg = go_name::GO_STDLIB_PKG;
 
         let mut statements = Vec::new();
         let (err_var, val_value) = self.push_go_returns(&mut statements, call, &ok_ty, layout);
@@ -436,12 +432,15 @@ impl Planner<'_> {
         let nil_check = self.partial_ok_nil_check(&ok_ty, val());
 
         let type_params = format!("[{}, {}]", ok_ty_str, err_ty_str);
-        let result_ty_str = format!("{pkg}.Partial{type_params}");
+        let result_ty_str = self.use_rendered_go_type(GoType::stdlib(format!(
+            "{}.Partial{type_params}",
+            go_name::GO_STDLIB_PKG
+        )));
         let (sink, outcome) =
             self.push_wrapper_slot(&mut statements, target, &result_ty_str, "result");
 
         let (mut both_setup, both_value) = self.plan_optional_payload_bridge(val(), payload_bridge);
-        let both = generic_call(
+        let both = prelude_call(
             PARTIAL_BOTH_CTOR,
             type_params.clone(),
             vec![both_value, err()],
@@ -454,7 +453,7 @@ impl Planner<'_> {
         let (mut ok_setup, ok_value) = self.plan_optional_payload_bridge(val(), payload_bridge);
         ok_setup.push(leaf_statement(
             &sink,
-            generic_call(PARTIAL_OK_CTOR, type_params.clone(), vec![ok_value]),
+            prelude_call(PARTIAL_OK_CTOR, type_params.clone(), vec![ok_value]),
         ));
         let ok_body = LoweredBlock {
             statements: ok_setup,
@@ -465,7 +464,7 @@ impl Planner<'_> {
                 check,
                 leaf_block(
                     &sink,
-                    generic_call(PARTIAL_ERR_CTOR, type_params, vec![err()]),
+                    prelude_call(PARTIAL_ERR_CTOR, type_params, vec![err()]),
                 ),
                 ElseArm::from_body(both_body, false),
             );
@@ -509,9 +508,6 @@ impl Planner<'_> {
         value: GoExpression,
     ) -> Option<GoExpression> {
         let guard = self.partial_ok_nil_guard(ok_ty)?;
-        if guard.is_interface() {
-            self.require_stdlib();
-        }
         Some(guard.is_nil(value))
     }
 
@@ -590,7 +586,6 @@ impl Planner<'_> {
             } else {
                 is_nil(nil_check)
             };
-            self.require_errors();
             let nil_err = {
                 let mut fe = FalliblePlanner::new(self, &fallible);
                 fe.emit_failure(Some(unexpected_nil_error()))
@@ -742,8 +737,6 @@ impl Planner<'_> {
         expression: &Expression,
         abi: &CallableAbi,
     ) -> GoExpression {
-        self.require_stdlib();
-
         let (return_type, param_strs, call) = self
             .wrapper_call_parts(setup, expression)
             .expect("expected function type");
@@ -792,8 +785,6 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
     ) -> GoExpression {
-        self.require_stdlib();
-
         let (return_type, param_strs, call) = self
             .wrapper_call_parts(setup, expression)
             .expect("expected function type");
@@ -858,7 +849,7 @@ impl Planner<'_> {
 
 pub(crate) fn unexpected_nil_error() -> GoExpression {
     GoExpression::call(
-        GoExpression::name("errors.New".to_string()),
+        GoExpression::generated(GeneratedPackage::Errors, "New"),
         vec![GoExpression::literal("\"unexpected nil\"".to_string())],
     )
 }

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -5,6 +5,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::expressions::access::index_access::range_var_bounds;
 use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{LoweredBlock, LoweredStatement};
 use crate::plan::calls::plan_variadic_spread;
 use crate::plan::go_expression::FunctionLiteralLayout;
@@ -19,7 +20,6 @@ pub(super) struct NativeCallResult {
     pub setup: Vec<LoweredStatement>,
     pub value: GoExpression,
     pub argument_effect: EvaluationEffect,
-    pub arguments_contain_deferred_evaluation: bool,
 }
 
 impl NativeCallResult {
@@ -27,23 +27,21 @@ impl NativeCallResult {
         setup: Vec<LoweredStatement>,
         value: GoExpression,
         argument_effect: EvaluationEffect,
-        arguments_contain_deferred_evaluation: bool,
     ) -> Self {
         Self {
             setup,
             value,
             argument_effect,
-            arguments_contain_deferred_evaluation,
         }
     }
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum InlineImport {
+enum InlinePackage {
     None,
     Slices,
     Strings,
-    Stdlib,
+    Prelude,
 }
 
 /// The Go shape a native method inlines to, given the receiver and arguments.
@@ -66,7 +64,7 @@ struct InlineRule {
     method: &'static str,
     arity: RuleArity,
     form: InlineForm,
-    import: InlineImport,
+    package: InlinePackage,
 }
 
 #[derive(Clone, Copy)]
@@ -107,14 +105,14 @@ static INLINE_METHODS: &[InlineRule] = &[
         method: "length",
         arity: RuleArity::Exact(0),
         form: InlineForm::Call("len"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::Slice, N::Channel, N::Sender, N::Receiver],
         method: "capacity",
         arity: RuleArity::Exact(0),
         form: InlineForm::Call("cap"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[
@@ -128,28 +126,28 @@ static INLINE_METHODS: &[InlineRule] = &[
         method: "is_empty",
         arity: RuleArity::Exact(0),
         form: InlineForm::IsEmpty,
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::Slice],
         method: "enumerate",
         arity: RuleArity::Exact(0),
         form: InlineForm::Receiver,
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::String],
         method: "bytes",
         arity: RuleArity::Exact(0),
         form: InlineForm::Conversion("[]byte"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::String],
         method: "runes",
         arity: RuleArity::Exact(0),
         form: InlineForm::Conversion("[]rune"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     // Single-arg methods
     InlineRule {
@@ -157,84 +155,84 @@ static INLINE_METHODS: &[InlineRule] = &[
         method: "delete",
         arity: RuleArity::Exact(1),
         form: InlineForm::Call("delete"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::Slice],
         method: "copy_from",
         arity: RuleArity::Exact(1),
         form: InlineForm::Call("copy"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::Slice],
         method: "contains",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("slices.Contains"),
-        import: InlineImport::Slices,
+        form: InlineForm::Call("Contains"),
+        package: InlinePackage::Slices,
     },
     InlineRule {
         types: &[N::String],
         method: "contains",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("strings.Contains"),
-        import: InlineImport::Strings,
+        form: InlineForm::Call("Contains"),
+        package: InlinePackage::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "split",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("strings.Split"),
-        import: InlineImport::Strings,
+        form: InlineForm::Call("Split"),
+        package: InlinePackage::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "starts_with",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("strings.HasPrefix"),
-        import: InlineImport::Strings,
+        form: InlineForm::Call("HasPrefix"),
+        package: InlinePackage::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "ends_with",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("strings.HasSuffix"),
-        import: InlineImport::Strings,
+        form: InlineForm::Call("HasSuffix"),
+        package: InlinePackage::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "byte_at",
         arity: RuleArity::Exact(1),
         form: InlineForm::Index,
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
     InlineRule {
         types: &[N::String],
         method: "rune_at",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("lisette.RuneAt"),
-        import: InlineImport::Stdlib,
+        form: InlineForm::Call("RuneAt"),
+        package: InlinePackage::Prelude,
     },
     InlineRule {
         types: &[N::Slice],
         method: "join",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("strings.Join"),
-        import: InlineImport::Strings,
+        form: InlineForm::Call("Join"),
+        package: InlinePackage::Strings,
     },
     InlineRule {
         types: &[N::Slice],
         method: "any",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("slices.ContainsFunc"),
-        import: InlineImport::Slices,
+        form: InlineForm::Call("ContainsFunc"),
+        package: InlinePackage::Slices,
     },
     InlineRule {
         types: &[N::Slice],
         method: "reserve",
         arity: RuleArity::Exact(1),
-        form: InlineForm::Call("slices.Grow"),
-        import: InlineImport::Slices,
+        form: InlineForm::Call("Grow"),
+        package: InlinePackage::Slices,
     },
     // Variadic methods
     InlineRule {
@@ -242,7 +240,7 @@ static INLINE_METHODS: &[InlineRule] = &[
         method: "append",
         arity: RuleArity::Variadic,
         form: InlineForm::Call("append"),
-        import: InlineImport::None,
+        package: InlinePackage::None,
     },
 ];
 
@@ -372,15 +370,26 @@ fn is_selector_chain(rendered: &str) -> bool {
 
 fn build_inline(
     form: InlineForm,
+    package: InlinePackage,
     receiver: &GoExpression,
     arguments: &[GoExpression],
     negated: bool,
 ) -> GoExpression {
     match form {
         InlineForm::Call(callee) => {
+            let callee = match package {
+                InlinePackage::None => GoExpression::name(callee.to_string()),
+                InlinePackage::Slices => GoExpression::generated(GeneratedPackage::Slices, callee),
+                InlinePackage::Strings => {
+                    GoExpression::generated(GeneratedPackage::Strings, callee)
+                }
+                InlinePackage::Prelude => {
+                    GoExpression::generated(GeneratedPackage::Prelude, callee)
+                }
+            };
             let mut all = vec![receiver.clone()];
             all.extend(arguments.iter().cloned());
-            GoExpression::call(GoExpression::name(callee.to_string()), all)
+            GoExpression::call(callee, all)
         }
         InlineForm::IsEmpty => {
             let operator = if negated { "!=" } else { "==" };
@@ -432,19 +441,22 @@ pub(super) fn try_inline_native_method(
     receiver: &GoExpression,
     arguments: &[GoExpression],
     negated: bool,
-) -> Option<(GoExpression, InlineImport)> {
+) -> Option<GoExpression> {
     // Go's `append` requires at least 2 args, so zero-arg `append` returns
     // the receiver unchanged.
     if !negated && method == "append" && arguments.is_empty() {
-        return Some((receiver.clone(), InlineImport::None));
+        return Some(receiver.clone());
     }
     let rule = lookup_inline_rule(native_type, method, arguments.len())?;
     if negated && !matches!(rule.form, InlineForm::IsEmpty) {
         return None;
     }
-    Some((
-        build_inline(rule.form, receiver, arguments, negated),
-        rule.import,
+    Some(build_inline(
+        rule.form,
+        rule.package,
+        receiver,
+        arguments,
+        negated,
     ))
 }
 
@@ -528,24 +540,21 @@ fn has_inline_negation(native_type: &NativeGoType, method: &str, arity: usize) -
 /// Resolve the inline rule for a dot-access form, applying the static-receiver
 /// fallback when the standard receiver shape does not match.
 fn apply_inline_lookup(
-    planner: &mut Planner,
     native_type: &NativeGoType,
     method: &str,
     receiver: &GoExpression,
     emitted_args: &[GoExpression],
     negated: bool,
 ) -> Option<GoExpression> {
-    if let Some((inlined, import)) =
+    if let Some(inlined) =
         try_inline_native_method(native_type, method, receiver, emitted_args, negated)
     {
-        apply_inline_import(planner, import);
         return Some(inlined);
     }
     if let Some((static_receiver, remaining)) = emitted_args.split_first()
-        && let Some((inlined, import)) =
+        && let Some(inlined) =
             try_inline_native_method(native_type, method, static_receiver, remaining, negated)
     {
-        apply_inline_import(planner, import);
         return Some(inlined);
     }
     None
@@ -562,17 +571,11 @@ struct StagedNativeMethod {
     receiver: GoExpression,
     arguments: Vec<GoExpression>,
     effect: EvaluationEffect,
-    contains_deferred_evaluation: bool,
 }
 
 impl StagedNativeMethod {
     fn finish(self, value: GoExpression) -> NativeCallResult {
-        NativeCallResult::new(
-            self.setup,
-            value,
-            self.effect,
-            self.contains_deferred_evaluation,
-        )
+        NativeCallResult::new(self.setup, value, self.effect)
     }
 }
 
@@ -626,12 +629,11 @@ impl Planner<'_> {
                 && self.needs_custom_equality(&element, &[])
             {
                 let mut staged = self.stage_native_method(ctx, form);
-                self.require_slices();
                 let searched = staged.arguments[0].clone();
                 let target = self.hoist_tmp_value_statement(&mut staged.setup, "want", searched);
                 let predicate = self.contains_predicate(&element, GoExpression::name(target), &[]);
                 let body = GoExpression::call(
-                    GoExpression::name("slices.ContainsFunc".to_string()),
+                    GoExpression::generated(GeneratedPackage::Slices, "ContainsFunc"),
                     vec![staged.receiver.clone(), predicate],
                 );
                 return staged.finish(body);
@@ -680,7 +682,6 @@ impl Planner<'_> {
 
         let inlined = match form {
             NativeMethodForm::Dot => apply_inline_lookup(
-                self,
                 ctx.native_type,
                 ctx.method,
                 &staged.receiver,
@@ -693,22 +694,19 @@ impl Planner<'_> {
                 &staged.receiver,
                 &staged.arguments,
                 false,
-            )
-            .map(|(value, import)| {
-                apply_inline_import(self, import);
-                value
-            }),
+            ),
         };
         if let Some(inlined) = inlined {
             return staged.finish(inlined);
         }
 
-        self.require_stdlib();
-        let fn_name = format!(
-            "{}.{}{}",
-            go_name::GO_STDLIB_PKG,
-            ctx.native_type.method_prefix(),
-            go_name::snake_to_camel(ctx.method)
+        let fn_name = GoExpression::generated(
+            GeneratedPackage::Prelude,
+            format!(
+                "{}{}",
+                ctx.native_type.method_prefix(),
+                go_name::snake_to_camel(ctx.method)
+            ),
         );
         let type_args = match form {
             NativeMethodForm::Dot
@@ -726,7 +724,7 @@ impl Planner<'_> {
         let mut emitted_args = vec![staged.receiver.clone()];
         emitted_args.extend(staged.arguments.iter().cloned());
         staged.finish(GoExpression::call(
-            GoExpression::instantiation(GoExpression::name(fn_name), type_args),
+            GoExpression::instantiation(fn_name, type_args),
             emitted_args,
         ))
     }
@@ -741,16 +739,16 @@ impl Planner<'_> {
     ) -> GoExpression {
         match method {
             "to_slice" => {
-                self.require_slices();
                 let view = self.sliceable_receiver(receiver_expr, receiver, setup);
-                GoExpression::call(GoExpression::name("slices.Clone".to_string()), vec![view])
+                GoExpression::call(
+                    GoExpression::generated(GeneratedPackage::Slices, "Clone"),
+                    vec![view],
+                )
             }
             "get" => {
-                self.require_stdlib();
                 let view = self.sliceable_receiver(receiver_expr, receiver, setup);
-                let pkg = go_name::GO_STDLIB_PKG;
                 GoExpression::call(
-                    GoExpression::name(format!("{pkg}.SliceGet")),
+                    GoExpression::generated(GeneratedPackage::Prelude, "SliceGet"),
                     vec![view, index.expect("get needs an index")],
                 )
             }
@@ -831,18 +829,14 @@ impl Planner<'_> {
             return None;
         }
         let staged = self.stage_native_method(ctx, form);
-        let (inlined, import) = match form {
-            NativeMethodForm::Dot => {
-                let value = apply_inline_lookup(
-                    self,
-                    ctx.native_type,
-                    ctx.method,
-                    &staged.receiver,
-                    &staged.arguments,
-                    true,
-                )?;
-                (value, InlineImport::None)
-            }
+        let inlined = match form {
+            NativeMethodForm::Dot => apply_inline_lookup(
+                ctx.native_type,
+                ctx.method,
+                &staged.receiver,
+                &staged.arguments,
+                true,
+            )?,
             NativeMethodForm::Identifier => try_inline_native_method(
                 ctx.native_type,
                 ctx.method,
@@ -852,7 +846,6 @@ impl Planner<'_> {
             )?,
         };
         setup.extend(staged.setup);
-        apply_inline_import(self, import);
         Some(inlined)
     }
 
@@ -908,9 +901,7 @@ impl Planner<'_> {
             } else {
                 array
             };
-            let contains_deferred_evaluation = base.contains_deferred_evaluation();
             GoExpression::slice(base, None, None, None)
-                .with_deferred_evaluation(contains_deferred_evaluation)
         })
     }
 
@@ -969,7 +960,6 @@ impl Planner<'_> {
             self.finalize_spread_stage(&mut sequenced.values, spread_index, false, combine);
         }
         let effect = sequenced.effect;
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut values = sequenced.values;
         let receiver = values.remove(0);
         StagedNativeMethod {
@@ -977,7 +967,6 @@ impl Planner<'_> {
             receiver,
             arguments: values,
             effect,
-            contains_deferred_evaluation,
         }
     }
 
@@ -1023,7 +1012,6 @@ impl Planner<'_> {
         args: &[Expression],
         capture_boundary: CaptureBoundary,
     ) -> NativeCallResult {
-        self.require_stdlib();
         let arg = &args[0];
         let is_ref_receiver = receiver_expr.get_type().is_ref();
         let deref = |raw: GoExpression| -> GoExpression {
@@ -1050,7 +1038,6 @@ impl Planner<'_> {
             }
             let sequenced = self.sequence_values(stages, capture_boundary, "arg");
             let effect = sequenced.effect;
-            let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
             let mut values = sequenced.values.into_iter();
             let receiver = values.next().expect("substring has a receiver");
             let start_bound = start
@@ -1068,7 +1055,6 @@ impl Planner<'_> {
                 sequenced.setup,
                 substring_call(deref(receiver), start_bound, end_bound),
                 effect,
-                contains_deferred_evaluation,
             );
         }
 
@@ -1081,7 +1067,6 @@ impl Planner<'_> {
         let sequenced =
             self.sequence_values(vec![receiver_staged, range_staged], capture_boundary, "arg");
         let effect = sequenced.effect;
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut values = sequenced.values.into_iter();
         let receiver = values.next().expect("substring has a receiver");
         let range = values.next().expect("substring has a range");
@@ -1090,7 +1075,6 @@ impl Planner<'_> {
             sequenced.setup,
             substring_call(deref(receiver), start, end),
             effect,
-            contains_deferred_evaluation,
         )
     }
 
@@ -1136,23 +1120,21 @@ impl Planner<'_> {
             return GoExpression::binary(lhs, operator, rhs);
         }
         if peeled.is_slice() {
-            self.require_slices();
             return match peeled.inner() {
                 Some(elem) if self.needs_custom_equality(&elem, generics) => {
                     let eq = self.equality_closure(&elem, generics);
                     negate(GoExpression::call(
-                        GoExpression::name("slices.EqualFunc".to_string()),
+                        GoExpression::generated(GeneratedPackage::Slices, "EqualFunc"),
                         vec![lhs, rhs, eq],
                     ))
                 }
                 _ => negate(GoExpression::call(
-                    GoExpression::name("slices.Equal".to_string()),
+                    GoExpression::generated(GeneratedPackage::Slices, "Equal"),
                     vec![lhs, rhs],
                 )),
             };
         }
         if peeled.is_map() {
-            self.require_maps();
             let value = peeled
                 .as_compound()
                 .and_then(|(_, args)| args.get(1).cloned());
@@ -1160,12 +1142,12 @@ impl Planner<'_> {
                 Some(value) if self.needs_custom_equality(&value, generics) => {
                     let eq = self.equality_closure(&value, generics);
                     negate(GoExpression::call(
-                        GoExpression::name("maps.EqualFunc".to_string()),
+                        GoExpression::generated(GeneratedPackage::Maps, "EqualFunc"),
                         vec![lhs, rhs, eq],
                     ))
                 }
                 _ => negate(GoExpression::call(
-                    GoExpression::name("maps.Equal".to_string()),
+                    GoExpression::generated(GeneratedPackage::Maps, "Equal"),
                     vec![lhs, rhs],
                 )),
             };
@@ -1242,7 +1224,6 @@ fn substring_call(
     start: Option<GoExpression>,
     end: Option<GoExpression>,
 ) -> GoExpression {
-    let pkg = go_name::GO_STDLIB_PKG;
     let (function, bounds) = match (start, end) {
         (Some(start), Some(end)) => ("Substring", vec![start, end]),
         (Some(start), None) => ("SubstringFrom", vec![start]),
@@ -1251,14 +1232,8 @@ fn substring_call(
     };
     let mut arguments = vec![receiver];
     arguments.extend(bounds);
-    GoExpression::call(GoExpression::name(format!("{pkg}.{function}")), arguments)
-}
-
-pub(super) fn apply_inline_import(planner: &mut Planner, import: InlineImport) {
-    match import {
-        InlineImport::Slices => planner.require_slices(),
-        InlineImport::Strings => planner.require_strings(),
-        InlineImport::Stdlib => planner.require_stdlib(),
-        InlineImport::None => {}
-    }
+    GoExpression::call(
+        GoExpression::generated(GeneratedPackage::Prelude, function),
+        arguments,
+    )
 }

--- a/crates/emit/src/calls/predicates.rs
+++ b/crates/emit/src/calls/predicates.rs
@@ -118,7 +118,7 @@ impl Planner<'_> {
         debug_assert!(condition.initializer.is_none());
         Some(ValuePlan::plain_call(
             setup,
-            condition.condition.with_deferred_evaluation(true),
+            condition.condition,
             EvaluationEffect::EffectfulCall,
         ))
     }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -16,6 +16,7 @@ use crate::context::expression::ExpressionContext;
 use crate::expressions::staging::LaterStages;
 use crate::expressions::staging::{SpreadSequenceOptions, VariadicCombine};
 use crate::names::generics::extract_type_mapping;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign, define,
 };
@@ -214,7 +215,7 @@ fn collapse_fmt_print(
                 format.insert_str(close_quote, "\\n");
             }
             Some(GoExpression::call(
-                GoExpression::name("fmt.Printf".to_string()),
+                GoExpression::generated(GeneratedPackage::Fmt, "Printf"),
                 inner.into_iter().map(GoExpression::from_node).collect(),
             ))
         }
@@ -416,20 +417,17 @@ impl<'a> Planner<'a> {
             .expect("sequenced exactly one argument");
         let call = match call_arguments_of(value.node(), "fmt.Sprintf") {
             Some(arguments) => GoExpression::call(
-                GoExpression::name("fmt.Errorf".to_string()),
+                GoExpression::generated(GeneratedPackage::Fmt, "Errorf"),
                 arguments
                     .iter()
                     .cloned()
                     .map(GoExpression::from_node)
                     .collect(),
             ),
-            None => {
-                let qualifier = self.require_package_import("go:errors");
-                GoExpression::call(
-                    GoExpression::name(format!("{}.New", qualifier)),
-                    vec![value],
-                )
-            }
+            None => GoExpression::call(
+                GoExpression::qualified(self.package_use_for_package("go:errors"), "New"),
+                vec![value],
+            ),
         };
         Some(ValuePlan::plain_call(sequenced.setup, call, effect))
     }
@@ -626,7 +624,6 @@ impl<'a> Planner<'a> {
                 let argument = self.lower_composite_value(arg, arg_ctx);
                 argument.map_expression_as_computed(|setup, value| {
                     self.emit_lower_arg_to_tagged(setup, value, target)
-                        .with_deferred_evaluation(true)
                 })
             }
             ArgumentPlan::Direct => self.lower_direct_arg(arg, ctx, param, declared_param_ty),
@@ -780,10 +777,9 @@ impl<'a> Planner<'a> {
             return argument;
         }
         argument.map_expression_as_computed(|setup, value| {
-            let contains_deferred_evaluation = value.contains_deferred_evaluation();
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            coerced.with_deferred_evaluation(contains_deferred_evaluation)
+            coerced
         })
     }
 
@@ -887,7 +883,6 @@ impl<'a> Planner<'a> {
         Some(argument.map_expression_as_computed(|setup, value| {
             emit_fn_arg_shape_adapter(self, setup, value, &arg_fn, &arg_abi, &param_abi)
                 .expect("fn_arg_shapes resolved a function signature")
-                .with_deferred_evaluation(true)
         }))
     }
 
@@ -1045,31 +1040,26 @@ impl<'a> Planner<'a> {
                 ExpressionContext::value().with_forced_tagged_go_function(true),
             ),
         };
-        argument.map_expression_as_computed(|setup, value| {
-            let contains_deferred_evaluation = value.contains_deferred_evaluation()
-                || !matches!(transition, AbiTransition::Identity);
-            let result = match transition {
-                AbiTransition::Identity => value,
-                AbiTransition::LowerFromTagged => {
-                    let param_fn_ty = self
-                        .facts
-                        .resolve_to_function_type(effective_param_ty.unwrap_forall())
-                        .expect("callback target resolves to a fn type");
-                    emit_lisette_callback_wrapper(self, setup, value, &param_fn_ty)
-                }
-                AbiTransition::WrapToTagged | AbiTransition::Reencode => {
-                    let arg_fn_ty = self
-                        .facts
-                        .resolve_to_function_type(arg.get_type().unwrap_forall())
-                        .expect("callback source resolves to a fn type");
-                    emit_fn_arg_shape_adapter(self, setup, value, &arg_fn_ty, source, target)
-                        .expect("callback ABI transition has a function signature")
-                }
-                AbiTransition::Incompatible => {
-                    unreachable!("type-checked callback ABIs must describe the same result")
-                }
-            };
-            result.with_deferred_evaluation(contains_deferred_evaluation)
+        argument.map_expression_as_computed(|setup, value| match transition {
+            AbiTransition::Identity => value,
+            AbiTransition::LowerFromTagged => {
+                let param_fn_ty = self
+                    .facts
+                    .resolve_to_function_type(effective_param_ty.unwrap_forall())
+                    .expect("callback target resolves to a fn type");
+                emit_lisette_callback_wrapper(self, setup, value, &param_fn_ty)
+            }
+            AbiTransition::WrapToTagged | AbiTransition::Reencode => {
+                let arg_fn_ty = self
+                    .facts
+                    .resolve_to_function_type(arg.get_type().unwrap_forall())
+                    .expect("callback source resolves to a fn type");
+                emit_fn_arg_shape_adapter(self, setup, value, &arg_fn_ty, source, target)
+                    .expect("callback ABI transition has a function signature")
+            }
+            AbiTransition::Incompatible => {
+                unreachable!("type-checked callback ABIs must describe the same result")
+            }
         })
     }
 
@@ -1165,7 +1155,7 @@ impl<'a> Planner<'a> {
         value.map_expression_as_computed(|setup, value| {
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            coerced.with_deferred_evaluation(true)
+            coerced
         })
     }
 
@@ -1217,7 +1207,7 @@ impl<'a> Planner<'a> {
         Some(value.map_expression_as_computed(|setup, value| {
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            coerced.with_deferred_evaluation(true)
+            coerced
         }))
     }
 }

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -5,7 +5,7 @@ use super::native::NativeCallResult;
 use super::{NativeCallContext, NativeMethodCall};
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
-use crate::control_flow::fallible::generic_call;
+use crate::control_flow::fallible::prelude_call;
 use crate::names::go_name;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
@@ -350,7 +350,6 @@ impl Planner<'_> {
             setup,
             result,
             effect.combine(EvaluationEffect::EffectfulCall),
-            false,
         ))
     }
 
@@ -422,15 +421,10 @@ impl Planner<'_> {
                 init.expect("fold stages its initial value").clone(),
             ),
             SliceLoop::Find => {
-                self.require_stdlib();
                 let payload = self.first_type_argument_go_string(result_ty);
                 define(
                     result.to_string(),
-                    generic_call(
-                        &format!("{}.MakeOptionNone", go_name::GO_STDLIB_PKG),
-                        format!("[{}]", payload),
-                        Vec::new(),
-                    ),
+                    prelude_call("MakeOptionNone", format!("[{}]", payload), Vec::new()),
                 )
             }
         }
@@ -487,12 +481,11 @@ impl Planner<'_> {
                         ));
                     }
                     None => {
-                        self.require_stdlib();
                         let payload = self.use_go_type(element_ty);
                         statements.push(assign(
                             name(result),
-                            generic_call(
-                                &format!("{}.MakeOptionSome", go_name::GO_STDLIB_PKG),
+                            prelude_call(
+                                "MakeOptionSome",
                                 format!("[{}]", payload),
                                 vec![name(element_name)],
                             ),

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -1,5 +1,5 @@
 use crate::calls::dispatch::{CallArgShape, all_type_params_inferrable};
-use crate::calls::native::{apply_inline_import, native_method_lowers_to_plain_call};
+use crate::calls::native::native_method_lowers_to_plain_call;
 use crate::plan::calls::plan_variadic_spread;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -121,7 +121,7 @@ impl Planner<'_> {
             callee: &call_plan.resolved,
         };
 
-        let (setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) =
+        let (setup, receiver_arg, emitted_args) =
             self.lower_ufcs_call_args(site, receiver, args, spread, coercion);
         let receiver_arg = match coercion {
             Some(ReceiverCoercion::AutoDeref) => GoExpression::dereference(receiver_arg),
@@ -129,19 +129,16 @@ impl Planner<'_> {
         };
 
         if let Some(inlined) =
-            try_inline_native_ufcs(self, receiver, member, &receiver_arg, &emitted_args)
+            try_inline_native_ufcs(receiver, member, &receiver_arg, &emitted_args)
         {
             let native_type = NativeGoType::from_type(&receiver.get_type())
                 .expect("inlined UFCS receiver has a native type");
             let plain_call =
                 native_method_lowers_to_plain_call(&native_type, member, emitted_args.len());
-            let deferred_evaluation =
-                plain_call || member == "is_empty" || arguments_contain_deferred_evaluation;
-            let expression = inlined.with_deferred_evaluation(deferred_evaluation);
             return if plain_call {
-                ValuePlan::plain_call(setup, expression, EvaluationEffect::EffectfulCall)
+                ValuePlan::plain_call(setup, inlined, EvaluationEffect::EffectfulCall)
             } else {
-                ValuePlan::computed(setup, expression, EvaluationEffect::EffectfulCall)
+                ValuePlan::computed(setup, inlined, EvaluationEffect::EffectfulCall)
             };
         }
 
@@ -173,7 +170,7 @@ impl Planner<'_> {
         args: &[Expression],
         spread: Option<&Expression>,
         coercion: Option<ReceiverCoercion>,
-    ) -> (Vec<LoweredStatement>, GoExpression, Vec<GoExpression>, bool) {
+    ) -> (Vec<LoweredStatement>, GoExpression, Vec<GoExpression>) {
         let UfcsCallSite { function, callee } = site;
         // The DotAccess function type curries `self` out, so its params line
         // up 1:1 with the user args. Pair each so a function-typed param
@@ -260,15 +257,9 @@ impl Planner<'_> {
                 boundary: CaptureBoundary::SiblingSequence,
             },
         );
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut all_values = sequenced.values;
         let receiver_arg = all_values.remove(0);
-        (
-            sequenced.setup,
-            receiver_arg,
-            all_values,
-            contains_deferred_evaluation,
-        )
+        (sequenced.setup, receiver_arg, all_values)
     }
 
     fn stage_ufcs_arg(
@@ -313,7 +304,7 @@ impl Planner<'_> {
             || self.method_needs_export(member);
 
         let qualified_method_name = self.qualify_method_call(qualified_name, member, is_public);
-        GoExpression::instantiation(GoExpression::name(qualified_method_name), type_args_string)
+        GoExpression::instantiation(qualified_method_name, type_args_string)
     }
 
     fn coerce_receiver_address_stage(
@@ -397,22 +388,13 @@ impl Planner<'_> {
 }
 
 fn try_inline_native_ufcs(
-    planner: &mut Planner,
     receiver: &Expression,
     member: &str,
     receiver_arg: &GoExpression,
     emitted_args: &[GoExpression],
 ) -> Option<GoExpression> {
     let native_type = NativeGoType::from_type(&receiver.get_type())?;
-    let (inlined, extra_import) = super::native::try_inline_native_method(
-        &native_type,
-        member,
-        receiver_arg,
-        emitted_args,
-        false,
-    )?;
-    apply_inline_import(planner, extra_import);
-    Some(inlined)
+    super::native::try_inline_native_method(&native_type, member, receiver_arg, emitted_args, false)
 }
 
 fn is_address_of_composite_literal(arg: Option<&Expression>) -> bool {

--- a/crates/emit/src/calls/wrap_err.rs
+++ b/crates/emit/src/calls/wrap_err.rs
@@ -1,6 +1,7 @@
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::literals::convert_escape_sequences;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::{Expression, FormatStringPart, Literal};
@@ -123,11 +124,13 @@ impl Planner<'_> {
         error: GoExpression,
     ) -> GoExpression {
         messages.iter().fold(error, |error, message| {
-            self.require_fmt();
             let mut args = vec![GoExpression::literal(format!("\"{}: %w\"", message.format))];
             args.extend(message.args.iter().cloned());
             args.push(error);
-            GoExpression::call(GoExpression::name("fmt.Errorf".to_string()), args)
+            GoExpression::call(
+                GoExpression::generated(GeneratedPackage::Fmt, "Errorf"),
+                args,
+            )
         })
     }
 }

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -1,8 +1,10 @@
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::GoExpression;
+use crate::types::go_type::GoType;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -12,17 +14,17 @@ pub(crate) const RESULT_ERR_FIELD: &str = "ErrVal";
 pub(crate) const PARTIAL_OK_FIELD: &str = "OkVal";
 pub(crate) const PARTIAL_ERR_FIELD: &str = "ErrVal";
 
-pub(crate) const RESULT_OK_TAG: &str = "lisette.ResultOk";
-pub(crate) const OPTION_SOME_TAG: &str = "lisette.OptionSome";
-pub(crate) const PARTIAL_OK_TAG: &str = "lisette.PartialOk";
-pub(crate) const PARTIAL_ERR_TAG: &str = "lisette.PartialErr";
-const RESULT_OK_CTOR: &str = "lisette.MakeResultOk";
-const OPTION_SOME_CTOR: &str = "lisette.MakeOptionSome";
-const RESULT_ERR_CTOR: &str = "lisette.MakeResultErr";
-const OPTION_NONE_CTOR: &str = "lisette.MakeOptionNone";
-pub(crate) const PARTIAL_OK_CTOR: &str = "lisette.MakePartialOk";
-pub(crate) const PARTIAL_BOTH_CTOR: &str = "lisette.MakePartialBoth";
-pub(crate) const PARTIAL_ERR_CTOR: &str = "lisette.MakePartialErr";
+pub(crate) const RESULT_OK_TAG: &str = "ResultOk";
+pub(crate) const OPTION_SOME_TAG: &str = "OptionSome";
+pub(crate) const PARTIAL_OK_TAG: &str = "PartialOk";
+pub(crate) const PARTIAL_ERR_TAG: &str = "PartialErr";
+const RESULT_OK_CTOR: &str = "MakeResultOk";
+const OPTION_SOME_CTOR: &str = "MakeOptionSome";
+const RESULT_ERR_CTOR: &str = "MakeResultErr";
+const OPTION_NONE_CTOR: &str = "MakeOptionNone";
+pub(crate) const PARTIAL_OK_CTOR: &str = "MakePartialOk";
+pub(crate) const PARTIAL_BOTH_CTOR: &str = "MakePartialBoth";
+pub(crate) const PARTIAL_ERR_CTOR: &str = "MakePartialErr";
 
 pub(crate) enum Fallible {
     Result { ok_ty: Type, err_ty: Type },
@@ -129,11 +131,11 @@ impl Fallible {
     ) -> GoExpression {
         match self {
             Self::Option { .. } => {
-                generic_call(OPTION_SOME_CTOR, format!("[{}]", inner_ty), vec![value])
+                prelude_call(OPTION_SOME_CTOR, format!("[{}]", inner_ty), vec![value])
             }
             Self::Result { .. } => {
                 let err_ty = err_ty.expect("Result must have error type");
-                generic_call(
+                prelude_call(
                     RESULT_OK_CTOR,
                     format!("[{}, {}]", inner_ty, err_ty),
                     vec![value],
@@ -143,13 +145,16 @@ impl Fallible {
     }
 }
 
-pub(crate) fn generic_call(
+pub(crate) fn prelude_call(
     callee: &str,
     type_arguments: String,
     arguments: Vec<GoExpression>,
 ) -> GoExpression {
     GoExpression::call(
-        GoExpression::instantiation(GoExpression::name(callee.to_string()), type_arguments),
+        GoExpression::instantiation(
+            GoExpression::generated(GeneratedPackage::Prelude, callee),
+            type_arguments,
+        ),
         arguments,
     )
 }
@@ -224,10 +229,9 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
     }
 
     pub(crate) fn full_type_string(&mut self) -> String {
-        self.planner.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.ok_type_string();
-        if self.fallible.is_result() {
+        let code = if self.fallible.is_result() {
             let err_ty = self.planner.use_go_type(
                 self.fallible
                     .err_ty()
@@ -242,11 +246,11 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
             )
         } else {
             format!("{}.{}[{}]", pkg, self.fallible.struct_name(), inner_ty)
-        }
+        };
+        self.planner.use_rendered_go_type(GoType::stdlib(code))
     }
 
     pub(crate) fn emit_success(&mut self, value: GoExpression) -> GoExpression {
-        self.planner.require_stdlib();
         let inner_ty = self.ok_type_string();
         let err_ty = self.err_type_string();
         self.fallible
@@ -254,7 +258,6 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
     }
 
     pub(crate) fn emit_failure(&mut self, error_value: Option<GoExpression>) -> GoExpression {
-        self.planner.require_stdlib();
         let inner_ty = self.ok_type_string();
         if self.fallible.is_result() {
             let err_ty = self.err_type_string().expect("Result must have error type");
@@ -269,7 +272,6 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
         &mut self,
         error_value: Option<GoExpression>,
     ) -> GoExpression {
-        self.planner.require_stdlib();
         let inner_ty = self.contextual_ok_type_string();
         if self.fallible.is_result() {
             let err_ty = self
@@ -298,7 +300,10 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
             format!("[{}]", inner_ty)
         };
         GoExpression::call(
-            GoExpression::instantiation(GoExpression::name(constructor.to_string()), type_args),
+            GoExpression::instantiation(
+                GoExpression::generated(GeneratedPackage::Prelude, constructor),
+                type_args,
+            ),
             arg.into_iter().collect(),
         )
     }
@@ -310,11 +315,11 @@ fn make_failure(
     error_value: Option<GoExpression>,
 ) -> GoExpression {
     match err_ty {
-        Some(err_ty) => generic_call(
+        Some(err_ty) => prelude_call(
             RESULT_ERR_CTOR,
             format!("[{}, {}]", inner_ty, err_ty),
             error_value.into_iter().collect(),
         ),
-        None => generic_call(OPTION_NONE_CTOR, format!("[{}]", inner_ty), Vec::new()),
+        None => prelude_call(OPTION_NONE_CTOR, format!("[{}]", inner_ty), Vec::new()),
     }
 }

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -5,6 +5,7 @@ use crate::abi::transition;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{LoweredBlock, LoweredStatement, define};
 use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::placement::is_unit_call;
@@ -15,8 +16,6 @@ use syntax::types::Type;
 impl Planner<'_> {
     /// `try { ... }` → `result := func() T { ... }()`; value is the bound result var.
     pub(crate) fn lower_try_block(&mut self, items: &[Expression], ty: &Type) -> ValuePlan {
-        self.require_stdlib();
-
         let return_ctx = self.return_ctx();
         let ty = self.facts.peel_alias(ty);
         let effective_ty = resolve_fallible_block_type(items, &ty, Some(&return_ctx));
@@ -160,7 +159,6 @@ impl Planner<'_> {
             };
             statements.push(transition::multi_value_return(values));
         } else {
-            self.require_stdlib();
             let err_arg = err_arg.map(|value| {
                 self.convert_error_to_return_context(&mut statements, value, fallible)
             });
@@ -175,8 +173,6 @@ impl Planner<'_> {
 
     /// `recover { ... }` → `result := lisette.RecoverBlock(func() T { ... })`.
     pub(crate) fn lower_recover_block(&mut self, items: &[Expression], ty: &Type) -> ValuePlan {
-        self.require_stdlib();
-
         let return_ctx = self.return_ctx();
         let ty = self.facts.peel_alias(ty);
         let effective_ty = resolve_fallible_block_type(items, &ty, Some(&return_ctx));
@@ -197,7 +193,7 @@ impl Planner<'_> {
         let setup = vec![define(
             result_var.clone(),
             GoExpression::call(
-                GoExpression::name("lisette.RecoverBlock".to_string()),
+                GoExpression::generated(GeneratedPackage::Prelude, "RecoverBlock"),
                 vec![GoExpression::function_literal(
                     String::new(),
                     inner_ty_str,

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -1,7 +1,9 @@
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
+use crate::names::go_name::GeneratedPackage;
 use crate::patterns::binding_decls::pattern_has_bindings;
 use crate::patterns::sites::PatternSubject;
+use crate::plan::bodies::GoUses;
 use crate::plan::bodies::{LoopHeader, LoweredBlock, LoweredStatement, define, directed, discard};
 use crate::plan::values::{CaptureBoundary, GoExpression};
 use crate::types::native::NativeGoType;
@@ -209,9 +211,8 @@ impl Planner<'_> {
             .native_shape(&iterable_ty)
             .is_some_and(|shape| matches!(shape, NativeGoType::Channel | NativeGoType::Receiver));
         if is_channel {
-            self.require_stdlib();
             iter_expression = GoExpression::call(
-                GoExpression::name("lisette.ChannelRange".to_string()),
+                GoExpression::generated(GeneratedPackage::Prelude, "ChannelRange"),
                 vec![iter_expression],
             );
         }
@@ -330,36 +331,19 @@ impl Planner<'_> {
             iterable: iter_expression,
         };
 
-        let ((mut bindings, lowered_body), used) = self.capture_go_uses(|this| {
-            let key_statements = this.lower_irrefutable_pattern_site(
-                PatternSubject::for_value(key_var.clone()),
-                first,
-                first_ty,
-            );
-            let key_block = LoweredBlock {
-                statements: key_statements,
-            };
-            if !key_block.renders_empty() {
-                this.scope.record_go_use(&key_var);
-            }
-            let value_statements = this.lower_irrefutable_pattern_site(
-                PatternSubject::for_value(value_var.clone()),
-                second,
-                second_ty,
-            );
-            let value_block = LoweredBlock {
-                statements: value_statements,
-            };
-            if !value_block.renders_empty() {
-                this.scope.record_go_use(&value_var);
-            }
-            let mut bindings = key_block.statements;
-            bindings.extend(value_block.statements);
-            (bindings, this.lower_block_as_body(body))
-        });
+        let mut bindings = self.lower_irrefutable_pattern_site(
+            PatternSubject::for_value(key_var.clone()),
+            first,
+            first_ty,
+        );
+        bindings.extend(self.lower_irrefutable_pattern_site(
+            PatternSubject::for_value(value_var.clone()),
+            second,
+            second_ty,
+        ));
+        bindings.extend(self.lower_block_as_body(body).statements);
 
-        bindings.extend(lowered_body.statements);
-
+        let used = GoUses::of(&bindings);
         let references_value = used.contains(&value_var);
         let references_key = used.contains(&key_var);
 
@@ -397,24 +381,14 @@ impl Planner<'_> {
                 } else {
                     range_header("_", Some(&item_var), iter_expression)
                 };
-                let ((mut bindings, lowered_body), used) = this.capture_go_uses(|this| {
-                    let binding_statements = this.lower_irrefutable_pattern_site(
-                        PatternSubject::for_value(item_var.clone()),
-                        &binding.pattern,
-                        &binding.ty,
-                    );
-                    let binding_block = LoweredBlock {
-                        statements: binding_statements,
-                    };
-                    if !binding_block.renders_empty() {
-                        this.scope.record_go_use(&item_var);
-                    }
-                    (binding_block.statements, this.lower_block_as_body(body))
-                });
+                let mut bindings = this.lower_irrefutable_pattern_site(
+                    PatternSubject::for_value(item_var.clone()),
+                    &binding.pattern,
+                    &binding.ty,
+                );
+                bindings.extend(this.lower_block_as_body(body).statements);
 
-                bindings.extend(lowered_body.statements);
-
-                let references_item = used.contains(&item_var);
+                let references_item = GoUses::of(&bindings).contains(&item_var);
 
                 let mut statements = Vec::new();
                 if !references_item {

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -6,6 +6,7 @@ use crate::calls::go_interop::{NilGuard, non_nil, unexpected_nil_error};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::is_go_never;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     Definition, LoweredBlock, LoweredStatement, PlacePlan, ReturnForm, assign, define,
 };
@@ -56,7 +57,6 @@ impl Planner<'_> {
             return fused;
         }
 
-        self.require_stdlib();
         let (check_setup, check) = self.hoist_propagate_check_var(expression);
         statements.extend(check_setup);
         statements.push(self.build_propagate_failure_check(&check, &fallible));
@@ -106,8 +106,8 @@ impl Planner<'_> {
         expression: &Expression,
     ) -> (Vec<LoweredStatement>, GoExpression) {
         let plan = self.plan_operand(expression, ExpressionContext::value());
-        let requires_capture = !matches!(expression, Expression::Identifier { .. })
-            || plan.expression.contains_deferred_evaluation();
+        let requires_capture =
+            !matches!(expression, Expression::Identifier { .. }) || plan.expression.does_work();
         let (mut setup, value) = plan.into_parts();
         if requires_capture {
             let check = self.hoist_tmp_value_statement(&mut setup, "check", value);
@@ -133,7 +133,7 @@ impl Planner<'_> {
             GoExpression::binary(
                 GoExpression::selector(check.clone(), "Tag".to_string()),
                 "!=",
-                GoExpression::name(fallible.success_tag().to_string()),
+                GoExpression::generated(GeneratedPackage::Prelude, fallible.success_tag()),
             ),
             setup,
             values,
@@ -263,16 +263,11 @@ impl Planner<'_> {
 
         if comma_ok {
             let failure_condition = match nil_guard {
-                Some(guard) => {
-                    if guard.is_interface() {
-                        self.require_stdlib();
-                    }
-                    GoExpression::binary(
-                        GoExpression::unary("!", outcome()),
-                        "||",
-                        guard.is_nil(guarded_value()),
-                    )
-                }
+                Some(guard) => GoExpression::binary(
+                    GoExpression::unary("!", outcome()),
+                    "||",
+                    guard.is_nil(guarded_value()),
+                ),
                 None => GoExpression::unary("!", outcome()),
             };
             let (failure_setup, failure_values) =
@@ -293,10 +288,6 @@ impl Planner<'_> {
                 failure_values,
             ));
             if let Some(guard) = nil_guard {
-                if guard.is_interface() {
-                    self.require_stdlib();
-                }
-                self.require_errors();
                 let error = self.wrap_error(&wraps, unexpected_nil_error());
                 let (nil_setup, nil_failure) = self.propagate_failure_values(fallible, error);
                 statements.push(transition::tag_check(
@@ -384,10 +375,7 @@ impl Planner<'_> {
         let plan = self.lower_value(expression, ExpressionContext::value());
         ReturnForm::Plain {
             value: plan.map_expression_as_computed(|setup, raw_value| {
-                let contains_deferred_evaluation = raw_value.contains_deferred_evaluation();
-                let final_value =
-                    self.apply_type_coercion(setup, return_ctx.ty(), expression, raw_value);
-                final_value.with_deferred_evaluation(contains_deferred_evaluation)
+                self.apply_type_coercion(setup, return_ctx.ty(), expression, raw_value)
             }),
         }
     }

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -3,6 +3,7 @@ use crate::context::expression::ExpressionContext;
 use crate::patterns::sites::{
     self, AnnotatedPattern, PatternSubject, TypedSubject, unwrap_some_pattern,
 };
+use crate::plan::bodies::GoUses;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan,
     SelectStatementPlan, assign, discard,
@@ -286,24 +287,22 @@ impl Planner<'_> {
         let (receiver_var, ok_var, then_statements) = self.with_binding_frame(|this| {
             let receiver_var = prepare_receiver(this);
             let ok_var = this.fresh_ok_var();
-            let (body_statements, used) = this.capture_go_uses(|this| {
-                if let Some(pattern) = inner_pattern {
-                    this.lower_select_receive_pattern_site(
-                        TypedSubject {
-                            var: &receiver_var,
-                            ty: &ctx.element_ty,
-                        },
-                        AnnotatedPattern { pattern },
-                        ctx.body,
-                        ctx.default_body,
-                        ctx.place,
-                    )
-                } else {
-                    this.lower_block_to_place(ctx.body, ctx.place).statements
-                }
-            });
+            let body_statements = if let Some(pattern) = inner_pattern {
+                this.lower_select_receive_pattern_site(
+                    TypedSubject {
+                        var: &receiver_var,
+                        ty: &ctx.element_ty,
+                    },
+                    AnnotatedPattern { pattern },
+                    ctx.body,
+                    ctx.default_body,
+                    ctx.place,
+                )
+            } else {
+                this.lower_block_to_place(ctx.body, ctx.place).statements
+            };
             let mut then_statements: Vec<LoweredStatement> = Vec::new();
-            if !used.contains(&receiver_var) {
+            if !GoUses::of(&body_statements).contains(&receiver_var) {
                 then_statements.push(discard(GoExpression::name(receiver_var.clone())));
             }
             then_statements.extend(body_statements);
@@ -501,27 +500,23 @@ impl Planner<'_> {
                 this.classify_receive_var_pattern(receiver_var_pattern);
             let ok_var = this.fresh_ok_var();
 
-            let (arms_plan, used) = this.capture_go_uses(|this| {
-                let some_block = this.lower_receive_some_arm(
-                    some_arm,
-                    match_arms,
-                    TypedSubject {
-                        var: &case_var,
-                        ty: element_ty,
-                    },
-                    needs_receiver_destructure,
-                    place,
-                );
-                let none_block = this.capture_scoped_block(|this| {
-                    sites::lower_none_arm_body(this, match_arms, place)
-                });
-
-                let arms_plan = build_receive_arms_plan(&ok_var, some_block, none_block);
-                if arms_plan.is_some() {
-                    this.scope.record_go_use(&ok_var);
-                }
-                arms_plan
-            });
+            let some_block = this.lower_receive_some_arm(
+                some_arm,
+                match_arms,
+                TypedSubject {
+                    var: &case_var,
+                    ty: element_ty,
+                },
+                needs_receiver_destructure,
+                place,
+            );
+            let none_block = this
+                .capture_scoped_block(|this| sites::lower_none_arm_body(this, match_arms, place));
+            let arms_plan = build_receive_arms_plan(&ok_var, some_block, none_block);
+            let mut used = GoUses::default();
+            if let Some(plan) = &arms_plan {
+                used.extend_if(plan);
+            }
 
             // Per-var discards (emitted when the body does not reference the var)
             // precede the structured body inside the `case x, ok := <-ch:` arm.
@@ -579,7 +574,6 @@ impl Planner<'_> {
 
 /// `*&x` is `x`. Any other pointer gets dereferenced.
 fn cancel_deref_of_address(channel: GoExpression) -> GoExpression {
-    let contains_deferred_evaluation = channel.contains_deferred_evaluation();
     let addressed = match channel.node() {
         GoExpressionNode::AddressOf(inner) => Some(inner.as_ref()),
         GoExpressionNode::Parenthesized(inner) => match inner.as_ref() {
@@ -589,8 +583,7 @@ fn cancel_deref_of_address(channel: GoExpression) -> GoExpression {
         _ => None,
     };
     match addressed {
-        Some(inner) => GoExpression::from_node(inner.clone())
-            .with_deferred_evaluation(contains_deferred_evaluation),
+        Some(inner) => GoExpression::from_node(inner.clone()),
         None => GoExpression::dereference(channel),
     }
 }

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -160,13 +160,13 @@ impl Planner<'_> {
                             access
                         }
                     };
-                    self.equality_expression(
+                    let comparison = self.equality_expression(
                         field(&receiver),
                         field(&other),
                         &sem_field.ty,
                         &sem_generics,
-                    )
-                    .rendered()
+                    );
+                    self.render_expression(&comparison)
                 })
                 .collect();
             cases.push(format!(

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -69,6 +69,7 @@ impl Planner<'_> {
         should_return: bool,
     ) {
         let lowered = self.lower_function_body(body, should_return);
+        self.collect_imports(&lowered.statements);
         Renderer.render_lowered_block(output, &lowered);
     }
 
@@ -411,6 +412,7 @@ impl Planner<'_> {
                 &pattern,
                 &param_ty,
             );
+            self.collect_imports(&statements);
             Renderer.render_lowered_block(body, &LoweredBlock { statements });
         }
         self.emit_function_body(

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -397,6 +397,7 @@ impl Planner<'_> {
         inner_call: GoExpression,
     ) -> (String, String) {
         let (go_ret, statements) = self.plan_adapter_body(method, inner_call);
+        self.collect_imports(&statements);
         (go_ret, crate::Renderer.render_setup(&statements))
     }
 

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -477,8 +477,9 @@ impl Planner<'_> {
                 let field = |base: &str| {
                     GoExpression::selector(GoExpression::name(base.to_string()), go_field.clone())
                 };
-                self.equality_expression(field(&receiver), field(&other), &f.ty, generics)
-                    .rendered()
+                let comparison =
+                    self.equality_expression(field(&receiver), field(&other), &f.ty, generics);
+                self.render_expression(&comparison)
             })
             .collect();
         let body = if comparisons.is_empty() {

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -107,6 +107,7 @@ impl Planner<'_> {
         ty: &Type,
     ) -> String {
         let plan = self.build_const_plan(identifier, expression, ty, ConstScope::Package);
+        self.collect_value_imports(&plan.value);
         let mut out = String::new();
         Renderer.render_const_declaration(&mut out, &plan);
         out.trim_end_matches('\n').to_string()

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -50,10 +50,12 @@ impl Planner<'_> {
 
         let expression_ty = expression.get_type();
 
-        let base_plan = if let Some(package) = expression_ty.as_import_namespace() {
-            ValuePlan::captured(Vec::new(), self.require_package_import(package))
-        } else {
-            self.plan_coerced_expression(expression, receiver_coercion, ctx)
+        let package = expression_ty
+            .as_import_namespace()
+            .map(|package| self.package_use_for_package(package));
+        let base_plan = match &package {
+            Some(package) => ValuePlan::captured(Vec::new(), package.qualifier().to_string()),
+            None => self.plan_coerced_expression(expression, receiver_coercion, ctx),
         };
         let effect = base_plan.evaluation.effect;
         let stability = if reads_value_member(
@@ -71,23 +73,10 @@ impl Planner<'_> {
             expression: base,
             ..
         } = base_plan;
-        let base_contains_deferred_evaluation = base.contains_deferred_evaluation();
-
         if let Some(member_access) =
             self.try_emit_tuple_member_dot(&base, &expression_ty, member, dot_access_kind)
         {
-            let is_newtype_conversion = matches!(
-                dot_access_kind,
-                Some(SemanticDotKind::TupleStructField { is_newtype: true })
-            );
-            return ValuePlan::computed(
-                setup,
-                member_access.with_deferred_evaluation(
-                    base_contains_deferred_evaluation || is_newtype_conversion,
-                ),
-                effect,
-            )
-            .with_stability(stability);
+            return ValuePlan::computed(setup, member_access, effect).with_stability(stability);
         }
 
         let is_exported =
@@ -111,7 +100,10 @@ impl Planner<'_> {
             return ValuePlan::computed(setup, wrapped, effect);
         }
 
-        let selector = GoExpression::selector(base, field);
+        let selector = match package {
+            Some(package) => GoExpression::qualified(package, field),
+            None => GoExpression::selector(base, field),
+        };
         let expression =
             self.append_cross_package_type_args(selector, &expression_ty, member, result_ty, ctx);
         ValuePlan::computed(setup, expression, effect).with_stability(stability)

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -44,16 +44,11 @@ impl Planner<'_> {
                 "base",
             );
             let effect = sequenced.effect;
-            let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
             let mut values = sequenced.values.into_iter();
             let base = values.next().expect("range index has a base");
             let range = values.next().expect("range index has a range");
             let value = range_var_slice(base, &range, &range_kind, needs_cap);
-            return ValuePlan::computed(
-                sequenced.setup,
-                value.with_deferred_evaluation(contains_deferred_evaluation),
-                effect,
-            );
+            return ValuePlan::computed(sequenced.setup, value, effect);
         }
 
         self.sequence_indexed_access(expression, base_staged, index, "base")
@@ -142,10 +137,7 @@ impl Planner<'_> {
             );
         }
 
-        if end_value
-            .as_ref()
-            .is_none_or(GoExpression::contains_deferred_evaluation)
-        {
+        if end_value.as_ref().is_none_or(GoExpression::does_work) {
             let base_expr = expression.deref_inner().unwrap_or(expression);
             if is_order_sensitive(base_expr) {
                 base = GoExpression::name(self.hoist_tmp_value_statement(&mut setup, "base", base));

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -12,11 +12,13 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::definitions::enum_layout;
 use crate::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{
     LoopHeader, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, assign, discard,
 };
 use crate::plan::go_expression::{CompositeLayout, FunctionLiteralLayout};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::types::go_type::GoType;
 use crate::utils::is_order_sensitive;
 use syntax::program::AliasKind;
 use syntax::types;
@@ -26,7 +28,6 @@ struct SpreadInput<'a> {
     base: &'a Expression,
     base_staged: ValuePlan,
     field_pairs: Vec<(String, GoExpression)>,
-    fields_contain_deferred_evaluation: bool,
 }
 
 struct StructCallContext<'a> {
@@ -39,7 +40,7 @@ struct StructCallContext<'a> {
 struct EnumCallContext {
     enum_id: String,
     variant_name: String,
-    tag_constant: String,
+    tag_constant: GoExpression,
     /// Fields that need pointer wrapping (recursive types).
     pointer_fields: HashSet<String>,
 }
@@ -72,7 +73,7 @@ impl Planner<'_> {
         let tag_field = ctx.enum_ctx.as_ref().map(|e| {
             (
                 enum_layout::ENUM_TAG_FIELD.to_string(),
-                GoExpression::name(e.tag_constant.clone()),
+                e.tag_constant.clone(),
             )
         });
 
@@ -113,7 +114,6 @@ impl Planner<'_> {
             .collect();
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "field");
         let mut effect = sequenced.effect;
-        let fields_contain_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
         let emitted_values = sequenced.values;
 
@@ -167,7 +167,6 @@ impl Planner<'_> {
                     }
                     setup.push(self.lower_statement(base));
                     GoExpression::empty_composite(ctx.go_type.clone())
-                        .with_deferred_evaluation(fields_contain_deferred_evaluation)
                 } else {
                     let base_staged = self.plan_operand(base, ExpressionContext::value());
                     effect = effect.combine(base_staged.evaluation.effect);
@@ -178,7 +177,6 @@ impl Planner<'_> {
                                 base,
                                 base_staged,
                                 field_pairs,
-                                fields_contain_deferred_evaluation,
                             },
                             &ctx,
                             field_assignments,
@@ -192,28 +190,18 @@ impl Planner<'_> {
                 }
             }
             StructSpread::Autofill { .. } => match self.go_imported_newtype_zero(ty) {
-                Some(zero) => zero.with_deferred_evaluation(false),
+                Some(zero) => zero,
                 None => {
                     let mut field_pairs =
                         fields.into_iter().map(StructCallField::into_pair).collect();
                     self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
-                    emit_struct_literal(
-                        &ctx.go_type,
-                        field_pairs,
-                        expression_ctx,
-                        fields_contain_deferred_evaluation,
-                    )
+                    emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx)
                 }
             },
             StructSpread::None => {
                 let field_pairs: Vec<_> =
                     fields.into_iter().map(StructCallField::into_pair).collect();
-                emit_struct_literal(
-                    &ctx.go_type,
-                    field_pairs,
-                    expression_ctx,
-                    fields_contain_deferred_evaluation,
-                )
+                emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx)
             }
         };
 
@@ -437,7 +425,7 @@ impl Planner<'_> {
                 };
                 pairs.push((go_field_name, zero));
             }
-            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value(), false);
+            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value());
         }
         GoExpression::empty_composite(go_ty)
     }
@@ -503,10 +491,9 @@ impl Planner<'_> {
                 .first()
                 .map(|a| self.use_go_type(a))
                 .unwrap_or_else(|| "any".to_string());
-            self.require_stdlib();
             return GoExpression::call(
                 GoExpression::instantiation(
-                    GoExpression::name(format!("{}.MakeOptionNone", go_name::GO_STDLIB_PKG)),
+                    GoExpression::generated(GeneratedPackage::Prelude, "MakeOptionNone"),
                     format!("[{inner}]"),
                 ),
                 Vec::new(),
@@ -540,7 +527,7 @@ impl Planner<'_> {
                     (go_name, self.lisette_zero(&field_ty))
                 })
                 .collect();
-            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value(), false);
+            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value());
         }
         if let Some(underlying) = self.facts.underlying_type(ty) {
             return self.lisette_zero(&underlying);
@@ -638,10 +625,6 @@ impl Planner<'_> {
 
         let go_type = self.compute_struct_call_go_type(name, ty, is_prelude, enum_id.is_some());
 
-        if let Some(ref id) = enum_id {
-            self.add_enum_imports_if_needed(name, id);
-        }
-
         let enum_ctx = enum_id.map(|id| self.compute_enum_call_context(name, &id));
 
         StructCallContext {
@@ -694,8 +677,9 @@ impl Planner<'_> {
                 } else {
                     go_name::snake_to_camel(type_name)
                 };
-                let pkg = self.require_package_import(&canonical);
-                return format!("{}.{}{}", pkg, member, type_args);
+                let package = self.package_use_for_package(&canonical);
+                let go_type = format!("{}.{}{}", package.qualifier(), member, type_args);
+                return self.use_rendered_go_type(GoType::with_package(go_type, package));
             }
         }
 
@@ -744,21 +728,6 @@ impl Planner<'_> {
             variant_name,
             tag_constant,
             pointer_fields,
-        }
-    }
-
-    fn add_enum_imports_if_needed(&mut self, name: &str, enum_id: &str) {
-        if let Some(enum_package) = self.facts.package_for_qualified_name(enum_id)
-            && !self.facts.is_current_package(enum_package)
-        {
-            let enum_package = enum_package.to_string();
-            self.require_package_import(&enum_package);
-        }
-
-        let parts: Vec<&str> = name.split('.').collect();
-        if parts.len() == 3 {
-            let package = self.canonical_package(parts[0]);
-            self.require_package_import(&package);
         }
     }
 
@@ -834,7 +803,6 @@ impl Planner<'_> {
             base,
             base_staged,
             mut field_pairs,
-            fields_contain_deferred_evaluation,
         } = input;
         let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
         let carried = self
@@ -851,12 +819,7 @@ impl Planner<'_> {
             statements.push(discard(base_value));
             return (
                 statements,
-                emit_struct_literal(
-                    &ctx.go_type,
-                    field_pairs,
-                    expression_ctx,
-                    fields_contain_deferred_evaluation,
-                ),
+                emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx),
             );
         }
 
@@ -875,12 +838,7 @@ impl Planner<'_> {
         }
         (
             statements,
-            emit_struct_literal(
-                &ctx.go_type,
-                field_pairs,
-                expression_ctx,
-                fields_contain_deferred_evaluation,
-            ),
+            emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx),
         )
     }
 }
@@ -953,7 +911,6 @@ pub(crate) fn emit_struct_literal(
     ty: &str,
     fields: Vec<(String, GoExpression)>,
     ctx: ExpressionContext<'_>,
-    contains_deferred_evaluation: bool,
 ) -> GoExpression {
     let layout = if fields.len() > 1 {
         CompositeLayout::MultiLine { indented: false }
@@ -964,17 +921,16 @@ pub(crate) fn emit_struct_literal(
         Some(ty.to_string()),
         fields
             .into_iter()
-            .map(|(name, value)| (Some(name), value))
+            .map(|(name, value)| (Some(GoExpression::name(name)), value))
             .collect(),
         layout,
-        contains_deferred_evaluation,
     );
 
     // Generic composite literals (`Type[Args]{...}`) need inner parens in
     // condition contexts because gofmt strips outer condition parens for
     // generics, producing invalid Go in `if`/`for`/`switch`.
     if ctx.is_condition() && ty.contains('[') {
-        GoExpression::parenthesized(literal).with_deferred_evaluation(contains_deferred_evaluation)
+        GoExpression::parenthesized(literal)
     } else {
         literal
     }

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -3,6 +3,7 @@ use crate::context::expression::ExpressionContext;
 use crate::expressions::identifiers::method_expression;
 use crate::names::go_name;
 use crate::plan::values::GoExpression;
+use crate::types::go_type::GoType;
 use syntax::ast::Expression;
 use syntax::program::DefinitionBody;
 use syntax::types::{Type, unqualified_name};
@@ -72,22 +73,17 @@ impl Planner<'_> {
 
         let make_fn = if needs_qualifier {
             if make_fn_name.starts_with(go_name::PRELUDE_PREFIX) {
-                let resolved = go_name::resolve(&make_fn_name);
-                if let Some(package) = resolved.package {
-                    self.require_generated_package(package);
-                }
-                resolved.name.to_string()
+                go_name::resolve(&make_fn_name).into_expression()
             } else {
-                let pkg = self.require_package_import(enum_package);
-                format!("{}.{}", pkg, make_fn_name)
+                GoExpression::qualified(
+                    self.package_use_for_package(enum_package),
+                    make_fn_name.to_string(),
+                )
             }
         } else {
-            make_fn_name.to_string()
+            GoExpression::name(make_fn_name.to_string())
         };
-        Some(GoExpression::instantiation(
-            GoExpression::name(make_fn),
-            type_args,
-        ))
+        Some(GoExpression::instantiation(make_fn, type_args))
     }
 
     fn emit_unit_variant_constructor(
@@ -122,19 +118,17 @@ impl Planner<'_> {
         let type_args = self.format_type_args(params);
 
         let callee = if is_prelude {
-            let resolved = go_name::resolve(&make_fn);
-            if let Some(package) = resolved.package {
-                self.require_generated_package(package);
-            }
-            resolved.name.to_string()
+            go_name::resolve(&make_fn).into_expression()
         } else if is_cross_package {
-            let pkg = self.require_package_import(enum_package);
-            format!("{}.{}", pkg, make_fn)
+            GoExpression::qualified(
+                self.package_use_for_package(enum_package),
+                make_fn.to_string(),
+            )
         } else {
-            make_fn.to_string()
+            GoExpression::name(make_fn.to_string())
         };
         Some(GoExpression::call(
-            GoExpression::instantiation(GoExpression::name(callee), type_args),
+            GoExpression::instantiation(callee, type_args),
             Vec::new(),
         ))
     }
@@ -161,9 +155,7 @@ impl Planner<'_> {
         let resolved_name = format!("{}.{}", real_type, member);
 
         let capitalized = self.capitalize_static_method_if_public(&resolved_name);
-        let go_name = self.resolve_go_name(&capitalized, None, false);
-
-        Some(GoExpression::name(go_name))
+        Some(self.resolve_go_name(&capitalized, None, false))
     }
 
     /// Instance method used as a value (e.g. `lib.Point.area` callback →
@@ -222,12 +214,14 @@ impl Planner<'_> {
             go_name::unexported_method_go_name(member)
         };
 
-        let pkg = self.require_package_import(package_name);
+        let package = self.package_use_for_package(package_name);
         let go_type_name = go_name::snake_to_camel(type_name);
         let type_args = self.method_expression_type_args(result_ty);
+        let receiver_type = format!("{}.{}{}", package.qualifier(), go_type_name, type_args);
+        let receiver_type = self.use_rendered_go_type(GoType::with_package(receiver_type, package));
 
         Some(method_expression(
-            format!("{}.{}{}", pkg, go_type_name, type_args),
+            receiver_type,
             is_pointer_receiver,
             go_method,
         ))
@@ -331,9 +325,6 @@ impl Planner<'_> {
             String::new()
         };
 
-        Some(GoExpression::instantiation(
-            GoExpression::name(qualified_name),
-            type_args,
-        ))
+        Some(GoExpression::instantiation(qualified_name, type_args))
     }
 }

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -29,34 +29,22 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
     ) -> GoExpression {
         if let Some(BindingValue::InlineExpr(expr)) = self.scope.resolve_identifier_binding(value) {
-            let expression = expr.expression().clone();
-            let refs = expr.refs().to_vec();
-            for go_name in &refs {
-                self.scope.record_go_use(go_name);
-            }
-            return expression;
+            return expr.expression().clone();
         }
         let bound_go_name = self
             .scope
             .resolve_binding_go_name(value)
             .map(str::to_string);
-        if let Some(go_name) = &bound_go_name {
-            self.scope.record_go_use(go_name);
-        }
         match self.classify_identifier(value, ty, ctx) {
             IdentifierKind::UnitValue => GoExpression::empty_composite("struct{}".to_string()),
             IdentifierKind::PublicFunction { capitalized } => GoExpression::name(capitalized),
             IdentifierKind::UnitConstructor { name, type_args } => GoExpression::call(
-                GoExpression::instantiation(
-                    GoExpression::name(self.resolve_go_name(&name, None, false)),
-                    type_args,
-                ),
+                GoExpression::instantiation(self.resolve_go_name(&name, None, false), type_args),
                 Vec::new(),
             ),
-            IdentifierKind::ConstructorFunction { name, type_args } => GoExpression::instantiation(
-                GoExpression::name(self.resolve_go_name(&name, None, false)),
-                type_args,
-            ),
+            IdentifierKind::ConstructorFunction { name, type_args } => {
+                GoExpression::instantiation(self.resolve_go_name(&name, None, false), type_args)
+            }
             IdentifierKind::Regular { name } => {
                 if let Some(expression) = self.try_emit_method_expression(&name, ty) {
                     return expression;
@@ -66,9 +54,9 @@ impl Planner<'_> {
                 if !ctx.is_callee()
                     && let Some(type_args) = self.format_generic_value_type_args(&name, ty)
                 {
-                    return GoExpression::instantiation(GoExpression::name(go_name), type_args);
+                    return GoExpression::instantiation(go_name, type_args);
                 }
-                GoExpression::name(go_name)
+                go_name
             }
         }
     }
@@ -319,7 +307,7 @@ impl Planner<'_> {
     pub(crate) fn try_resolve_cross_package_static_method(
         &mut self,
         qualified: Option<&str>,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let id = qualified?;
         let package_name = self.facts.package_for_qualified_name(id)?.to_string();
         if self.facts.is_current_package(&package_name) {

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::context::expression::ExpressionContext;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::{
     CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, ValuePlan,
@@ -109,7 +110,6 @@ impl Planner<'_> {
             .collect();
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "v");
         let effect = sequenced.effect;
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
 
         let mut wrapped = Vec::with_capacity(sequenced.values.len());
@@ -133,7 +133,7 @@ impl Planner<'_> {
         let layout = CompositeLayout::for_elements(wrapped.len(), widest);
         ValuePlan::computed(
             setup,
-            GoExpression::composite(Some(go_type), wrapped, layout, contains_deferred_evaluation),
+            GoExpression::composite(Some(go_type), wrapped, layout),
             effect,
         )
     }
@@ -196,7 +196,6 @@ impl Planner<'_> {
             return ValuePlan::evaluated_literal(setup, format!("\"{}\"", format_string), effect);
         }
 
-        self.require_fmt();
         // Solo-expression f-strings round-trip through fmt.Sprint, which skips
         // the format-string parse. Excluded: `%c`, because Sprint on a rune
         // prints the integer codepoint instead of the character.
@@ -205,7 +204,10 @@ impl Planner<'_> {
         {
             return ValuePlan::observable_call(
                 setup,
-                GoExpression::call(GoExpression::name("fmt.Sprint".to_string()), args),
+                GoExpression::call(
+                    GoExpression::generated(GeneratedPackage::Fmt, "Sprint"),
+                    args,
+                ),
                 effect,
             );
         }
@@ -213,7 +215,10 @@ impl Planner<'_> {
         arguments.extend(args);
         ValuePlan::observable_call(
             setup,
-            GoExpression::call(GoExpression::name("fmt.Sprintf".to_string()), arguments),
+            GoExpression::call(
+                GoExpression::generated(GeneratedPackage::Fmt, "Sprintf"),
+                arguments,
+            ),
             effect,
         )
     }

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -160,7 +160,6 @@ impl Planner<'_> {
                 LoweredBlock { statements },
                 FunctionLiteralLayout::MultiLine,
             )
-            .with_deferred_evaluation(true)
         };
 
         ValuePlan::computed(
@@ -247,11 +246,7 @@ impl Planner<'_> {
                 } else {
                     negated
                 };
-                return ValuePlan::computed(
-                    setup,
-                    negated.with_deferred_evaluation(true),
-                    EvaluationEffect::EffectfulCall,
-                );
+                return ValuePlan::computed(setup, negated, EvaluationEffect::EffectfulCall);
             }
         }
 

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -2,7 +2,7 @@ use crate::Planner;
 use crate::abi::is_tagged_shape_fn_value;
 use crate::abi::transition::lower_arg_to_tagged;
 use crate::context::expression::ExpressionContext;
-use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{LoweredStatement, define};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::go_expression::CompositeLayout;
@@ -55,7 +55,7 @@ impl LaterStages {
         let stage_has_setup = !stage.setup.is_empty();
         let value_pin = !stage_has_setup && self.can_change(stage.evaluation.stability);
         let ordering_pin = stage.evaluation.effect.has_call()
-            && stage.expression.contains_deferred_evaluation()
+            && stage.expression.does_work()
             && (self.has_setup || self.has_pin);
         let pinned = value_pin || ordering_pin;
 
@@ -256,7 +256,6 @@ impl Planner<'_> {
                     value,
                     param_ty.expect("detected lowering requires a parameter type"),
                 )
-                .with_deferred_evaluation(true)
             });
         }
 
@@ -332,10 +331,9 @@ impl Planner<'_> {
         combine: Option<VariadicCombine>,
     ) {
         if wrap_to_any {
-            self.require_stdlib();
             let spread_value = mem::replace(&mut values[spread_index], GoExpression::empty());
             values[spread_index] = GoExpression::call(
-                GoExpression::name(format!("{}.SliceToAny", go_name::GO_STDLIB_PKG)),
+                GoExpression::generated(GeneratedPackage::Prelude, "SliceToAny"),
                 vec![spread_value],
             );
         }
@@ -351,7 +349,6 @@ impl Planner<'_> {
                     Some(format!("[]{element_go}")),
                     combined.into_iter().map(|value| (None, value)).collect(),
                     CompositeLayout::Inline { padded: false },
-                    false,
                 );
                 let appended = GoExpression::call(
                     GoExpression::name("append".to_string()),

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -9,6 +9,7 @@ use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::abi::transition::emit_lisette_callback_wrapper;
 use crate::context::expression::ExpressionContext;
 use crate::is_order_sensitive;
+use crate::names::go_name::GeneratedPackage;
 use crate::plan::bodies::{LoweredBlock, LoweredStatement, assign, discard, expression_statement};
 use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::go_expression::FunctionLiteralLayout;
@@ -50,7 +51,7 @@ impl Planner<'_> {
                     return value.map_expression_as_computed(|setup, value| {
                         let (bridge_setup, value) = layout_coercion.lower(self, value);
                         setup.extend(bridge_setup);
-                        value.with_deferred_evaluation(true)
+                        value
                     });
                 }
             }
@@ -117,7 +118,7 @@ impl Planner<'_> {
             return call.map_expression_as_observable_computed(|setup, call| {
                 let (bridge_setup, value) = bridge.lower(self, call);
                 setup.extend(bridge_setup);
-                value.with_deferred_evaluation(false)
+                value
             });
         }
 
@@ -245,9 +246,9 @@ impl Planner<'_> {
                 if adapter_setup.is_empty() {
                     plan
                 } else {
-                    plan.map_expression_as_computed(|setup, identifier| {
+                    plan.map_expression_as_computed(|setup, _| {
                         setup.extend(adapter_setup);
-                        value.with_deferred_evaluation(identifier.contains_deferred_evaluation())
+                        value
                     })
                 }
             }
@@ -296,8 +297,7 @@ impl Planner<'_> {
                 let setup = self.lower_assignment_operand(target, value);
                 ValuePlan::computed(
                     setup,
-                    GoExpression::empty_composite("struct{}".to_string())
-                        .with_deferred_evaluation(false),
+                    GoExpression::empty_composite("struct{}".to_string()),
                     EvaluationEffect::Pure,
                 )
             }
@@ -335,8 +335,8 @@ impl Planner<'_> {
     }
 
     pub(crate) fn make_tuple_callee(&mut self, slot_types: &[Type], arity: usize) -> GoExpression {
-        self.require_stdlib();
-        let callee = GoExpression::name(format!("lisette.MakeTuple{}", arity));
+        let callee =
+            GoExpression::generated(GeneratedPackage::Prelude, format!("MakeTuple{arity}"));
         if slot_types.len() != arity {
             return callee;
         }
@@ -406,7 +406,7 @@ impl Planner<'_> {
             let mut converted = inner.map_expression_as_computed(|setup, value| {
                 let (coercion_setup, coerced) = coercion.lower(self, value);
                 setup.extend(coercion_setup);
-                coerced.with_deferred_evaluation(true)
+                coerced
             });
             if !converted.evaluation.stability.is_stable_across_calls() {
                 converted.make_observable();
@@ -424,7 +424,7 @@ impl Planner<'_> {
                 .map_expression_as_computed(|setup, value| {
                     let (bridge_setup, bridged) = function_bridge.lower(self, value);
                     setup.extend(bridge_setup);
-                    bridged.with_deferred_evaluation(true)
+                    bridged
                 })
                 .conversion(go_type);
         }
@@ -593,7 +593,6 @@ impl Planner<'_> {
 
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "range");
         let effect = sequenced.effect;
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut values = sequenced.values.into_iter();
         let mut fields = Vec::new();
         if has_start {
@@ -608,12 +607,7 @@ impl Planner<'_> {
             fields.push(("End".to_string(), values.next().expect("range has an end")));
         }
 
-        let value = emit_struct_literal(
-            &type_string,
-            fields,
-            ExpressionContext::value(),
-            contains_deferred_evaluation,
-        );
+        let value = emit_struct_literal(&type_string, fields, ExpressionContext::value());
         ValuePlan::computed(sequenced.setup, value, effect)
     }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -43,7 +43,8 @@ use names::go_name::GeneratedPackage;
 use names::packages::{PackageRequirements, PackageUse};
 use plan::PackagePlan;
 use plan::bodies::{LoopId, LoweredBlock, LoweredStatement, define};
-use plan::values::GoExpression;
+use plan::go_expression::GoExpressionNode;
+use plan::values::{GoExpression, ValuePlan};
 use state::adapter_registry::AdapterRegistry;
 use state::file_namespace::FileNamespace;
 use state::package_state::{FunctionEmissionContext, PackageState};
@@ -206,18 +207,6 @@ impl Planner<'_> {
         self.require_generated_package(GeneratedPackage::Errors);
     }
 
-    fn require_slices(&mut self) {
-        self.require_generated_package(GeneratedPackage::Slices);
-    }
-
-    fn require_strings(&mut self) {
-        self.require_generated_package(GeneratedPackage::Strings);
-    }
-
-    fn require_maps(&mut self) {
-        self.require_generated_package(GeneratedPackage::Maps);
-    }
-
     fn require_json(&mut self) {
         self.require_generated_package(GeneratedPackage::Json);
     }
@@ -249,6 +238,32 @@ impl Planner<'_> {
 
     fn require_packages(&mut self, requirements: &PackageRequirements) {
         self.namespace.absorb(requirements);
+    }
+
+    fn collect_imports(&mut self, statements: &[LoweredStatement]) {
+        let namespace = &mut self.namespace;
+        for statement in statements {
+            statement.visit_expressions(&mut |node| require_qualified(namespace, node));
+        }
+    }
+
+    fn collect_value_imports(&mut self, value: &ValuePlan) {
+        let namespace = &mut self.namespace;
+        value.visit_expressions(&mut |node| require_qualified(namespace, node));
+    }
+
+    fn render_expression(&mut self, expression: &GoExpression) -> String {
+        let namespace = &mut self.namespace;
+        expression
+            .node()
+            .visit(&mut |node| require_qualified(namespace, node));
+        expression.rendered()
+    }
+}
+
+fn require_qualified(namespace: &mut FileNamespace, node: &GoExpressionNode) {
+    if let GoExpressionNode::Qualified { package, .. } = node {
+        namespace.require(package.clone());
     }
 }
 
@@ -551,13 +566,6 @@ impl<'a> Planner<'a> {
             self.scope.deactivate_assign_target(target);
         }
         result
-    }
-
-    fn capture_go_uses<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> (R, HashSet<String>) {
-        self.scope.enter_use_region();
-        let result = f(self);
-        let uses = self.scope.exit_use_region();
-        (result, uses)
     }
 
     fn fresh_var(&mut self, hint: Option<&str>) -> String {

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -3,6 +3,9 @@ use std::borrow::Cow;
 use syntax::go_names::ENUM_TAG_FIELD;
 use syntax::types::Type;
 
+use crate::names::packages::PackageUse;
+use crate::plan::values::GoExpression;
+
 pub(crate) const GO_IMPORT_PREFIX: &str = "go:";
 
 pub(crate) fn is_go_import(id: &str) -> bool {
@@ -116,15 +119,15 @@ pub(crate) fn sanitize_package_name(name: &str) -> Cow<'_, str> {
 }
 
 pub(crate) struct ResolvedName {
-    pub(crate) name: String,
-    pub(crate) package: Option<GeneratedPackage>,
+    name: String,
+    package: Option<PackageUse>,
 }
 
 impl ResolvedName {
     fn stdlib(name: String) -> Self {
         Self {
             name,
-            package: Some(GeneratedPackage::Prelude),
+            package: Some(PackageUse::generated(GeneratedPackage::Prelude)),
         }
     }
 
@@ -132,6 +135,20 @@ impl ResolvedName {
         Self {
             name,
             package: None,
+        }
+    }
+
+    fn foreign(name: String, package: PackageUse) -> Self {
+        Self {
+            name,
+            package: Some(package),
+        }
+    }
+
+    pub(crate) fn into_expression(self) -> GoExpression {
+        match self.package {
+            Some(package) => GoExpression::qualified(package, self.name),
+            None => GoExpression::name(self.name),
         }
     }
 }
@@ -146,7 +163,7 @@ impl ResolvedName {
 pub(crate) fn resolve(name: &str) -> ResolvedName {
     if let Some(rest) = name.strip_prefix(PRELUDE_PREFIX) {
         let go_name: String = rest.split('.').map(snake_to_camel).collect();
-        ResolvedName::stdlib(format!("{}.{}", GO_STDLIB_PKG, go_name))
+        ResolvedName::stdlib(go_name)
     } else {
         ResolvedName::local(escape_reserved(&name.replace('.', "_")).into_owned())
     }
@@ -157,13 +174,13 @@ pub(crate) fn variant(
     ty: &Type,
     enum_package: &str,
     current_package: &str,
-    package_alias: Option<&str>,
+    package: Option<PackageUse>,
 ) -> ResolvedName {
     let Type::Nominal { id, .. } = ty else {
         return ResolvedName::local(identifier.replace('.', "_"));
     };
 
-    variant_by_id(identifier, id, enum_package, current_package, package_alias)
+    variant_by_id(identifier, id, enum_package, current_package, package)
 }
 
 pub(crate) fn variant_by_id(
@@ -171,19 +188,21 @@ pub(crate) fn variant_by_id(
     enum_id: &str,
     enum_package: &str,
     current_package: &str,
-    package_alias: Option<&str>,
+    package: Option<PackageUse>,
 ) -> ResolvedName {
     let is_prelude = enum_id.starts_with(PRELUDE_PREFIX);
     let enum_name = unqualified_name(enum_id);
     let variant_name = unqualified_name(identifier);
 
     if is_prelude {
-        ResolvedName::stdlib(format!("{}.{enum_name}{variant_name}", GO_STDLIB_PKG))
+        ResolvedName::stdlib(format!("{enum_name}{variant_name}"))
     } else {
         let base = enum_tag_constant(enum_name, variant_name);
         if enum_package != current_package {
-            let pkg = package_alias.unwrap_or_else(|| go_package_name(enum_package));
-            ResolvedName::local(format!("{pkg}.{base}"))
+            match package {
+                Some(package) => ResolvedName::foreign(base, package),
+                None => ResolvedName::local(format!("{}.{base}", go_package_name(enum_package))),
+            }
         } else {
             ResolvedName::local(base)
         }
@@ -318,7 +337,7 @@ pub(crate) fn qualify_method(
     method: &str,
     current_package: &str,
     is_public: bool,
-    package_alias: Option<&str>,
+    package_use: Option<PackageUse>,
 ) -> ResolvedName {
     let Some(package) = package else {
         let method_name = if is_public {
@@ -330,12 +349,7 @@ pub(crate) fn qualify_method(
     };
 
     if package == PRELUDE_PACKAGE {
-        ResolvedName::stdlib(format!(
-            "{}.{}{}",
-            GO_STDLIB_PKG,
-            type_name,
-            snake_to_camel(method)
-        ))
+        ResolvedName::stdlib(format!("{}{}", type_name, snake_to_camel(method)))
     } else if package == current_package {
         let method_name = if is_public {
             snake_to_camel(method)
@@ -344,7 +358,10 @@ pub(crate) fn qualify_method(
         };
         ResolvedName::local(format!("{}_{}", type_name, method_name))
     } else {
-        let pkg = package_alias.unwrap_or_else(|| go_package_name(package));
-        ResolvedName::local(format!("{}.{}_{}", pkg, type_name, snake_to_camel(method)))
+        let name = format!("{}_{}", type_name, snake_to_camel(method));
+        match package_use {
+            Some(package_use) => ResolvedName::foreign(name, package_use),
+            None => ResolvedName::local(format!("{}.{name}", go_package_name(package))),
+        }
     }
 }

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -2,7 +2,8 @@ use syntax::types::unqualified_name;
 
 use crate::Planner;
 use crate::names::go_name;
-use crate::names::packages::{PackageRequirements, PackageUse};
+use crate::names::packages::PackageUse;
+use crate::plan::values::GoExpression;
 use syntax::program;
 
 impl Planner<'_> {
@@ -13,12 +14,12 @@ impl Planner<'_> {
         name: &str,
         qualified: Option<&str>,
         locally_bound: bool,
-    ) -> String {
+    ) -> GoExpression {
         if !locally_bound
             && !name.contains('.')
             && let Some(remapped) = self.package.escape_remap(name)
         {
-            return remapped.to_string();
+            return GoExpression::name(remapped.to_string());
         }
 
         if let Some(go_call) = self.try_resolve_cross_package_static_method(qualified) {
@@ -47,11 +48,7 @@ impl Planner<'_> {
             name
         };
 
-        let resolved = go_name::resolve(&name);
-        if let Some(package) = resolved.package {
-            self.require_generated_package(package);
-        }
-        resolved.name
+        go_name::resolve(&name).into_expression()
     }
 
     pub(crate) fn resolve_alias_type_name(&self, type_part: &str) -> Option<String> {
@@ -109,27 +106,6 @@ impl Planner<'_> {
             .unwrap_or_else(|| go_name::escape_reserved(lisette_name).into_owned())
     }
 
-    /// Record `package`'s Go import and return the package
-    /// qualifier exactly as the import renders it: `format_import` sanitizes
-    /// default package names and prints explicit aliases verbatim, so
-    /// references must follow the same rule.
-    pub(crate) fn record_package_import(
-        &self,
-        package: &str,
-        requirements: &mut PackageRequirements,
-    ) -> String {
-        let package = self.package_use_for_package(package);
-        let qualifier = package.qualifier().to_string();
-        requirements.require(package);
-        qualifier
-    }
-
-    /// Record a package reference in the current file namespace.
-    pub(crate) fn require_package_import(&mut self, package: &str) -> String {
-        let package = self.package_use_for_package(package);
-        self.namespace.reference(package)
-    }
-
     pub(crate) fn canonical_package(&self, package: &str) -> String {
         self.namespace
             .package_for_alias(package)
@@ -137,6 +113,7 @@ impl Planner<'_> {
             .to_string()
     }
 
+    /// The qualifier is the one the import renders: sanitized default names, aliases as written.
     pub(crate) fn package_use_for_package(&self, package: &str) -> PackageUse {
         if package == go_name::TEST_PRELUDE_PACKAGE {
             return PackageUse::generated(go_name::GeneratedPackage::TestKit);
@@ -167,50 +144,43 @@ impl Planner<'_> {
         type_id: &str,
         method: &str,
         is_public: bool,
-    ) -> String {
+    ) -> GoExpression {
         let package = self
             .facts
             .package_for_qualified_name(type_id)
             .map(str::to_string);
         let type_name = unqualified_name(type_id);
-        let computed_alias = match package.as_deref() {
-            Some(m) if self.facts.is_foreign_package(m) => Some(self.require_package_import(m)),
+        let package_use = match package.as_deref() {
+            Some(m) if self.facts.is_foreign_package(m) => Some(self.package_use_for_package(m)),
             _ => None,
         };
-        let resolved = go_name::qualify_method(
+        go_name::qualify_method(
             package.as_deref(),
             type_name,
             method,
             self.facts.current_package(),
             is_public,
-            computed_alias.as_deref(),
-        );
-        if let Some(package) = resolved.package {
-            self.require_generated_package(package);
-        }
-        resolved.name
+            package_use,
+        )
+        .into_expression()
     }
 
-    pub(crate) fn resolve_variant(&mut self, identifier: &str, enum_id: &str) -> String {
+    pub(crate) fn resolve_variant(&mut self, identifier: &str, enum_id: &str) -> GoExpression {
         let enum_package = self
             .facts
             .package_for_qualified_name(enum_id)
             .unwrap_or(enum_id);
-        let computed_alias = if self.facts.is_foreign_package(enum_package) {
-            Some(self.require_package_import(enum_package))
-        } else {
-            None
-        };
-        let resolved = go_name::variant_by_id(
+        let package_use = self
+            .facts
+            .is_foreign_package(enum_package)
+            .then(|| self.package_use_for_package(enum_package));
+        go_name::variant_by_id(
             identifier,
             enum_id,
             enum_package,
             self.facts.current_package(),
-            computed_alias.as_deref(),
-        );
-        if let Some(package) = resolved.package {
-            self.require_generated_package(package);
-        }
-        resolved.name
+            package_use,
+        )
+        .into_expression()
     }
 }

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -26,7 +26,6 @@ pub(crate) fn apply_root_assertion<'s>(
     let [go_type] = assertion.go_types.as_slice() else {
         unreachable!("multi-type root assertions only reach match destructure paths")
     };
-    planner.scope.record_go_use(subject);
     let expression =
         GoExpression::type_assertion(GoExpression::name(subject.to_string()), go_type.clone());
     let var = planner.hoist_tmp_value_statement(statements, "asserted", expression);
@@ -44,7 +43,6 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
     let Some(assertion) = info.root_assertion.as_ref() else {
         return (Cow::Borrowed(subject), None);
     };
-    planner.scope.record_go_use(subject);
     let needs_asserted = info.requires_asserted_subject();
     let assertion_of = |go_type: &String| {
         GoExpression::type_assertion(GoExpression::name(subject.to_string()), go_type.clone())
@@ -130,18 +128,11 @@ pub(crate) fn tree_binding_statements(
             let composable = binding
                 .path
                 .render_composable(SubjectRoot::Var(subject_var));
-            planner.scope.bind_inline_expr(
-                &binding.lisette_name,
-                InlineExpr::new(
-                    composable,
-                    vec![subject_var.to_string()],
-                    binding.path.contains_deferred_evaluation(),
-                ),
-            );
+            planner
+                .scope
+                .bind_inline_expr(&binding.lisette_name, InlineExpr::new(composable));
             continue;
         }
-
-        planner.scope.record_go_use(subject_var);
         let name = if planner.scope.has_binding_for_go_name(go_name) {
             let fresh = planner.fresh_var(Some(&binding.lisette_name));
             planner.scope.bind(&binding.lisette_name, &fresh);
@@ -194,7 +185,6 @@ pub(crate) fn tree_assignment_statements(
             continue;
         };
         let name = registered_name.to_string();
-        planner.scope.record_go_use(subject_var);
         let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
         statements.push(assign(GoExpression::name(name), access_expression));
     }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -72,13 +72,6 @@ impl<'a> SubjectRoot<'a> {
             Self::Elements(names) => (names[element_index(segments)].clone(), &segments[1..]),
         }
     }
-
-    pub(crate) fn names(&self) -> Vec<&'a str> {
-        match self {
-            Self::Var(var) => vec![var],
-            Self::Elements(names) => names.iter().map(String::as_str).collect(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -167,11 +160,11 @@ impl AccessPath {
 pub(crate) enum Check {
     EnumTag {
         path: AccessPath,
-        tag_constant: String,
+        tag_constant: GoExpression,
     },
     Literal {
         path: AccessPath,
-        go_literal: String,
+        go_literal: GoExpression,
     },
     SliceLenEq {
         path: AccessPath,
@@ -226,7 +219,7 @@ impl Check {
                 GoExpression::binary(
                     GoExpression::selector(path.render(subject), "Tag".to_string()),
                     operator,
-                    GoExpression::name(tag_constant.clone()),
+                    tag_constant.clone(),
                 )
             }
             Check::Literal { path, go_literal } => {
@@ -234,12 +227,8 @@ impl Check {
                 match (go_literal.as_str(), negative) {
                     ("true", false) | ("false", true) => rendered_path,
                     ("true", true) | ("false", false) => GoExpression::unary("!", rendered_path),
-                    (_, false) => {
-                        GoExpression::binary(rendered_path, "==", label_expression(go_literal))
-                    }
-                    (_, true) => {
-                        GoExpression::binary(rendered_path, "!=", label_expression(go_literal))
-                    }
+                    (_, false) => GoExpression::binary(rendered_path, "==", go_literal.clone()),
+                    (_, true) => GoExpression::binary(rendered_path, "!=", go_literal.clone()),
                 }
             }
             Check::SliceLenEq { path, length } => {
@@ -310,14 +299,14 @@ impl Check {
         }
     }
 
-    fn as_enum_tag(&self) -> Option<&str> {
+    fn as_enum_tag(&self) -> Option<&GoExpression> {
         match self {
             Check::EnumTag { tag_constant, .. } => Some(tag_constant),
             _ => None,
         }
     }
 
-    fn as_literal(&self) -> Option<&str> {
+    fn as_literal(&self) -> Option<&GoExpression> {
         match self {
             Check::Literal { go_literal, .. } => Some(go_literal),
             _ => None,
@@ -519,7 +508,7 @@ pub(crate) fn tree_has_unguarded_terminal(tree: &Decision) -> bool {
 
 #[derive(Debug)]
 pub(crate) struct SwitchBranch {
-    pub case_label: String,
+    pub case_label: GoExpression,
     pub decision: Decision,
 }
 
@@ -667,12 +656,12 @@ fn validate_switch_arms(
 }
 
 struct GroupedBranches {
-    branches: Vec<(String, Vec<ArmInfo>)>,
+    branches: Vec<(GoExpression, Vec<ArmInfo>)>,
     fallback: Vec<ArmInfo>,
 }
 
 fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches {
-    let mut branches: Vec<(String, Vec<ArmInfo>)> = Vec::new();
+    let mut branches: Vec<(GoExpression, Vec<ArmInfo>)> = Vec::new();
     let mut fallback = Vec::new();
 
     for arm in arms {
@@ -684,15 +673,18 @@ fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches
         let (case_label, inner_checks) = match kind {
             SwitchKind::EnumTag => {
                 let tag = arm.checks[0].as_enum_tag().unwrap();
-                (tag.to_string(), arm.checks[1..].to_vec())
+                (tag.clone(), arm.checks[1..].to_vec())
             }
             SwitchKind::Value => {
                 let lit = arm.checks[0].as_literal().unwrap();
-                (lit.to_string(), arm.checks[1..].to_vec())
+                (lit.clone(), arm.checks[1..].to_vec())
             }
             SwitchKind::TypeSwitch => {
                 let assertion = arm.root_assertion.as_ref().unwrap();
-                (assertion.go_types.join(", "), arm.checks.clone())
+                (
+                    GoExpression::type_name(assertion.go_types.join(", ")),
+                    arm.checks.clone(),
+                )
             }
         };
         let inner_arm = ArmInfo {
@@ -716,7 +708,7 @@ fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches
 /// Splice the catchall into any fail-prone case body: Go `switch` cases do not
 /// fall through to `default`, so a failed inner check has nowhere else to go.
 fn build_switch_branches(
-    branches: Vec<(String, Vec<ArmInfo>)>,
+    branches: Vec<(GoExpression, Vec<ArmInfo>)>,
     fallback_arms: &[ArmInfo],
 ) -> Vec<SwitchBranch> {
     branches
@@ -840,7 +832,7 @@ fn collect_checks_and_bindings(
         Pattern::Literal { literal, .. } => {
             collector.checks.push(Check::Literal {
                 path: path.clone(),
-                go_literal: emit_pattern_literal(literal),
+                go_literal: GoExpression::literal(emit_pattern_literal(literal)),
             });
         }
 
@@ -1177,8 +1169,7 @@ fn collect_enum_variant_checks(
     collect_tagged_enum_checks(planner, path, &variant_data, collector);
 }
 
-/// Emit a const pattern as a Go `case` constant (e.g. `time.Friday`), requiring
-/// the constant's package import when it is cross-package.
+/// Emit a const pattern as a Go `case` constant (e.g. `time.Friday`).
 fn collect_const_pattern_check(
     planner: &Planner,
     path: &AccessPath,
@@ -1187,20 +1178,15 @@ fn collect_const_pattern_check(
 ) {
     let const_name = unqualified_name(qualified_name);
     let go_literal = match planner.facts.package_for_qualified_name(qualified_name) {
-        Some(package) => {
-            if planner.facts.is_current_package(package) {
-                local_const_go_name(planner, const_name)
+        Some(package) if !planner.facts.is_current_package(package) => {
+            let member = if go_name::is_go_import(package) {
+                const_name.to_string()
             } else {
-                let member = if go_name::is_go_import(package) {
-                    const_name.to_string()
-                } else {
-                    go_name::screaming_snake_to_camel(const_name)
-                };
-                let qualifier = planner.record_package_import(package, &mut collector.packages);
-                format!("{}.{}", qualifier, member)
-            }
+                go_name::screaming_snake_to_camel(const_name)
+            };
+            GoExpression::qualified(planner.package_use_for_package(package), member)
         }
-        None => local_const_go_name(planner, const_name),
+        _ => GoExpression::name(local_const_go_name(planner, const_name)),
     };
     collector.checks.push(Check::Literal {
         path: path.clone(),
@@ -1228,16 +1214,18 @@ fn handle_foreign_variant_literal(
     if planner.as_enum(ty).is_some() || !identifier.contains('.') {
         return false;
     }
-    if let Some((package, _)) = identifier.split_once('.')
-        && planner.facts.is_foreign_package(package)
-    {
-        collector
-            .packages
-            .require(planner.package_use_for_package(&planner.canonical_package(package)));
-    }
+    let go_literal = match identifier.split_once('.') {
+        Some((package, member)) if planner.facts.is_foreign_package(package) => {
+            GoExpression::qualified(
+                planner.package_use_for_package(&planner.canonical_package(package)),
+                member,
+            )
+        }
+        _ => GoExpression::name(identifier.to_string()),
+    };
     collector.checks.push(Check::Literal {
         path: path.clone(),
-        go_literal: identifier.to_string(),
+        go_literal,
     });
     true
 }
@@ -1302,24 +1290,20 @@ fn collect_tagged_enum_checks(
     collector: &mut PatternCollector,
 ) {
     let enum_package = enum_package_of(planner, variant.ty);
-    let alias = if planner.facts.is_foreign_package(enum_package) {
-        Some(planner.record_package_import(enum_package, &mut collector.packages))
-    } else {
-        None
-    };
+    let package = planner
+        .facts
+        .is_foreign_package(enum_package)
+        .then(|| planner.package_use_for_package(enum_package));
     let resolved = go_name::variant(
         variant.identifier,
         variant.ty,
         enum_package,
         planner.facts.current_package(),
-        alias.as_deref(),
+        package,
     );
-    if let Some(package) = resolved.package {
-        collector.packages.require_generated(package);
-    }
     collector.checks.push(Check::EnumTag {
         path: path.clone(),
-        tag_constant: resolved.name.clone(),
+        tag_constant: resolved.into_expression(),
     });
 
     let variant_name = variant
@@ -1437,24 +1421,20 @@ fn resolve_struct_child_path(
     let enum_info = detect_enum_info(resolution);
     if enum_info.is_some() {
         let enum_package = enum_package_of(planner, ty);
-        let alias = if planner.facts.is_foreign_package(enum_package) {
-            Some(planner.record_package_import(enum_package, &mut collector.packages))
-        } else {
-            None
-        };
+        let package = planner
+            .facts
+            .is_foreign_package(enum_package)
+            .then(|| planner.package_use_for_package(enum_package));
         let resolved = go_name::variant(
             identifier,
             ty,
             enum_package,
             planner.facts.current_package(),
-            alias.as_deref(),
+            package,
         );
-        if let Some(package) = resolved.package {
-            collector.packages.require_generated(package);
-        }
         collector.checks.push(Check::EnumTag {
             path: path.clone(),
-            tag_constant: resolved.name.clone(),
+            tag_constant: resolved.into_expression(),
         });
     }
     (enum_info, path.clone())
@@ -1739,20 +1719,4 @@ fn join_conditions(checks: &[Check], subject: SubjectRoot<'_>) -> GoExpression {
         .map(|check| check.render(subject))
         .reduce(|left, right| GoExpression::binary(left, "&&", right))
         .expect("join_conditions requires at least one check")
-}
-
-pub(crate) fn label_expression(label: &str) -> GoExpression {
-    let is_name = label
-        .chars()
-        .next()
-        .is_some_and(|first| first.is_alphabetic() || first == '_')
-        && label
-            .chars()
-            .all(|character| character.is_alphanumeric() || character == '_' || character == '.')
-        && !matches!(label, "true" | "false" | "nil");
-    if is_name {
-        GoExpression::name(label.to_string())
-    } else {
-        GoExpression::literal(label.to_string())
-    }
 }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -12,6 +12,7 @@ use crate::names::go_name::is_plain_identifier;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::decision_tree;
 use crate::patterns::tree_emitter::{MatchSubject, TreePlanner};
+use crate::plan::bodies::GoUses;
 use crate::plan::bodies::{
     Definition, ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan, assign, define,
     discard, expression_statement,
@@ -141,9 +142,6 @@ impl BoundOption {
                 nil_guard,
                 initializer_call,
             } => {
-                if nil_guard.is_interface() {
-                    planner.require_stdlib();
-                }
                 let tested = GoExpression::name(value.clone());
                 let test = if success {
                     nil_guard.non_nil(tested)
@@ -408,15 +406,13 @@ impl Planner<'_> {
         let (subject_var, declaration) =
             self.lower_match_subject_var(&mut statements, subject, arms);
 
-        let (block, used_set) = self.capture_go_uses(|this| {
-            this.lower_match_tree(
-                arms,
-                MatchSubject::Var(subject_var.clone()),
-                subject_ty,
-                place,
-            )
-        });
-        let used = used_set.contains(&subject_var);
+        let block = self.lower_match_tree(
+            arms,
+            MatchSubject::Var(subject_var.clone()),
+            subject_ty,
+            place,
+        );
+        let used = GoUses::of(&block.statements).contains(&subject_var);
 
         match declaration {
             SubjectDeclaration::PlainDiscard { var } => {
@@ -763,7 +759,6 @@ impl Planner<'_> {
 
         let err_read = err_used.first().copied().unwrap_or(false) || !wraps.is_empty();
         if has_nil_guard && err_read {
-            self.require_errors();
             else_body.statements.insert(
                 0,
                 LoweredStatement::If(IfPlan::plain(
@@ -997,18 +992,12 @@ impl Planner<'_> {
             PartialVariant::Ok => is_nil(err()),
             PartialVariant::Both => match nil_guard {
                 Some(guard) => {
-                    if guard.is_interface() {
-                        self.require_stdlib();
-                    }
                     GoExpression::binary(non_nil(err()), "&&", guard.non_nil(guarded_value()))
                 }
                 None => non_nil(err()),
             },
             PartialVariant::Err => {
                 let guard = nil_guard.expect("non-nilable Err returned above");
-                if guard.is_interface() {
-                    self.require_stdlib();
-                }
                 GoExpression::binary(non_nil(err()), "&&", guard.is_nil(guarded_value()))
             }
         };
@@ -1101,8 +1090,8 @@ impl Planner<'_> {
                     })
                 })
                 .collect();
-            let (body_block, used) =
-                this.capture_go_uses(|this| this.lower_block_to_place(body, place));
+            let body_block = this.lower_block_to_place(body, place);
+            let used = GoUses::of(&body_block.statements);
             let mut statements = Vec::new();
             let binding_uses = bound
                 .iter()

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -1,4 +1,5 @@
 use crate::patterns::binding_decls::pattern_has_bindings;
+use crate::plan::bodies::GoUses;
 use std::borrow::Cow;
 
 use syntax::ast::{Expression, MatchArm, Pattern, Span};
@@ -7,7 +8,7 @@ use syntax::types::Type;
 use crate::Planner;
 use crate::calls::comma_ok::{CommaOkValueSlot, PairCondition};
 use crate::context::expression::ExpressionContext;
-use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
+use crate::names::go_name::{self, GeneratedPackage, testkit_qualifier};
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::binding_emit::{
     apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
@@ -211,14 +212,11 @@ impl Planner<'_> {
         let info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
         self.require_packages(&info.packages);
 
-        let (body, used) = self.capture_go_uses(|this| {
-            let mut body = Vec::new();
-            let effective = apply_root_assertion(this, &mut body, &info, resolved.var());
-            tree_binding_statements(this, &mut body, &info.bindings, &effective, &[]);
-            body
-        });
+        let mut body = Vec::new();
+        let effective = apply_root_assertion(self, &mut body, &info, resolved.var());
+        tree_binding_statements(self, &mut body, &info.bindings, &effective, &[]);
 
-        let references = used.contains(resolved.var());
+        let references = GoUses::of(&body).contains(resolved.var());
         resolved.push_declaration(&mut statements, references);
         statements.extend(body);
         statements
@@ -286,15 +284,13 @@ impl Planner<'_> {
         };
 
         let subject_is_fixed = self.is_unmutated_identifier(scrutinee);
-        let (body, used) = self.capture_go_uses(|this| {
-            if matches!(ap.pattern, Pattern::Or { .. }) {
-                this.lower_let_else_or_pattern(ap, binding_ty, subject, fail)
-            } else {
-                this.lower_let_else_single_pattern(ap, subject, fail, subject_is_fixed)
-            }
-        });
+        let body = if matches!(ap.pattern, Pattern::Or { .. }) {
+            self.lower_let_else_or_pattern(ap, binding_ty, subject, fail)
+        } else {
+            self.lower_let_else_single_pattern(ap, subject, fail, subject_is_fixed)
+        };
 
-        let references = used.contains(resolved.var());
+        let references = GoUses::of(&body).contains(resolved.var());
         resolved.push_declaration(&mut statements, references);
         statements.extend(body);
         statements
@@ -547,22 +543,18 @@ impl Planner<'_> {
                     .current_test_handle()
                     .expect("let assert without a test handle should be rejected by semantics");
                 self.require_testkit();
-                self.require_stdlib();
                 let testkit = testkit_qualifier();
-                let prelude = prelude_qualifier();
-                self.scope.record_go_use(subject_var);
                 let literal = |text: String| GoExpression::literal(text);
                 let operand = GoExpression::composite(
                     Some(format!("{testkit}.Operand")),
                     vec![(
-                        Some("Value".to_string()),
+                        Some(GoExpression::name("Value".to_string())),
                         GoExpression::call(
-                            GoExpression::name(format!("{prelude}.Debug")),
+                            GoExpression::generated(GeneratedPackage::Prelude, "Debug"),
                             vec![GoExpression::name(subject_var.to_string())],
                         ),
                     )],
                     CompositeLayout::Inline { padded: false },
-                    false,
                 );
                 let call = GoExpression::call(
                     GoExpression::name(format!("{handle}.FailAssert")),
@@ -625,7 +617,6 @@ impl Planner<'_> {
             guard_parts.push(GoExpression::unary("!", ok));
         }
         if !info.checks.is_empty() {
-            self.scope.record_go_use(effective_subject.as_ref());
             let negated = match info.checks.as_slice() {
                 [check] => check.render_negated(SubjectRoot::Var(&effective_subject)),
                 _ => GoExpression::unary(
@@ -705,9 +696,6 @@ impl Planner<'_> {
                     statements.push(assemble_if_else_chain(pieces, body));
                 }
                 return statements;
-            }
-            if !info.checks.is_empty() {
-                self.scope.record_go_use(&subject);
             }
             let condition = compose_refutable_condition(ok_test.as_ref(), &info.checks, &subject);
             pieces.push((condition, body));
@@ -868,10 +856,6 @@ impl Planner<'_> {
                 },
             );
             return statements;
-        }
-
-        if !info.checks.is_empty() {
-            self.scope.record_go_use(effective.as_ref());
         }
         let condition = compose_refutable_condition(ok_test.as_ref(), &info.checks, &effective);
         let mut then_body = Vec::new();

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -1,3 +1,4 @@
+use crate::plan::bodies::GoUses;
 use syntax::ast::{BinaryOperator, Expression, Literal, MatchArm, UnaryOperator};
 use syntax::types::Type;
 
@@ -9,7 +10,7 @@ use crate::patterns::binding_emit::tree_binding_statements;
 use crate::patterns::decision_tree::{
     ChainTest, Decision, PatternBinding, SubjectRoot, SwitchBranch,
     SwitchKind as PatternSwitchKind, SwitchShape, compile_expanded_arms, decision_is_exhaustive,
-    expand_or_patterns, label_expression, render_condition, tree_has_unguarded_terminal,
+    expand_or_patterns, render_condition, tree_has_unguarded_terminal,
 };
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
@@ -179,10 +180,6 @@ impl MatchSubject {
             Self::Elements(names) => SubjectRoot::Elements(names),
         }
     }
-
-    fn names(&self) -> Vec<&str> {
-        self.root().names()
-    }
 }
 
 pub(crate) struct TreePlanner<'a, 'e> {
@@ -233,12 +230,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             }
         }
         LoweredBlock { statements }
-    }
-
-    fn record_subject_use(&mut self) {
-        for name in self.subject.names().to_vec() {
-            self.planner.scope.record_go_use(name);
-        }
     }
 
     fn with_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
@@ -357,9 +348,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let mut branches: Vec<ChainBranch> = Vec::with_capacity(regular_len);
         let mut last_diverges = false;
         for (test, condition) in tests[..regular_len].iter().zip(&conditions) {
-            if condition.is_some() {
-                self.record_subject_use();
-            }
             let condition = condition
                 .clone()
                 .unwrap_or_else(|| GoExpression::literal("true".to_string()));
@@ -585,7 +573,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                         }
                         continue;
                     }
-                    self.record_subject_use();
                     conditions.push(render_condition(&test.checks, self.subject.root()));
                     let flattened = self.collect_flat_cases(&test.decision, conditions, out, false);
                     conditions.pop();
@@ -608,7 +595,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 let rendered_path = path.render(self.subject.root());
                 let (cased, lifted) = split_with_default_lift(branches, fallback.as_deref());
                 for branch in cased {
-                    self.record_subject_use();
                     conditions.push(switch_branch_condition(
                         &rendered_path,
                         kind,
@@ -660,14 +646,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 continue;
             }
             let composable = binding.path.render_composable(self.subject.root());
-            self.planner.scope.bind_inline_expr(
-                &binding.lisette_name,
-                InlineExpr::new(
-                    composable,
-                    vec![self.subject.var().to_string()],
-                    binding.path.contains_deferred_evaluation(),
-                ),
-            );
+            self.planner
+                .scope
+                .bind_inline_expr(&binding.lisette_name, InlineExpr::new(composable));
         }
     }
 
@@ -753,7 +734,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let rendered_path = path.render(self.subject.root());
         match shape {
             SwitchShape::TypeSwitch => {
-                self.record_subject_use();
                 let plan = self.lower_type_switch(rendered_path, branches, fallback, ctx.arm_place);
                 let body_diverges =
                     capture_diverge(vec![LoweredStatement::Switch(plan)], statements);
@@ -762,11 +742,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             SwitchShape::Bool => {
                 let true_branch = branches
                     .iter()
-                    .find(|branch| branch.case_label == "true")
+                    .find(|branch| branch.case_label.as_str() == "true")
                     .expect("Bool shape requires a true-labeled branch");
                 let false_branch = branches
                     .iter()
-                    .find(|branch| branch.case_label == "false")
+                    .find(|branch| branch.case_label.as_str() == "false")
                     .expect("Bool shape requires a false-labeled branch");
                 self.walk_condition_branch(
                     statements,
@@ -780,7 +760,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 let condition = GoExpression::binary(
                     render_switch_expression(rendered_path, kind),
                     "==",
-                    label_expression(&branches[0].case_label),
+                    branches[0].case_label.clone(),
                 );
                 self.walk_condition_branch(
                     statements,
@@ -803,12 +783,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 let condition = GoExpression::binary(
                     render_switch_expression(rendered_path, kind),
                     "==",
-                    label_expression(&branch.case_label),
+                    branch.case_label.clone(),
                 );
                 self.walk_condition_branch(statements, condition, &branch.decision, fallback, ctx);
             }
             SwitchShape::Multi => {
-                self.record_subject_use();
                 let expr = render_switch_expression(rendered_path, kind);
                 let plan = self.lower_value_switch(expr, branches, fallback, ctx.arm_place);
                 let body_diverges =
@@ -826,7 +805,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         else_branch: &Decision,
         ctx: &WalkCtx,
     ) {
-        self.record_subject_use();
         let inner = WalkCtx::switch_case(ctx.arm_place);
         let then_statements = self.with_scope(|this| {
             this.planner.scope.establish_condition(condition.rendered());
@@ -983,18 +961,23 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let arms = self.arms;
         let subject_ty = self.subject_ty.clone();
         let base = subject.rendered();
-        let ((case_plans, default_block), used) = self.planner.capture_go_uses(|planner| {
-            let mut nested =
-                TreePlanner::new(planner, arms, MatchSubject::Var(base.clone()), subject_ty);
-            let case_plans = nested.lower_switch_cases(regular, place, None);
-            let default_block = nested.lower_switch_default(default, place);
-            (case_plans, default_block)
-        });
+        let mut nested = TreePlanner::new(
+            self.planner,
+            arms,
+            MatchSubject::Var(base.clone()),
+            subject_ty,
+        );
+        let case_plans = nested.lower_switch_cases(regular, place, None);
+        let default_block = nested.lower_switch_default(default, place);
 
         // Keep the `base :=` type-switch binding only when a case references it;
         // Go rejects an unused `:= base` assignment otherwise.
-        let references_base = used.contains(&base);
-        let binding = references_base.then(|| base.clone());
+        let mut used = GoUses::default();
+        used.extend_cases(&case_plans);
+        if let Some(block) = &default_block {
+            used.extend(&block.statements);
+        }
+        let binding = used.contains(&base).then(|| base.clone());
 
         SwitchStatementPlan {
             kind: SwitchKind::Type { subject, binding },
@@ -1015,7 +998,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         for branch in branches {
             // A case listing several labels establishes none of them on its own.
             let established = subject
-                .filter(|_| !branch.case_label.contains(','))
+                .filter(|_| !branch.case_label.as_str().contains(','))
                 .map(|subject| format!("{} == {}", subject, branch.case_label));
             let body = self.with_scope(|this| {
                 if let Some(condition) = established {
@@ -1026,8 +1009,8 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 body
             });
             let labels = match subject {
-                Some(_) => vec![label_expression(&branch.case_label)],
-                None => split_top_level_type_list(&branch.case_label)
+                Some(_) => vec![branch.case_label.clone()],
+                None => split_top_level_type_list(branch.case_label.as_str())
                     .into_iter()
                     .map(|go_type| GoExpression::type_name(go_type.to_string()))
                     .collect(),
@@ -1115,9 +1098,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
         let body = LoweredBlock { statements: body };
         let first_condition = &conditions[indices[0]];
-        if first_condition.is_some() {
-            self.record_subject_use();
-        }
         match first_condition {
             Some(condition) => statements.push(LoweredStatement::If(IfPlan::plain(
                 condition.clone(),
@@ -1342,15 +1322,15 @@ fn switch_branch_condition(
     rendered_path: &GoExpression,
     kind: &PatternSwitchKind,
     shape: &SwitchShape,
-    case_label: &str,
+    case_label: &GoExpression,
 ) -> GoExpression {
-    if matches!(shape, SwitchShape::Bool) && case_label == "true" {
+    if matches!(shape, SwitchShape::Bool) && case_label.as_str() == "true" {
         return wrap_if_struct_literal(rendered_path.clone());
     }
     GoExpression::binary(
         render_switch_expression(rendered_path.clone(), kind),
         "==",
-        label_expression(case_label),
+        case_label.clone(),
     )
 }
 

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -1,7 +1,9 @@
 //! Lowered body IR: the typed vocabulary `plan::lower` produces and `render/`
 //! consumes.
 
+use crate::plan::go_expression::GoExpressionNode;
 use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
+use rustc_hash::FxHashSet as HashSet;
 use syntax::types::Type;
 
 pub(crate) fn define(name: String, value: GoExpression) -> LoweredStatement {
@@ -449,7 +451,54 @@ impl ElseArm {
     }
 }
 
+fn visit_statements(statements: &[LoweredStatement], visit: &mut impl FnMut(&GoExpressionNode)) {
+    for statement in statements {
+        statement.visit_expressions(visit);
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct GoUses {
+    names: HashSet<String>,
+}
+
+impl GoUses {
+    pub(crate) fn of(statements: &[LoweredStatement]) -> Self {
+        let mut uses = Self::default();
+        uses.extend(statements);
+        uses
+    }
+
+    pub(crate) fn extend(&mut self, statements: &[LoweredStatement]) {
+        visit_statements(statements, &mut |node| self.record(node));
+    }
+
+    pub(crate) fn extend_cases(&mut self, cases: &[SwitchCasePlan]) {
+        for case in cases {
+            case.visit_expressions(&mut |node| self.record(node));
+        }
+    }
+
+    pub(crate) fn extend_if(&mut self, plan: &IfPlan) {
+        plan.visit_expressions(&mut |node| self.record(node));
+    }
+
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+
+    fn record(&mut self, node: &GoExpressionNode) {
+        if let GoExpressionNode::Identifier(name) = node {
+            self.names.insert(name.clone());
+        }
+    }
+}
+
 impl LoweredBlock {
+    pub(crate) fn visit_expressions(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
+        visit_statements(&self.statements, visit);
+    }
+
     /// Whether the block's last rendered line is `break`, `continue`,
     /// `return`, or `panic(...)`.
     pub(crate) fn ends_with_diverge(&self) -> bool {
@@ -471,6 +520,138 @@ impl LoweredBlock {
 }
 
 impl LoweredStatement {
+    pub(crate) fn visit_expressions(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
+        match self {
+            LoweredStatement::If(plan) => plan.visit_expressions(visit),
+            LoweredStatement::Loop(plan) => {
+                visit_statements(&plan.prologue, visit);
+                match &plan.header {
+                    LoopHeader::Infinite => {}
+                    LoopHeader::While(condition) => condition.node().visit(visit),
+                    LoopHeader::Range { iterable, .. } => iterable.node().visit(visit),
+                    LoopHeader::Counted {
+                        start, condition, ..
+                    } => {
+                        start.node().visit(visit);
+                        if let Some(condition) = condition {
+                            condition.node().visit(visit);
+                        }
+                    }
+                }
+                plan.body.visit_expressions(visit);
+            }
+            LoweredStatement::Block(body)
+            | LoweredStatement::Body(body)
+            | LoweredStatement::WhileLet(body) => body.visit_expressions(visit),
+            LoweredStatement::Break(_)
+            | LoweredStatement::Continue(_)
+            | LoweredStatement::UnreachablePanic => {}
+            LoweredStatement::Const(plan) => plan.value.visit_expressions(visit),
+            LoweredStatement::Return(form) => match form {
+                ReturnForm::Plain { value } => value.visit_expressions(visit),
+                ReturnForm::Unit { side_effect } => {
+                    if let Some(body) = side_effect {
+                        body.visit_expressions(visit);
+                    }
+                }
+                ReturnForm::Multi { values } => {
+                    for value in values {
+                        value.node().visit(visit);
+                    }
+                }
+                ReturnForm::Body { body } => body.visit_expressions(visit),
+            },
+            LoweredStatement::BreakValue(plan) => match plan {
+                BreakValuePlan::Diverged { value } | BreakValuePlan::Transfer { value, .. } => {
+                    value.visit_expressions(visit)
+                }
+            },
+            LoweredStatement::Let(plan) => {
+                if let Some(declaration) = &plan.declaration {
+                    declaration.visit_expressions(visit);
+                }
+                plan.body.visit_expressions(visit);
+            }
+            LoweredStatement::Assign(form) => match form {
+                AssignForm::Compound {
+                    target_capture,
+                    target,
+                    kind,
+                } => {
+                    visit_statements(target_capture, visit);
+                    target.node().visit(visit);
+                    if let CompoundKind::OpAssign { rhs, .. } = kind {
+                        rhs.visit_expressions(visit);
+                    }
+                }
+                AssignForm::Simple {
+                    target_capture,
+                    target,
+                    value,
+                } => {
+                    visit_statements(target_capture, visit);
+                    target.node().visit(visit);
+                    value.visit_expressions(visit);
+                }
+            },
+            LoweredStatement::Async { call, .. } => call.node().visit(visit),
+            LoweredStatement::Select(plan) => {
+                visit_statements(&plan.setup, visit);
+                for arm in &plan.arms {
+                    match arm {
+                        SelectArmPlan::Receive { channel, body, .. } => {
+                            channel.node().visit(visit);
+                            body.visit_expressions(visit);
+                        }
+                        SelectArmPlan::Send {
+                            channel,
+                            value,
+                            body,
+                        } => {
+                            channel.node().visit(visit);
+                            value.node().visit(visit);
+                            body.visit_expressions(visit);
+                        }
+                        SelectArmPlan::Default { body } => body.visit_expressions(visit),
+                    }
+                }
+                visit_statements(&plan.postlude, visit);
+            }
+            LoweredStatement::Switch(plan) => {
+                match &plan.kind {
+                    SwitchKind::Conditional => {}
+                    SwitchKind::Value { subject } | SwitchKind::Type { subject, .. } => {
+                        subject.node().visit(visit)
+                    }
+                }
+                for case in &plan.cases {
+                    case.visit_expressions(visit);
+                }
+                if let Some(default) = &plan.default {
+                    default.visit_expressions(visit);
+                }
+                visit_statements(&plan.postlude, visit);
+            }
+            LoweredStatement::Define(definition) => definition.value.node().visit(visit),
+            LoweredStatement::AssignMany { targets, value } => {
+                for target in targets {
+                    target.node().visit(visit);
+                }
+                value.node().visit(visit);
+            }
+            LoweredStatement::VarDecl { value, .. } => {
+                if let Some(value) = value {
+                    value.node().visit(visit);
+                }
+            }
+            LoweredStatement::Discard(expression)
+            | LoweredStatement::ExpressionStatement { expression, .. } => {
+                expression.node().visit(visit)
+            }
+            LoweredStatement::Directed { inner, .. } => inner.visit_expressions(visit),
+        }
+    }
+
     /// The Go name this statement binds, seeing through a sourcemap directive.
     pub(crate) fn bound_name(&self) -> Option<&str> {
         match self {
@@ -588,7 +769,30 @@ impl LoweredStatement {
     }
 }
 
+impl SwitchCasePlan {
+    fn visit_expressions(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
+        for label in &self.labels {
+            label.node().visit(visit);
+        }
+        self.body.visit_expressions(visit);
+    }
+}
+
 impl IfPlan {
+    fn visit_expressions(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
+        visit_statements(&self.condition_setup, visit);
+        if let Some(initializer) = &self.initializer {
+            initializer.value.node().visit(visit);
+        }
+        self.condition.node().visit(visit);
+        self.then_body.visit_expressions(visit);
+        match &self.else_arm {
+            ElseArm::None => {}
+            ElseArm::ElseIf(plan) => plan.visit_expressions(visit),
+            ElseArm::Else { body, .. } => body.visit_expressions(visit),
+        }
+    }
+
     fn ends_with_diverge(&self) -> bool {
         if !self.then_body.ends_with_diverge() {
             return false;

--- a/crates/emit/src/plan/go_expression.rs
+++ b/crates/emit/src/plan/go_expression.rs
@@ -1,5 +1,6 @@
 //! The Go expression tree behind `GoExpression`.
 
+use crate::names::packages::PackageUse;
 use crate::plan::bodies::LoweredBlock;
 use crate::render::Renderer;
 use crate::types::go_type::render_conversion;
@@ -8,6 +9,10 @@ use std::slice;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum GoExpressionNode {
     Identifier(String),
+    Qualified {
+        package: PackageUse,
+        name: String,
+    },
     Literal(String),
     /// A Go type in operand position, such as the element type of `make`.
     Type(String),
@@ -82,7 +87,7 @@ pub(crate) enum FunctionLiteralLayout {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CompositeElement {
-    pub key: Option<String>,
+    pub key: Option<GoExpressionNode>,
     pub value: GoExpressionNode,
 }
 
@@ -109,6 +114,99 @@ impl CompositeLayout {
 }
 
 impl GoExpressionNode {
+    /// The node holds a call or a type assertion. A function literal only defines code.
+    pub(crate) fn does_work(&self) -> bool {
+        match self {
+            Self::Identifier(_)
+            | Self::Qualified { .. }
+            | Self::Literal(_)
+            | Self::Type(_)
+            | Self::Empty
+            | Self::Verbatim(_)
+            | Self::FunctionLiteral { .. } => false,
+            Self::Call { .. } | Self::TypeAssertion { .. } => true,
+            Self::CompositeLiteral { elements, .. } => {
+                elements.iter().any(|element| element.value.does_work())
+            }
+            Self::Instantiation { base, .. } | Self::Selector { base, .. } => base.does_work(),
+            Self::Index { base, index } => base.does_work() || index.does_work(),
+            Self::Slice {
+                base,
+                low,
+                high,
+                max,
+            } => {
+                base.does_work()
+                    || [low, high, max]
+                        .into_iter()
+                        .flatten()
+                        .any(|bound| bound.does_work())
+            }
+            Self::Unary { operand, .. }
+            | Self::Conversion { operand, .. }
+            | Self::AddressOf(operand)
+            | Self::Dereference(operand)
+            | Self::Parenthesized(operand)
+            | Self::Spread(operand) => operand.does_work(),
+            Self::Binary { left, right, .. } => left.does_work() || right.does_work(),
+        }
+    }
+
+    pub(crate) fn visit(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
+        visit(self);
+        match self {
+            Self::Identifier(_)
+            | Self::Qualified { .. }
+            | Self::Literal(_)
+            | Self::Type(_)
+            | Self::Empty
+            | Self::Verbatim(_) => {}
+            Self::CompositeLiteral { elements, .. } => {
+                for element in elements {
+                    if let Some(key) = &element.key {
+                        key.visit(visit);
+                    }
+                    element.value.visit(visit);
+                }
+            }
+            Self::Call { callee, arguments } => {
+                callee.visit(visit);
+                for argument in arguments {
+                    argument.visit(visit);
+                }
+            }
+            Self::Instantiation { base, .. }
+            | Self::Selector { base, .. }
+            | Self::TypeAssertion { base, .. } => base.visit(visit),
+            Self::Index { base, index } => {
+                base.visit(visit);
+                index.visit(visit);
+            }
+            Self::Slice {
+                base,
+                low,
+                high,
+                max,
+            } => {
+                base.visit(visit);
+                for bound in [low, high, max].into_iter().flatten() {
+                    bound.visit(visit);
+                }
+            }
+            Self::Unary { operand, .. }
+            | Self::Conversion { operand, .. }
+            | Self::AddressOf(operand)
+            | Self::Dereference(operand)
+            | Self::Parenthesized(operand)
+            | Self::Spread(operand) => operand.visit(visit),
+            Self::Binary { left, right, .. } => {
+                left.visit(visit);
+                right.visit(visit);
+            }
+            Self::FunctionLiteral { body, .. } => body.visit_expressions(visit),
+        }
+    }
+
     /// Print the node token for token, since `gofmt` owns the spacing.
     pub(crate) fn print(&self) -> String {
         let mut output = String::new();
@@ -122,6 +220,11 @@ impl GoExpressionNode {
             | Self::Literal(text)
             | Self::Type(text)
             | Self::Verbatim(text) => output.push_str(text),
+            Self::Qualified { package, name } => {
+                output.push_str(package.qualifier());
+                output.push('.');
+                output.push_str(name);
+            }
             Self::Empty => {}
             Self::CompositeLiteral {
                 go_type,
@@ -307,7 +410,7 @@ impl GoExpressionNode {
 impl CompositeElement {
     fn write(&self, output: &mut String) {
         if let Some(key) = &self.key {
-            output.push_str(key);
+            key.write(output);
             output.push_str(": ");
         }
         self.value.write(output);

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -8,7 +8,7 @@ use crate::control_flow::targets::legalize_source_loop;
 use crate::definitions::ConstScope;
 use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_context_ty};
 use crate::expressions::{flip_comparison, flip_preserves_nan};
-use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
+use crate::names::go_name::{GeneratedPackage, testkit_qualifier};
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopHeader, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement,
     PlacePlan, define, directed, directed_first, expression_statement,
@@ -452,16 +452,12 @@ impl Planner<'_> {
         else {
             unreachable!("lower_test_log_call requires a method receiver");
         };
-        self.require_testkit();
-        self.require_stdlib();
-
         let mut statements = Vec::new();
         let handle = self.lower_value(receiver, ExpressionContext::value());
         statements.extend(handle.setup);
         let value = self.lower_value(&args[0], ExpressionContext::value());
         statements.extend(value.setup);
 
-        let prelude = prelude_qualifier();
         let span = args[0].get_span();
         let call = GoExpression::call(
             GoExpression::selector(handle.expression, "Log".to_string()),
@@ -470,7 +466,7 @@ impl Planner<'_> {
                 GoExpression::literal(span.byte_offset.to_string()),
                 GoExpression::literal((span.byte_offset + span.byte_length).to_string()),
                 GoExpression::call(
-                    GoExpression::name(format!("{prelude}.Debug")),
+                    GoExpression::generated(GeneratedPackage::Prelude, "Debug"),
                     vec![value.expression],
                 ),
             ],
@@ -487,7 +483,6 @@ impl Planner<'_> {
         right: &Expression,
         statements: &mut Vec<LoweredStatement>,
     ) -> AssertShape {
-        self.require_stdlib();
         let (lhs, rhs) =
             self.stage_assert_operands(left, right, LiteralInlining::Allowed, statements);
         let flipped = flip_comparison(operator)
@@ -519,7 +514,6 @@ impl Planner<'_> {
         arg: &Expression,
         statements: &mut Vec<LoweredStatement>,
     ) -> AssertShape {
-        self.require_stdlib();
         let recv_ty = recv.get_type();
         let (lhs, rhs) = self.stage_assert_operands(recv, arg, LiteralInlining::Denied, statements);
         let failure_condition =
@@ -1126,25 +1120,24 @@ enum LiteralInlining {
 }
 
 fn paired_operands(lhs: &GoExpression, rhs: &GoExpression) -> Vec<GoExpression> {
-    let (test_kit, prelude) = (testkit_qualifier(), prelude_qualifier());
+    let test_kit = testkit_qualifier();
     let operand = |label: &str, value: &GoExpression| {
         GoExpression::composite(
             Some(format!("{test_kit}.Operand")),
             vec![
                 (
-                    Some("Label".to_string()),
+                    Some(GoExpression::name("Label".to_string())),
                     GoExpression::literal(format!("\"{label}\"")),
                 ),
                 (
-                    Some("Value".to_string()),
+                    Some(GoExpression::name("Value".to_string())),
                     GoExpression::call(
-                        GoExpression::name(format!("{prelude}.Debug")),
+                        GoExpression::generated(GeneratedPackage::Prelude, "Debug"),
                         vec![value.clone()],
                     ),
                 ),
             ],
             CompositeLayout::Inline { padded: false },
-            false,
         )
     };
     vec![operand("left", lhs), operand("right", rhs)]

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -5,7 +5,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::expressions::staging::SpreadSequenceOptions;
-use crate::names::go_name::is_plain_identifier;
+use crate::names::go_name::{GeneratedPackage, is_plain_identifier};
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::plan::bodies::{
     AssignForm, BreakValueAction, BreakValuePlan, ElseArm, LoopHeader, LoopTransfer, LoweredBlock,
@@ -99,7 +99,7 @@ pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, nam
                 || target.as_str() != name
                 || !target_capture.is_empty()
                 || !value.setup.is_empty()
-                || value.expression.contains_deferred_evaluation()
+                || value.expression.does_work()
             {
                 return;
             }
@@ -149,7 +149,7 @@ fn single_simple_assign_value(body: &LoweredBlock, name: &str) -> Option<GoExpre
     (target.as_str() == name
         && target_capture.is_empty()
         && value.setup.is_empty()
-        && !value.expression.contains_deferred_evaluation())
+        && !value.expression.does_work())
     .then(|| value.expression.clone())
 }
 
@@ -603,9 +603,7 @@ impl Planner<'_> {
         }
         let value = self.lower_value(last, ExpressionContext::value());
         let value = value.map_expression_as_computed(|setup, expression| {
-            let contains_deferred_evaluation = expression.contains_deferred_evaluation();
-            let expression = self.apply_type_coercion(setup, target_ty, last, expression);
-            expression.with_deferred_evaluation(contains_deferred_evaluation)
+            self.apply_type_coercion(setup, target_ty, last, expression)
         });
         vec![simple_assign(target, value)]
     }
@@ -654,10 +652,12 @@ impl Planner<'_> {
             };
             capture.extend(ordering.setup);
             let value = if method == "reserve" {
-                self.require_slices();
                 let mut all = vec![receiver];
                 all.extend(arguments);
-                GoExpression::call(GoExpression::name("slices.Grow".to_string()), all)
+                GoExpression::call(
+                    GoExpression::generated(GeneratedPackage::Slices, "Grow"),
+                    all,
+                )
             } else if arguments.is_empty() {
                 receiver
             } else {

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -1,6 +1,8 @@
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
+use crate::names::go_name::GeneratedPackage;
+use crate::names::packages::PackageUse;
 use crate::plan::bodies::{LoweredBlock, LoweredStatement};
 use crate::plan::go_expression::{
     CompositeElement, CompositeLayout, FunctionLiteralLayout, GoExpressionNode,
@@ -78,26 +80,15 @@ fn unary_constant(operator: &str, value: Option<ConstantKind>) -> Option<Constan
 pub(crate) struct GoExpression {
     node: GoExpressionNode,
     rendered: String,
-    contains_deferred_evaluation: bool,
-    composite_literal: bool,
-    syntax_form: OperandForm,
     constant: Option<ConstantKind>,
 }
 
 impl GoExpression {
-    fn new(
-        node: GoExpressionNode,
-        contains_deferred_evaluation: bool,
-        composite_literal: bool,
-        syntax_form: OperandForm,
-    ) -> Self {
+    fn new(node: GoExpressionNode) -> Self {
         let rendered = node.print();
         Self {
             node,
             rendered,
-            contains_deferred_evaluation,
-            composite_literal,
-            syntax_form,
             constant: None,
         }
     }
@@ -116,12 +107,18 @@ impl GoExpression {
     }
 
     pub(crate) fn name(value: String) -> Self {
-        Self::new(
-            GoExpressionNode::Identifier(value),
-            false,
-            false,
-            OperandForm::Name,
-        )
+        Self::new(GoExpressionNode::Identifier(value))
+    }
+
+    pub(crate) fn qualified(package: PackageUse, name: impl Into<String>) -> Self {
+        Self::new(GoExpressionNode::Qualified {
+            package,
+            name: name.into(),
+        })
+    }
+
+    pub(crate) fn generated(package: GeneratedPackage, name: impl Into<String>) -> Self {
+        Self::qualified(PackageUse::generated(package), name)
     }
 
     pub(crate) fn nil() -> Self {
@@ -130,59 +127,38 @@ impl GoExpression {
 
     /// The value of a lowering that produced only statements.
     pub(crate) fn empty() -> Self {
-        Self::new(GoExpressionNode::Empty, false, false, OperandForm::Other)
+        Self::new(GoExpressionNode::Empty)
     }
 
     pub(crate) fn verbatim(source: String) -> Self {
-        Self::new(
-            GoExpressionNode::Verbatim(source),
-            false,
-            false,
-            OperandForm::Other,
-        )
+        Self::new(GoExpressionNode::Verbatim(source))
     }
 
     pub(crate) fn literal(rendered: String) -> Self {
-        Self::new(
-            GoExpressionNode::Literal(rendered),
-            false,
-            false,
-            OperandForm::Literal,
-        )
+        Self::new(GoExpressionNode::Literal(rendered))
     }
 
     pub(crate) fn type_name(go_type: String) -> Self {
-        Self::new(
-            GoExpressionNode::Type(go_type),
-            false,
-            false,
-            OperandForm::Other,
-        )
+        Self::new(GoExpressionNode::Type(go_type))
     }
 
     pub(crate) fn composite(
         go_type: Option<String>,
-        elements: Vec<(Option<String>, GoExpression)>,
+        elements: Vec<(Option<GoExpression>, GoExpression)>,
         layout: CompositeLayout,
-        contains_deferred_evaluation: bool,
     ) -> Self {
         let node = GoExpressionNode::CompositeLiteral {
             go_type,
             elements: elements
                 .into_iter()
                 .map(|(key, value)| CompositeElement {
-                    key,
+                    key: key.map(|key| key.node),
                     value: value.node,
                 })
                 .collect(),
             layout,
         };
-        Self::new(
-            node,
-            contains_deferred_evaluation,
-            true,
-            OperandForm::Literal,
-        )
+        Self::new(node)
     }
 
     /// `T{}` with no elements.
@@ -191,19 +167,13 @@ impl GoExpression {
             Some(go_type),
             Vec::new(),
             CompositeLayout::Inline { padded: true },
-            false,
         )
     }
 
     /// The callee without its type arguments, for a call site that re-instantiates.
     pub(crate) fn without_instantiation(self) -> Self {
         match self.node {
-            GoExpressionNode::Instantiation { base, .. } => Self::new(
-                *base,
-                self.contains_deferred_evaluation,
-                self.composite_literal,
-                self.syntax_form,
-            ),
+            GoExpressionNode::Instantiation { base, .. } => Self::new(*base),
             _ => self,
         }
     }
@@ -223,12 +193,11 @@ impl GoExpression {
         if type_arguments.is_empty() {
             return base;
         }
-        let deferred = base.contains_deferred_evaluation();
         let node = GoExpressionNode::Instantiation {
             base: Box::new(base.node),
             type_arguments,
         };
-        Self::new(node, deferred, false, base.syntax_form)
+        Self::new(node)
     }
 
     pub(crate) fn type_assertion(base: GoExpression, go_type: String) -> Self {
@@ -236,37 +205,19 @@ impl GoExpression {
             base: Box::new(base.node),
             go_type,
         };
-        Self::new(node, true, false, OperandForm::Other)
+        Self::new(node)
     }
 
     pub(crate) fn address_of(operand: GoExpression) -> Self {
-        let deferred = operand.contains_deferred_evaluation();
-        Self::new(
-            GoExpressionNode::AddressOf(Box::new(operand.node)),
-            deferred,
-            false,
-            OperandForm::Other,
-        )
+        Self::new(GoExpressionNode::AddressOf(Box::new(operand.node)))
     }
 
     pub(crate) fn dereference(operand: GoExpression) -> Self {
-        let deferred = operand.contains_deferred_evaluation();
-        Self::new(
-            GoExpressionNode::Dereference(Box::new(operand.node)),
-            deferred,
-            false,
-            OperandForm::Other,
-        )
+        Self::new(GoExpressionNode::Dereference(Box::new(operand.node)))
     }
 
     pub(crate) fn spread(operand: GoExpression) -> Self {
-        let deferred = operand.contains_deferred_evaluation();
-        Self::new(
-            GoExpressionNode::Spread(Box::new(operand.node)),
-            deferred,
-            false,
-            OperandForm::Other,
-        )
+        Self::new(GoExpressionNode::Spread(Box::new(operand.node)))
     }
 
     pub(crate) fn function_literal(
@@ -275,17 +226,12 @@ impl GoExpression {
         body: LoweredBlock,
         layout: FunctionLiteralLayout,
     ) -> Self {
-        Self::new(
-            GoExpressionNode::FunctionLiteral {
-                parameters,
-                result,
-                body,
-                layout,
-            },
-            false,
-            false,
-            OperandForm::Other,
-        )
+        Self::new(GoExpressionNode::FunctionLiteral {
+            parameters,
+            result,
+            body,
+            layout,
+        })
     }
 
     pub(crate) fn immediate_call(
@@ -307,7 +253,7 @@ impl GoExpression {
                 .map(|argument| argument.node)
                 .collect(),
         };
-        Self::new(node, true, false, OperandForm::Call)
+        Self::new(node)
     }
 
     pub(crate) fn binary(
@@ -316,32 +262,29 @@ impl GoExpression {
         right: GoExpression,
     ) -> Self {
         let operator = operator.into();
-        let deferred = left.contains_deferred_evaluation() || right.contains_deferred_evaluation();
         let constant = binary_constant(left.constant, &operator, right.constant);
         let node = GoExpressionNode::Binary {
             operator,
             left: Box::new(left.node),
             right: Box::new(right.node),
         };
-        Self::new(node, deferred, false, OperandForm::Other).with_constant(constant)
+        Self::new(node).with_constant(constant)
     }
 
     pub(crate) fn selector(base: GoExpression, field: String) -> Self {
-        let deferred = base.contains_deferred_evaluation();
         let node = GoExpressionNode::Selector {
             base: Box::new(base.node),
             field,
         };
-        Self::new(node, deferred, false, OperandForm::Other)
+        Self::new(node)
     }
 
     pub(crate) fn index(base: GoExpression, index: GoExpression) -> Self {
-        let deferred = base.contains_deferred_evaluation() || index.contains_deferred_evaluation();
         let node = GoExpressionNode::Index {
             base: Box::new(base.node),
             index: Box::new(index.node),
         };
-        Self::new(node, deferred, false, OperandForm::Other)
+        Self::new(node)
     }
 
     pub(crate) fn conversion(go_type: String, value: GoExpression) -> Self {
@@ -349,28 +292,21 @@ impl GoExpression {
             go_type,
             operand: Box::new(value.node),
         };
-        Self::new(node, true, false, OperandForm::Other)
+        Self::new(node)
     }
 
     pub(crate) fn parenthesized(value: GoExpression) -> Self {
         let constant = value.constant;
-        Self::new(
-            GoExpressionNode::Parenthesized(Box::new(value.node)),
-            true,
-            false,
-            OperandForm::Other,
-        )
-        .with_constant(constant)
+        Self::new(GoExpressionNode::Parenthesized(Box::new(value.node))).with_constant(constant)
     }
 
     pub(crate) fn unary(operator: &str, value: GoExpression) -> Self {
-        let deferred = value.contains_deferred_evaluation();
         let constant = unary_constant(operator, value.constant);
         let node = GoExpressionNode::Unary {
             operator: operator.to_string(),
             operand: Box::new(value.node),
         };
-        Self::new(node, deferred, false, OperandForm::Other).with_constant(constant)
+        Self::new(node).with_constant(constant)
     }
 
     pub(crate) fn slice(
@@ -379,12 +315,6 @@ impl GoExpression {
         end: Option<&GoExpression>,
         capacity: Option<&GoExpression>,
     ) -> Self {
-        let deferred = base.contains_deferred_evaluation()
-            || start
-                .into_iter()
-                .chain(end)
-                .chain(capacity)
-                .any(GoExpression::contains_deferred_evaluation);
         let bound = |bound: Option<&GoExpression>| bound.map(|bound| Box::new(bound.node.clone()));
         let node = GoExpressionNode::Slice {
             base: Box::new(base.node),
@@ -392,18 +322,12 @@ impl GoExpression {
             high: bound(end),
             max: bound(capacity),
         };
-        Self::new(node, deferred, false, OperandForm::Other)
+        Self::new(node)
     }
 
-    /// Lift a subtree taken out of another expression. The parent supplies the facts.
+    /// Lift a subtree taken out of another expression.
     pub(crate) fn from_node(node: GoExpressionNode) -> Self {
-        Self::new(node, false, false, OperandForm::Other)
-    }
-
-    /// Override the derived flag where a lowering path computes it itself.
-    pub(crate) fn with_deferred_evaluation(mut self, contains_deferred_evaluation: bool) -> Self {
-        self.contains_deferred_evaluation = contains_deferred_evaluation;
-        self
+        Self::new(node)
     }
 
     pub(crate) fn node(&self) -> &GoExpressionNode {
@@ -419,23 +343,35 @@ impl GoExpression {
     }
 
     pub(crate) fn is_composite_literal(&self) -> bool {
-        self.composite_literal
+        matches!(self.node, GoExpressionNode::CompositeLiteral { .. })
     }
 
     pub(crate) fn is_literal(&self) -> bool {
-        matches!(self.syntax_form, OperandForm::Literal)
+        matches!(self.syntax_form(), OperandForm::Literal)
     }
 
     fn syntax_form(&self) -> OperandForm {
-        self.syntax_form
+        syntax_form(&self.node)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         self.rendered.is_empty()
     }
 
-    pub(crate) fn contains_deferred_evaluation(&self) -> bool {
-        self.contains_deferred_evaluation
+    pub(crate) fn does_work(&self) -> bool {
+        self.node.does_work()
+    }
+}
+
+fn syntax_form(node: &GoExpressionNode) -> OperandForm {
+    match node {
+        GoExpressionNode::Identifier(_) | GoExpressionNode::Qualified { .. } => OperandForm::Name,
+        GoExpressionNode::Literal(_) | GoExpressionNode::CompositeLiteral { .. } => {
+            OperandForm::Literal
+        }
+        GoExpressionNode::Call { .. } => OperandForm::Call,
+        GoExpressionNode::Instantiation { base, .. } => syntax_form(base),
+        _ => OperandForm::Other,
     }
 }
 
@@ -559,15 +495,14 @@ pub(crate) struct SequencedValues {
     pub effect: EvaluationEffect,
 }
 
-impl SequencedValues {
-    pub(crate) fn contains_deferred_evaluation(&self) -> bool {
-        self.values
-            .iter()
-            .any(GoExpression::contains_deferred_evaluation)
-    }
-}
-
 impl ValuePlan {
+    pub(crate) fn visit_expressions(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
+        for statement in &self.setup {
+            statement.visit_expressions(visit);
+        }
+        self.expression.node().visit(visit);
+    }
+
     fn from_facts(
         setup: Vec<LoweredStatement>,
         expression: GoExpression,

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -3,28 +3,15 @@ use crate::plan::values::GoExpression;
 #[derive(Clone, Debug)]
 pub(crate) struct InlineExpr {
     expression: GoExpression,
-    /// Emitter vars the expression references, recorded as uses on substitution.
-    refs: Vec<String>,
 }
 
 impl InlineExpr {
-    pub(crate) fn new(
-        expression: GoExpression,
-        refs: Vec<String>,
-        contains_deferred_evaluation: bool,
-    ) -> Self {
-        Self {
-            expression: expression.with_deferred_evaluation(contains_deferred_evaluation),
-            refs,
-        }
+    pub(crate) fn new(expression: GoExpression) -> Self {
+        Self { expression }
     }
 
     pub(crate) fn expression(&self) -> &GoExpression {
         &self.expression
-    }
-
-    pub(crate) fn refs(&self) -> &[String] {
-        &self.refs
     }
 }
 

--- a/crates/emit/src/state/file_namespace.rs
+++ b/crates/emit/src/state/file_namespace.rs
@@ -40,12 +40,6 @@ impl FileNamespace {
         self.imports.package_for_alias(alias)
     }
 
-    pub(crate) fn reference(&mut self, package: PackageUse) -> String {
-        let qualifier = package.qualifier().to_string();
-        self.requirements.require(package);
-        qualifier
-    }
-
     pub(crate) fn require(&mut self, package: PackageUse) {
         self.requirements.require(package);
     }

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -13,8 +13,6 @@ pub(crate) struct ScopeState {
     return_ctx_stack: Vec<ReturnContext>,
     test_handle_stack: Vec<String>,
     assign_targets: HashSet<String>,
-    /// Go identifiers referenced during lowering, for structural liveness.
-    use_frames: Vec<HashSet<String>>,
 }
 
 struct ScopeFrame {
@@ -61,29 +59,6 @@ impl ScopeState {
             return_ctx_stack: vec![ReturnContext::None],
             test_handle_stack: Vec::new(),
             assign_targets: HashSet::default(),
-            use_frames: Vec::new(),
-        }
-    }
-
-    pub(crate) fn enter_use_region(&mut self) {
-        self.use_frames.push(HashSet::default());
-    }
-
-    /// Pop and return the region's uses, merging them into the enclosing region.
-    pub(crate) fn exit_use_region(&mut self) -> HashSet<String> {
-        let frame = self
-            .use_frames
-            .pop()
-            .expect("a use region must be entered before it is exited");
-        if let Some(parent) = self.use_frames.last_mut() {
-            parent.extend(frame.iter().cloned());
-        }
-        frame
-    }
-
-    pub(crate) fn record_go_use(&mut self, go_name: &str) {
-        if let Some(frame) = self.use_frames.last_mut() {
-            frame.insert(go_name.to_string());
         }
     }
 
@@ -427,10 +402,7 @@ mod tests {
         scope.bind("value", "outer");
         scope.mark_go_const("value");
         scope.push_binding_frame();
-        scope.bind_inline_expr(
-            "value",
-            InlineExpr::new(pair_first(), vec!["pair".into()], false),
-        );
+        scope.bind_inline_expr("value", InlineExpr::new(pair_first()));
         scope.enter_block();
         scope.bind("value", "inner");
         scope.bind("value", "rebound");
@@ -470,7 +442,7 @@ mod tests {
         scope.enter_block();
         scope.bind("first", "inner");
         assert!(scope.has_binding_for_go_name("shared"));
-        scope.bind_inline_expr("second", InlineExpr::new(pair_first(), vec![], false));
+        scope.bind_inline_expr("second", InlineExpr::new(pair_first()));
         assert!(!scope.has_binding_for_go_name("shared"));
         scope.exit_block();
         assert!(scope.has_binding_for_go_name("shared"));

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -77,10 +77,9 @@ impl Planner<'_> {
             self.value_slot_coercion(value, &target.get_type())
         };
         let value = right_hand_side.map_expression_as_computed(|value_setup, rhs_value| {
-            let contains_deferred_evaluation = rhs_value.contains_deferred_evaluation();
             let (coercion_setup, final_value) = coercion.lower(self, rhs_value);
             value_setup.extend(coercion_setup);
-            final_value.with_deferred_evaluation(contains_deferred_evaluation)
+            final_value
         });
         LoweredStatement::Assign(AssignForm::Simple {
             target_capture,
@@ -128,9 +127,7 @@ impl Planner<'_> {
             pinned_left.is_some() && matches!(rhs.unwrap_parens(), Expression::Binary { .. });
         let mut right_hand_side = right_hand_side.map_expression(|_, staged_value| {
             if parenthesize_rhs {
-                let contains_deferred_evaluation = staged_value.contains_deferred_evaluation();
                 GoExpression::parenthesized(staged_value)
-                    .with_deferred_evaluation(contains_deferred_evaluation)
             } else {
                 staged_value
             }

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -35,7 +35,7 @@ impl GoType {
         }
     }
 
-    fn stdlib(code: impl Into<String>) -> Self {
+    pub(crate) fn stdlib(code: impl Into<String>) -> Self {
         let mut result = Self::new(code);
         result
             .requirements
@@ -43,7 +43,7 @@ impl GoType {
         result
     }
 
-    fn with_package(code: impl Into<String>, package: PackageUse) -> Self {
+    pub(crate) fn with_package(code: impl Into<String>, package: PackageUse) -> Self {
         let mut result = Self::new(code);
         result.requirements.require(package);
         result

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2595,7 +2595,7 @@ fn main() {
 }
 
 #[test]
-fn predicate_value_is_pinned_before_a_later_sibling_binds_err() {
+fn predicate_value_stays_inline_when_a_later_sibling_binds_err() {
     let input = r#"
 fn first() -> Result<int, error> { Ok(1) }
 fn second() -> Result<int, error> { Ok(2) }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_reused_binding_name.snap
@@ -35,7 +35,6 @@ func test() string {
 	}
 	_ = p.F0 + p.F1
 	n := Name("hello")
-	var b string
-	b = string(n)
+	b := string(n)
 	return b
 }

--- a/tests/spec/emit/snapshots/predicate_value_stays_inline_when_a_later_sibling_binds_err.snap
+++ b/tests/spec/emit/snapshots/predicate_value_stays_inline_when_a_later_sibling_binds_err.snap
@@ -29,10 +29,9 @@ func pick(flag bool, n int) int {
 
 func run() (int, error) {
 	_, err := first()
-	arg_3 := err == nil
 	ret_1, err_2 := second()
 	if err_2 != nil {
 		return 0, err_2
 	}
-	return pick(arg_3, ret_1), nil
+	return pick(err == nil, ret_1), nil
 }


### PR DESCRIPTION
The emitter now reads three facts from the Go expression tree instead of recording them beside it: 
- whether an expression runs code (which decides evaluation-order pins), 
- which pkgs a fn body imports, and 
- which Go names a body reads (which decides `_ = x` discards)

This way, a later cleanup pass that drops or moves an expression cannot leave a stale import or pin behind.

Follow-up to #1432