### PR TITLE
feat: idiomatic Go for parens and temps

### DIFF
--- a/crates/emit/src/calls/bounds.rs
+++ b/crates/emit/src/calls/bounds.rs
@@ -1,5 +1,4 @@
 use super::NativeMethodCall;
-use super::comma_ok::parenthesize_prefixed_expression;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::plan::bodies::LoweredStatement;
@@ -68,8 +67,7 @@ impl Planner<'_> {
                 ),
             )
         };
-        let element =
-            GoExpression::index(parenthesize_prefixed_expression(receiver.clone()), index);
+        let element = GoExpression::index(receiver.clone(), index);
         (
             setup,
             BoundsCheckedIndex {

--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -102,41 +102,8 @@ impl LoweredPair {
         let call = self.initializer_call.as_ref()?;
         Some(Definition {
             names: self.binding(),
-            value: header_call(call.clone()),
+            value: call.clone(),
         })
-    }
-}
-
-/// Go reads a bare `T{` in an `if` header as the block, so such a receiver takes parentheses.
-pub(crate) fn header_call(call: GoExpression) -> GoExpression {
-    let text = call.as_str();
-    let mut rest = text.trim_start_matches(['&', '*']);
-    let type_name_end = rest
-        .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == '.'))
-        .unwrap_or(rest.len());
-    if type_name_end == 0 {
-        return call;
-    }
-    rest = &rest[type_name_end..];
-    if let Some(after_bracket) = rest.strip_prefix('[') {
-        let mut depth = 1usize;
-        let close = after_bracket.char_indices().find(|(_, character)| {
-            match character {
-                '[' => depth += 1,
-                ']' => depth -= 1,
-                _ => {}
-            }
-            depth == 0
-        });
-        let Some((close, _)) = close else {
-            return call;
-        };
-        rest = &after_bracket[close + 1..];
-    }
-    if rest.starts_with('{') {
-        GoExpression::parenthesized(call)
-    } else {
-        call
     }
 }
 
@@ -395,20 +362,10 @@ impl Planner<'_> {
                 let (setup, operand) = self
                     .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
-                let operand = parenthesize_prefixed_expression(operand);
                 let target_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
                 let target = self.use_go_type(&target_ty);
                 (setup, GoExpression::type_assertion(operand, target))
             }
         }
-    }
-}
-
-/// `*x` and `&x` bind looser than a postfix `[k]` or `.(T)`.
-pub(super) fn parenthesize_prefixed_expression(operand: GoExpression) -> GoExpression {
-    if operand.as_str().starts_with('*') || operand.as_str().starts_with('&') {
-        GoExpression::parenthesized(operand)
-    } else {
-        operand
     }
 }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -723,7 +723,7 @@ impl<'a> Planner<'a> {
 
         Some(ValuePlan::computed(
             setup,
-            emit_struct_literal(&target.go_ty, field_pairs, ctx),
+            emit_struct_literal(&target.go_ty, field_pairs),
             effect,
         ))
     }

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -364,10 +364,6 @@ fn retired_covers_receiver(target: &Expression, receiver: &Expression) -> bool {
     }
 }
 
-fn is_selector_chain(rendered: &str) -> bool {
-    rendered.split('.').all(go_name::is_plain_identifier)
-}
-
 fn build_inline(
     form: InlineForm,
     package: InlinePackage,
@@ -409,11 +405,7 @@ fn build_inline(
             vec![receiver.clone()],
         ),
         InlineForm::Index => {
-            let base = if is_selector_chain(receiver.as_str()) {
-                receiver.clone()
-            } else {
-                GoExpression::parenthesized(receiver.clone())
-            };
+            let base = receiver.clone();
             let index = arguments
                 .first()
                 .expect("an index rule takes one argument")
@@ -763,11 +755,7 @@ impl Planner<'_> {
         setup: &mut Vec<LoweredStatement>,
     ) -> GoExpression {
         let base = if self.receiver_is_addressable(expression) {
-            if receiver.as_str().starts_with('*') {
-                GoExpression::parenthesized(receiver)
-            } else {
-                receiver
-            }
+            receiver
         } else {
             GoExpression::name(self.hoist_tmp_value_statement(setup, "arr", receiver))
         };
@@ -896,11 +884,7 @@ impl Planner<'_> {
             self.pin_staged(&mut staged, "arr");
         }
         staged.map_expression_as_observable_computed(|_setup, array| {
-            let base = if array.as_str().starts_with('*') {
-                GoExpression::parenthesized(array)
-            } else {
-                array
-            };
+            let base = array;
             GoExpression::slice(base, None, None, None)
         })
     }
@@ -1001,7 +985,7 @@ impl Planner<'_> {
             result_name: None,
         };
         let mut staged = self.stage_native_method(&ctx, NativeMethodForm::Dot);
-        let receiver = super::comma_ok::parenthesize_prefixed_expression(staged.receiver);
+        let receiver = staged.receiver;
         let key = staged.arguments.remove(0);
         (staged.setup, GoExpression::index(receiver, key))
     }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -298,10 +298,6 @@ impl<'a> Planner<'a> {
             ..
         } = callee_staged;
 
-        if function.deref_inner().is_some() {
-            callee = GoExpression::parenthesized(callee);
-        }
-
         let mut type_args_string = self.resolve_call_type_args(CallTypeArgsRequest {
             function,
             callee: &call_plan.resolved,

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -372,10 +372,9 @@ impl Planner<'_> {
         };
         let receiver = match addressed {
             Some(inner) if is_address_of_composite_literal(args.first()) => {
-                GoExpression::parenthesized(GoExpression::address_of(inner))
+                GoExpression::address_of(inner)
             }
             Some(inner) => inner,
-            None if receiver.as_str().starts_with('*') => GoExpression::parenthesized(receiver),
             None => receiver,
         };
 

--- a/crates/emit/src/calls/unwrap_or.rs
+++ b/crates/emit/src/calls/unwrap_or.rs
@@ -265,7 +265,11 @@ impl Planner<'_> {
             &result_var,
             &ty,
         ));
-        collapse_declared_temp(&mut statements, &result_var);
+        collapse_declared_temp(
+            &mut statements,
+            &result_var,
+            self.short_declaration_keeps_type(&ty),
+        );
         Some(ValuePlan::captured(statements, result_var))
     }
 }

--- a/crates/emit/src/context/expression.rs
+++ b/crates/emit/src/context/expression.rs
@@ -5,21 +5,11 @@ use crate::abi::layout::SlotOrigin;
 use crate::plan::values::CaptureBoundary;
 
 /// Whether the expression is being emitted as the callee of a call.
-/// Independent of [`SyntaxContext`]: a callee can appear inside a condition.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum CalleeRole {
     #[default]
     Value,
     Callee,
-}
-
-/// The enclosing syntactic context. `Condition` is `if`/`for`/`switch` head,
-/// where Go forbids unparenthesized composite literals.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) enum SyntaxContext {
-    #[default]
-    Plain,
-    Condition,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -44,7 +34,6 @@ pub(crate) enum ArgumentTarget {
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct ExpressionContext<'a> {
     callee_role: CalleeRole,
-    syntax_context: SyntaxContext,
     expected_slot_type: Option<&'a Type>,
     function_value_abi_target: FunctionValueAbiTarget,
     argument_target: ArgumentTarget,
@@ -59,11 +48,6 @@ impl<'a> ExpressionContext<'a> {
 
     pub(crate) fn callee(mut self) -> Self {
         self.callee_role = CalleeRole::Callee;
-        self
-    }
-
-    pub(crate) fn condition(mut self) -> Self {
-        self.syntax_context = SyntaxContext::Condition;
         self
     }
 
@@ -115,10 +99,6 @@ impl<'a> ExpressionContext<'a> {
 
     pub(crate) fn is_callee(self) -> bool {
         matches!(self.callee_role, CalleeRole::Callee)
-    }
-
-    pub(crate) fn is_condition(self) -> bool {
-        matches!(self.syntax_context, SyntaxContext::Condition)
     }
 
     pub(crate) fn forces_tagged_go_function(self) -> bool {

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -576,10 +576,6 @@ impl Planner<'_> {
 fn cancel_deref_of_address(channel: GoExpression) -> GoExpression {
     let addressed = match channel.node() {
         GoExpressionNode::AddressOf(inner) => Some(inner.as_ref()),
-        GoExpressionNode::Parenthesized(inner) => match inner.as_ref() {
-            GoExpressionNode::AddressOf(inner) => Some(inner.as_ref()),
-            _ => None,
-        },
         _ => None,
     };
     match addressed {

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -155,7 +155,7 @@ impl Planner<'_> {
                             layout_field.go_name.clone(),
                         );
                         if layout_field.is_recursive() {
-                            GoExpression::parenthesized(GoExpression::dereference(access))
+                            GoExpression::dereference(access)
                         } else {
                             access
                         }

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -8,6 +8,7 @@ use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::PatternSubject;
 use crate::plan::bodies::{LoweredBlock, LoweredStatement};
+use crate::plan::cleanup::clean_up;
 use crate::plan::go_expression::FunctionLiteralLayout;
 use crate::plan::values::GoExpression;
 use crate::state::package_state::FunctionEmissionContext;
@@ -68,7 +69,8 @@ impl Planner<'_> {
         body: &Expression,
         should_return: bool,
     ) {
-        let lowered = self.lower_function_body(body, should_return);
+        let mut lowered = self.lower_function_body(body, should_return);
+        clean_up(&mut lowered.statements);
         self.collect_imports(&lowered.statements);
         Renderer.render_lowered_block(output, &lowered);
     }

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -5,6 +5,7 @@ use crate::control_flow::propagation::plain_return;
 use crate::names::go_name;
 use crate::names::go_name::GO_IMPORT_PREFIX;
 use crate::plan::bodies::{LoweredStatement, define, expression_statement};
+use crate::plan::cleanup::clean_up;
 use crate::plan::values::GoExpression;
 use crate::write_line;
 use ecow::EcoString;
@@ -396,7 +397,8 @@ impl Planner<'_> {
         method: &AdapterMethod,
         inner_call: GoExpression,
     ) -> (String, String) {
-        let (go_ret, statements) = self.plan_adapter_body(method, inner_call);
+        let (go_ret, mut statements) = self.plan_adapter_body(method, inner_call);
+        clean_up(&mut statements);
         self.collect_imports(&statements);
         (go_ret, crate::Renderer.render_setup(&statements))
     }

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -312,9 +312,7 @@ impl Planner<'_> {
                 Expression::Call { .. } => {
                     GoExpression::name(self.hoist_tmp_value_statement(setup, "ref", base))
                 }
-                Expression::StructCall { .. } => {
-                    GoExpression::parenthesized(GoExpression::address_of(base))
-                }
+                Expression::StructCall { .. } => GoExpression::address_of(base),
                 _ => base,
             }
         })

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -88,8 +88,7 @@ impl Planner<'_> {
         };
         let mut staged = self
             .plan_operand(inner, ExpressionContext::value())
-            .unary("*")
-            .parenthesized();
+            .unary("*");
         staged.make_observable();
         staged
     }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -66,7 +66,6 @@ impl Planner<'_> {
         field_assignments: &[StructFieldAssignment],
         spread: &StructSpread,
         ty: &Type,
-        expression_ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
         let ctx = self.analyze_struct_call(name, ty);
 
@@ -180,7 +179,6 @@ impl Planner<'_> {
                             },
                             &ctx,
                             field_assignments,
-                            expression_ctx,
                         )
                     } else {
                         self.lower_struct_update(base_staged, &field_pairs)
@@ -195,13 +193,13 @@ impl Planner<'_> {
                     let mut field_pairs =
                         fields.into_iter().map(StructCallField::into_pair).collect();
                     self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
-                    emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx)
+                    emit_struct_literal(&ctx.go_type, field_pairs)
                 }
             },
             StructSpread::None => {
                 let field_pairs: Vec<_> =
                     fields.into_iter().map(StructCallField::into_pair).collect();
-                emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx)
+                emit_struct_literal(&ctx.go_type, field_pairs)
             }
         };
 
@@ -425,7 +423,7 @@ impl Planner<'_> {
                 };
                 pairs.push((go_field_name, zero));
             }
-            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value());
+            return emit_struct_literal(&go_ty, pairs);
         }
         GoExpression::empty_composite(go_ty)
     }
@@ -527,7 +525,7 @@ impl Planner<'_> {
                     (go_name, self.lisette_zero(&field_ty))
                 })
                 .collect();
-            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value());
+            return emit_struct_literal(&go_ty, pairs);
         }
         if let Some(underlying) = self.facts.underlying_type(ty) {
             return self.lisette_zero(&underlying);
@@ -797,7 +795,6 @@ impl Planner<'_> {
         input: SpreadInput<'_>,
         ctx: &StructCallContext<'_>,
         field_assignments: &[StructFieldAssignment],
-        expression_ctx: ExpressionContext<'_>,
     ) -> (Vec<LoweredStatement>, GoExpression) {
         let SpreadInput {
             base,
@@ -817,10 +814,7 @@ impl Planner<'_> {
 
         if carried.is_empty() {
             statements.push(discard(base_value));
-            return (
-                statements,
-                emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx),
-            );
+            return (statements, emit_struct_literal(&ctx.go_type, field_pairs));
         }
 
         let source = if is_order_sensitive(base) {
@@ -836,10 +830,7 @@ impl Planner<'_> {
             let slot = self.resolve_struct_call_field_name(&field_name, ctx);
             field_pairs.push((slot.clone(), GoExpression::selector(source.clone(), slot)));
         }
-        (
-            statements,
-            emit_struct_literal(&ctx.go_type, field_pairs, expression_ctx),
-        )
+        (statements, emit_struct_literal(&ctx.go_type, field_pairs))
     }
 }
 
@@ -907,31 +898,18 @@ fn unspecified_pairs<'a>(
         .collect()
 }
 
-pub(crate) fn emit_struct_literal(
-    ty: &str,
-    fields: Vec<(String, GoExpression)>,
-    ctx: ExpressionContext<'_>,
-) -> GoExpression {
+pub(crate) fn emit_struct_literal(ty: &str, fields: Vec<(String, GoExpression)>) -> GoExpression {
     let layout = if fields.len() > 1 {
         CompositeLayout::MultiLine { indented: false }
     } else {
         CompositeLayout::Inline { padded: true }
     };
-    let literal = GoExpression::composite(
+    GoExpression::composite(
         Some(ty.to_string()),
         fields
             .into_iter()
             .map(|(name, value)| (Some(GoExpression::name(name)), value))
             .collect(),
         layout,
-    );
-
-    // Generic composite literals (`Type[Args]{...}`) need inner parens in
-    // condition contexts because gofmt strips outer condition parens for
-    // generics, producing invalid Go in `if`/`for`/`switch`.
-    if ctx.is_condition() && ty.contains('[') {
-        GoExpression::parenthesized(literal)
-    } else {
-        literal
-    }
+    )
 }

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -213,7 +213,6 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
         let target = expression.unwrap_parens();
-        let preserve_parens = matches!(expression, Expression::Paren { .. });
         if let Expression::Binary {
             operator: cmp,
             left,
@@ -223,29 +222,15 @@ impl Planner<'_> {
             && let Some(flipped) = flip_comparison(cmp)
             && flip_preserves_nan(&self.facts, cmp, left, right)
         {
-            let plan = self.plan_binary(&flipped, left, right, ctx);
-            return if preserve_parens {
-                plan.parenthesized()
-            } else {
-                plan
-            };
+            return self.plan_binary(&flipped, left, right, ctx);
         }
         let (innermost, inner_negated) = strip_negations(expression);
         if let Some(predicate) = self.lower_fused_predicate_value(innermost, !inner_negated) {
-            return if preserve_parens {
-                predicate.parenthesized()
-            } else {
-                predicate
-            };
+            return predicate;
         }
         if matches!(target, Expression::Call { .. }) {
             let mut setup: Vec<LoweredStatement> = Vec::new();
             if let Some(negated) = self.try_emit_negated_call(&mut setup, target) {
-                let negated = if preserve_parens {
-                    GoExpression::parenthesized(negated)
-                } else {
-                    negated
-                };
                 return ValuePlan::computed(setup, negated, EvaluationEffect::EffectfulCall);
             }
         }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -436,14 +436,6 @@ impl Planner<'_> {
         inner.conversion(go_type)
     }
 
-    /// `T(x)` is a primary expression, so parentheses around it add nothing.
-    pub(crate) fn is_conversion_cast(&self, expression: &Expression) -> bool {
-        matches!(
-            expression.unwrap_parens(),
-            Expression::Cast { ty, .. } if !self.facts.is_interface(ty)
-        )
-    }
-
     fn shift_pin_go_type(&mut self, expression: &Expression, target_ty: &Type) -> Option<String> {
         let target_is_float = self
             .facts
@@ -607,7 +599,7 @@ impl Planner<'_> {
             fields.push(("End".to_string(), values.next().expect("range has an end")));
         }
 
-        let value = emit_struct_literal(&type_string, fields, ExpressionContext::value());
+        let value = emit_struct_literal(&type_string, fields);
         ValuePlan::computed(sequenced.setup, value, effect)
     }
 

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -85,10 +85,7 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
                 })
                 .reduce(|left, right| GoExpression::binary(left, "||", right))
                 .expect("a multi-type assertion names at least one type");
-            (
-                Cow::Borrowed(subject),
-                Some(GoExpression::parenthesized(oks)),
-            )
+            (Cow::Borrowed(subject), Some(oks))
         }
     }
 }
@@ -125,9 +122,7 @@ pub(crate) fn tree_binding_statements(
         let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
 
         if analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline {
-            let composable = binding
-                .path
-                .render_composable(SubjectRoot::Var(subject_var));
+            let composable = binding.path.render(SubjectRoot::Var(subject_var));
             planner
                 .scope
                 .bind_inline_expr(&binding.lisette_name, InlineExpr::new(composable));

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -97,8 +97,7 @@ impl AccessPath {
     pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> GoExpression {
         let (root, segments) = subject.resolve(&self.segments);
         let mut result = GoExpression::name(root);
-        let last = segments.len().saturating_sub(1);
-        for (i, seg) in segments.iter().enumerate() {
+        for seg in segments {
             result = match seg {
                 PathSegment::Field(name) => GoExpression::selector(result, name.clone()),
                 PathSegment::Index(index) => {
@@ -119,10 +118,7 @@ impl AccessPath {
                         None,
                     ),
                 ),
-                PathSegment::Deref if i == last => GoExpression::dereference(result),
-                PathSegment::Deref => {
-                    GoExpression::parenthesized(GoExpression::dereference(result))
-                }
+                PathSegment::Deref => GoExpression::dereference(result),
                 PathSegment::NewtypeCast(go_type) => {
                     GoExpression::conversion(go_type.clone(), result)
                 }
@@ -130,17 +126,6 @@ impl AccessPath {
             };
         }
         result
-    }
-
-    /// Like `render`, but a tail-`Deref` is parenthesized so the result is
-    /// safe as a selector receiver, index target, or call callee.
-    pub(crate) fn render_composable(&self, subject: SubjectRoot<'_>) -> GoExpression {
-        let rendered = self.render(subject);
-        if matches!(self.segments.last(), Some(PathSegment::Deref)) {
-            GoExpression::parenthesized(rendered)
-        } else {
-            rendered
-        }
     }
 
     pub(crate) fn contains_deferred_evaluation(&self) -> bool {
@@ -247,25 +232,11 @@ impl Check {
                     GoExpression::literal(min_length.to_string()),
                 )
             }
-            Check::Or { alternatives } if !negative => {
-                let alternative_count = alternatives.len();
-                let joined = alternatives
-                    .iter()
-                    .map(|checks| {
-                        if checks.len() == 1 {
-                            checks[0].render(subject)
-                        } else {
-                            GoExpression::parenthesized(join_conditions(checks, subject))
-                        }
-                    })
-                    .reduce(|left, right| GoExpression::binary(left, "||", right))
-                    .expect("an or-check has at least one alternative");
-                if alternative_count > 1 {
-                    GoExpression::parenthesized(joined)
-                } else {
-                    joined
-                }
-            }
+            Check::Or { alternatives } if !negative => alternatives
+                .iter()
+                .map(|checks| join_conditions(checks, subject))
+                .reduce(|left, right| GoExpression::binary(left, "||", right))
+                .expect("an or-check has at least one alternative"),
             Check::TypeAssert { path, go_type } if !negative => GoExpression::immediate_call(
                 "bool".to_string(),
                 LoweredBlock {
@@ -281,9 +252,7 @@ impl Check {
             ),
             Check::Or { .. } | Check::TypeAssert { .. } => GoExpression::unary(
                 "!",
-                GoExpression::parenthesized(
-                    self.render_with_polarity(subject, CheckPolarity::Positive),
-                ),
+                self.render_with_polarity(subject, CheckPolarity::Positive),
             ),
         }
     }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -3,7 +3,7 @@ use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
 use crate::calls::NativeMethodCall;
 use crate::calls::bounds::BoundsCheckedIndex;
 use crate::calls::comma_ok::CommaOkSource;
-use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairCondition, PairKind, header_call};
+use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairCondition, PairKind};
 use crate::calls::go_interop::{NilGuard, is_nil, non_nil, unexpected_nil_error};
 use crate::calls::slice_loop::FoundSink;
 use crate::calls::wrap_err::WrapMessage;
@@ -151,7 +151,7 @@ impl BoundOption {
                 PairCondition {
                     initializer: initializer_call.as_ref().map(|call| Definition {
                         names: vec![value.clone()],
-                        value: header_call(call.clone()),
+                        value: call.clone(),
                     }),
                     condition: test,
                 }
@@ -879,7 +879,7 @@ impl Planner<'_> {
         };
         let initializer = Definition {
             names: vec![bound_value, err_var.clone()],
-            value: header_call(call),
+            value: call,
         };
 
         let nil_check = val_var
@@ -1006,7 +1006,7 @@ impl Planner<'_> {
             condition_setup: Vec::new(),
             initializer: Some(Definition {
                 names: vec![bound_value, error.clone()],
-                value: header_call(call),
+                value: call,
             }),
             condition,
             then_body: selected,

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -23,7 +23,6 @@ use crate::plan::bodies::{
 use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::GoExpression;
 use crate::state::bindings::BindingValue;
-use crate::utils::wrap_if_struct_literal;
 
 #[derive(Clone, Copy)]
 pub(crate) struct AnnotatedPattern<'a> {
@@ -621,13 +620,10 @@ impl Planner<'_> {
                 [check] => check.render_negated(SubjectRoot::Var(&effective_subject)),
                 _ => GoExpression::unary(
                     "!",
-                    GoExpression::parenthesized(render_condition(
-                        &info.checks,
-                        SubjectRoot::Var(&effective_subject),
-                    )),
+                    render_condition(&info.checks, SubjectRoot::Var(&effective_subject)),
                 ),
             };
-            guard_parts.push(wrap_if_struct_literal(negated));
+            guard_parts.push(negated);
         }
         let guard = guard_parts
             .into_iter()

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -20,7 +20,6 @@ use crate::plan::placement::unreachable_panic_if_needed;
 use crate::plan::values::GoExpression;
 use crate::state::bindings::InlineExpr;
 use crate::types::go_type::split_top_level_type_list;
-use crate::utils::wrap_if_struct_literal;
 
 struct FlatCase<'d> {
     conditions: Vec<GoExpression>,
@@ -33,16 +32,6 @@ fn decision_arm_index(decision: &Decision) -> usize {
         Decision::Success { arm_index, .. } | Decision::Guard { arm_index, .. } => *arm_index,
         _ => unreachable!("a flattened case body lowers from an arm leaf"),
     }
-}
-
-fn binds_looser_than_conjunction(guard: &Expression) -> bool {
-    matches!(
-        guard,
-        Expression::Binary {
-            operator: BinaryOperator::Or,
-            ..
-        }
-    )
 }
 
 fn guard_renders_inline(guard: &Expression) -> bool {
@@ -629,15 +618,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         if !setup.is_empty() {
             return None;
         }
-        let guard = self.arms[arm_index]
-            .guard
-            .as_deref()
-            .expect("a Guard decision has a guard expression");
-        Some(if binds_looser_than_conjunction(guard) {
-            GoExpression::parenthesized(condition)
-        } else {
-            condition
-        })
+        Some(condition)
     }
 
     fn install_path_overlays(&mut self, bindings: &[PatternBinding]) {
@@ -645,7 +626,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             if binding.go_name.is_none() {
                 continue;
             }
-            let composable = binding.path.render_composable(self.subject.root());
+            let composable = binding.path.render(self.subject.root());
             self.planner
                 .scope
                 .bind_inline_expr(&binding.lisette_name, InlineExpr::new(composable));
@@ -750,7 +731,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                     .expect("Bool shape requires a false-labeled branch");
                 self.walk_condition_branch(
                     statements,
-                    wrap_if_struct_literal(rendered_path),
+                    rendered_path,
                     &true_branch.decision,
                     &false_branch.decision,
                     ctx,
@@ -1273,9 +1254,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let guard_expression = self.arms[arm_index].guard.as_deref()?;
         let plan = self
             .planner
-            .plan_operand(guard_expression, ExpressionContext::value().condition());
+            .plan_operand(guard_expression, ExpressionContext::value());
         let (setup, value) = plan.into_parts();
-        Some((setup, wrap_if_struct_literal(value)))
+        Some((setup, value))
     }
 
     fn render_chain_conditions(&self, tests: &[ChainTest]) -> Vec<Option<GoExpression>> {
@@ -1325,7 +1306,7 @@ fn switch_branch_condition(
     case_label: &GoExpression,
 ) -> GoExpression {
     if matches!(shape, SwitchShape::Bool) && case_label.as_str() == "true" {
-        return wrap_if_struct_literal(rendered_path.clone());
+        return rendered_path.clone();
     }
     GoExpression::binary(
         render_switch_expression(rendered_path.clone(), kind),
@@ -1336,10 +1317,8 @@ fn switch_branch_condition(
 
 fn render_switch_expression(rendered_path: GoExpression, kind: &PatternSwitchKind) -> GoExpression {
     match kind {
-        PatternSwitchKind::EnumTag => {
-            wrap_if_struct_literal(GoExpression::selector(rendered_path, "Tag".to_string()))
-        }
-        PatternSwitchKind::Value => wrap_if_struct_literal(rendered_path),
+        PatternSwitchKind::EnumTag => GoExpression::selector(rendered_path, "Tag".to_string()),
+        PatternSwitchKind::Value => rendered_path,
         PatternSwitchKind::TypeSwitch => unreachable!("TypeSwitch handled separately"),
     }
 }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -250,8 +250,8 @@ pub(crate) enum CompoundKind {
     /// into `pinned_left`, rendered as `target = pinned_left op rhs`.
     OpAssign {
         op_text: String,
-        rhs: ValuePlan,
-        pinned_left: Option<String>,
+        rhs: Box<ValuePlan>,
+        pinned_left: Option<GoExpression>,
     },
 }
 
@@ -457,6 +457,26 @@ fn visit_statements(statements: &[LoweredStatement], visit: &mut impl FnMut(&GoE
     }
 }
 
+pub(crate) fn for_each_statement(
+    statements: &[LoweredStatement],
+    f: &mut impl FnMut(&LoweredStatement),
+) {
+    for statement in statements {
+        f(statement);
+        statement.for_each_nested_statement(f);
+    }
+}
+
+pub(crate) fn for_each_statements_mut(
+    statements: &mut Vec<LoweredStatement>,
+    f: &mut impl FnMut(&mut Vec<LoweredStatement>),
+) {
+    f(statements);
+    for statement in statements {
+        statement.for_each_nested_statements_mut(f);
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct GoUses {
     names: HashSet<String>,
@@ -580,8 +600,14 @@ impl LoweredStatement {
                 } => {
                     visit_statements(target_capture, visit);
                     target.node().visit(visit);
-                    if let CompoundKind::OpAssign { rhs, .. } = kind {
+                    if let CompoundKind::OpAssign {
+                        rhs, pinned_left, ..
+                    } = kind
+                    {
                         rhs.visit_expressions(visit);
+                        if let Some(left) = pinned_left {
+                            left.node().visit(visit);
+                        }
                     }
                 }
                 AssignForm::Simple {
@@ -649,6 +675,168 @@ impl LoweredStatement {
                 expression.node().visit(visit)
             }
             LoweredStatement::Directed { inner, .. } => inner.visit_expressions(visit),
+        }
+    }
+
+    fn for_each_nested_statement(&self, f: &mut impl FnMut(&LoweredStatement)) {
+        match self {
+            LoweredStatement::If(plan) => plan.for_each_statement(f),
+            LoweredStatement::Loop(plan) => {
+                for_each_statement(&plan.prologue, f);
+                for_each_statement(&plan.body.statements, f);
+            }
+            LoweredStatement::Block(body)
+            | LoweredStatement::Body(body)
+            | LoweredStatement::WhileLet(body) => for_each_statement(&body.statements, f),
+            LoweredStatement::Const(plan) => for_each_statement(&plan.value.setup, f),
+            LoweredStatement::Return(form) => match form {
+                ReturnForm::Plain { value } => for_each_statement(&value.setup, f),
+                ReturnForm::Unit { side_effect } => {
+                    if let Some(body) = side_effect {
+                        for_each_statement(&body.statements, f);
+                    }
+                }
+                ReturnForm::Multi { .. } => {}
+                ReturnForm::Body { body } => for_each_statement(&body.statements, f),
+            },
+            LoweredStatement::BreakValue(
+                BreakValuePlan::Diverged { value } | BreakValuePlan::Transfer { value, .. },
+            ) => for_each_statement(&value.setup, f),
+            LoweredStatement::Let(plan) => {
+                if let Some(declaration) = &plan.declaration {
+                    f(declaration);
+                    declaration.for_each_nested_statement(f);
+                }
+                for_each_statement(&plan.body.statements, f);
+            }
+            LoweredStatement::Assign(form) => match form {
+                AssignForm::Compound {
+                    target_capture,
+                    kind,
+                    ..
+                } => {
+                    for_each_statement(target_capture, f);
+                    if let CompoundKind::OpAssign { rhs, .. } = kind {
+                        for_each_statement(&rhs.setup, f);
+                    }
+                }
+                AssignForm::Simple {
+                    target_capture,
+                    value,
+                    ..
+                } => {
+                    for_each_statement(target_capture, f);
+                    for_each_statement(&value.setup, f);
+                }
+            },
+            LoweredStatement::Select(plan) => {
+                for_each_statement(&plan.setup, f);
+                for arm in &plan.arms {
+                    for_each_statement(&arm.body().statements, f);
+                }
+                for_each_statement(&plan.postlude, f);
+            }
+            LoweredStatement::Switch(plan) => {
+                for case in &plan.cases {
+                    for_each_statement(&case.body.statements, f);
+                }
+                if let Some(default) = &plan.default {
+                    for_each_statement(&default.statements, f);
+                }
+                for_each_statement(&plan.postlude, f);
+            }
+            LoweredStatement::Directed { inner, .. } => {
+                f(inner);
+                inner.for_each_nested_statement(f);
+            }
+            LoweredStatement::Break(_)
+            | LoweredStatement::Continue(_)
+            | LoweredStatement::Async { .. }
+            | LoweredStatement::Define(_)
+            | LoweredStatement::AssignMany { .. }
+            | LoweredStatement::VarDecl { .. }
+            | LoweredStatement::Discard(_)
+            | LoweredStatement::ExpressionStatement { .. }
+            | LoweredStatement::UnreachablePanic => {}
+        }
+    }
+
+    fn for_each_nested_statements_mut(&mut self, f: &mut impl FnMut(&mut Vec<LoweredStatement>)) {
+        match self {
+            LoweredStatement::If(plan) => plan.for_each_statements_mut(f),
+            LoweredStatement::Loop(plan) => {
+                for_each_statements_mut(&mut plan.prologue, f);
+                for_each_statements_mut(&mut plan.body.statements, f);
+            }
+            LoweredStatement::Block(body)
+            | LoweredStatement::Body(body)
+            | LoweredStatement::WhileLet(body) => for_each_statements_mut(&mut body.statements, f),
+            LoweredStatement::Const(plan) => for_each_statements_mut(&mut plan.value.setup, f),
+            LoweredStatement::Return(form) => match form {
+                ReturnForm::Plain { value } => for_each_statements_mut(&mut value.setup, f),
+                ReturnForm::Unit { side_effect } => {
+                    if let Some(body) = side_effect {
+                        for_each_statements_mut(&mut body.statements, f);
+                    }
+                }
+                ReturnForm::Multi { .. } => {}
+                ReturnForm::Body { body } => for_each_statements_mut(&mut body.statements, f),
+            },
+            LoweredStatement::BreakValue(
+                BreakValuePlan::Diverged { value } | BreakValuePlan::Transfer { value, .. },
+            ) => for_each_statements_mut(&mut value.setup, f),
+            LoweredStatement::Let(plan) => {
+                if let Some(declaration) = &mut plan.declaration {
+                    declaration.for_each_nested_statements_mut(f);
+                }
+                for_each_statements_mut(&mut plan.body.statements, f);
+            }
+            LoweredStatement::Assign(form) => match form {
+                AssignForm::Compound {
+                    target_capture,
+                    kind,
+                    ..
+                } => {
+                    for_each_statements_mut(target_capture, f);
+                    if let CompoundKind::OpAssign { rhs, .. } = kind {
+                        for_each_statements_mut(&mut rhs.setup, f);
+                    }
+                }
+                AssignForm::Simple {
+                    target_capture,
+                    value,
+                    ..
+                } => {
+                    for_each_statements_mut(target_capture, f);
+                    for_each_statements_mut(&mut value.setup, f);
+                }
+            },
+            LoweredStatement::Select(plan) => {
+                for_each_statements_mut(&mut plan.setup, f);
+                for arm in &mut plan.arms {
+                    for_each_statements_mut(&mut arm.body_mut().statements, f);
+                }
+                for_each_statements_mut(&mut plan.postlude, f);
+            }
+            LoweredStatement::Switch(plan) => {
+                for case in &mut plan.cases {
+                    for_each_statements_mut(&mut case.body.statements, f);
+                }
+                if let Some(default) = &mut plan.default {
+                    for_each_statements_mut(&mut default.statements, f);
+                }
+                for_each_statements_mut(&mut plan.postlude, f);
+            }
+            LoweredStatement::Directed { inner, .. } => inner.for_each_nested_statements_mut(f),
+            LoweredStatement::Break(_)
+            | LoweredStatement::Continue(_)
+            | LoweredStatement::Async { .. }
+            | LoweredStatement::Define(_)
+            | LoweredStatement::AssignMany { .. }
+            | LoweredStatement::VarDecl { .. }
+            | LoweredStatement::Discard(_)
+            | LoweredStatement::ExpressionStatement { .. }
+            | LoweredStatement::UnreachablePanic => {}
         }
     }
 
@@ -779,6 +967,26 @@ impl SwitchCasePlan {
 }
 
 impl IfPlan {
+    fn for_each_statement(&self, f: &mut impl FnMut(&LoweredStatement)) {
+        for_each_statement(&self.condition_setup, f);
+        for_each_statement(&self.then_body.statements, f);
+        match &self.else_arm {
+            ElseArm::None => {}
+            ElseArm::ElseIf(plan) => plan.for_each_statement(f),
+            ElseArm::Else { body, .. } => for_each_statement(&body.statements, f),
+        }
+    }
+
+    fn for_each_statements_mut(&mut self, f: &mut impl FnMut(&mut Vec<LoweredStatement>)) {
+        for_each_statements_mut(&mut self.condition_setup, f);
+        for_each_statements_mut(&mut self.then_body.statements, f);
+        match &mut self.else_arm {
+            ElseArm::None => {}
+            ElseArm::ElseIf(plan) => plan.for_each_statements_mut(f),
+            ElseArm::Else { body, .. } => for_each_statements_mut(&mut body.statements, f),
+        }
+    }
+
     fn visit_expressions(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
         visit_statements(&self.condition_setup, visit);
         if let Some(initializer) = &self.initializer {

--- a/crates/emit/src/plan/cleanup.rs
+++ b/crates/emit/src/plan/cleanup.rs
@@ -1,0 +1,436 @@
+//! Rewrites of a lowered body that the tree makes safe to decide.
+
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use crate::names::go_name;
+use crate::plan::bodies::{
+    AssignForm, BreakValueAction, BreakValuePlan, CompoundKind, Definition, ElseArm, LoopHeader,
+    LoweredStatement, ReturnForm, SelectArmPlan, SwitchKind, for_each_statement,
+    for_each_statements_mut,
+};
+use crate::plan::go_expression::GoExpressionNode;
+use crate::plan::values::GoExpression;
+
+pub(crate) fn clean_up(statements: &mut Vec<LoweredStatement>) {
+    inline_name_aliases(statements);
+    drop_unread_temps(statements);
+}
+
+#[derive(Default)]
+struct NameUses {
+    reads: HashMap<String, usize>,
+    assigned: HashMap<String, usize>,
+    writes: HashSet<String>,
+    bindings: HashMap<String, usize>,
+}
+
+impl NameUses {
+    fn of(statements: &[LoweredStatement]) -> Self {
+        let mut uses = Self::default();
+        for statement in statements {
+            statement.visit_expressions(&mut |node| {
+                if let GoExpressionNode::Identifier(text) | GoExpressionNode::Verbatim(text) = node
+                {
+                    uses.record_reads(text);
+                }
+            });
+        }
+        for_each_statement(statements, &mut |statement| uses.record_bindings(statement));
+        uses
+    }
+
+    fn record_reads(&mut self, text: &str) {
+        for token in
+            text.split(|character: char| !(character.is_alphanumeric() || character == '_'))
+        {
+            if token
+                .chars()
+                .next()
+                .is_some_and(|first| first.is_alphabetic() || first == '_')
+            {
+                *self.reads.entry(token.to_string()).or_default() += 1;
+            }
+        }
+    }
+
+    fn reads(&self, name: &str) -> usize {
+        self.reads.get(name).copied().unwrap_or_default()
+    }
+
+    fn bindings(&self, name: &str) -> usize {
+        self.bindings.get(name).copied().unwrap_or_default()
+    }
+
+    fn value_reads(&self, name: &str) -> usize {
+        self.reads(name)
+            .saturating_sub(self.assigned.get(name).copied().unwrap_or_default())
+    }
+
+    fn bind(&mut self, name: &str) {
+        *self.bindings.entry(name.to_string()).or_default() += 1;
+    }
+
+    fn write_through(&mut self, target: &GoExpression) {
+        if let GoExpressionNode::Identifier(name) = target.node() {
+            *self.assigned.entry(name.clone()).or_default() += 1;
+        }
+        target.node().visit(&mut |node| {
+            if let GoExpressionNode::Identifier(name) = node {
+                self.writes.insert(name.clone());
+            }
+        });
+    }
+
+    fn record_bindings(&mut self, statement: &LoweredStatement) {
+        match statement {
+            LoweredStatement::Define(definition) => {
+                for name in &definition.names {
+                    self.bind(name);
+                }
+            }
+            LoweredStatement::VarDecl { name, .. } => self.bind(name),
+            LoweredStatement::Const(plan) => self.bind(&plan.name),
+            LoweredStatement::If(plan) => {
+                if let Some(initializer) = &plan.initializer {
+                    for name in &initializer.names {
+                        self.bind(name);
+                    }
+                }
+            }
+            LoweredStatement::Loop(plan) => match &plan.header {
+                LoopHeader::Range { key, value, .. } => {
+                    for name in key.iter().chain(value) {
+                        self.bind(name);
+                    }
+                }
+                LoopHeader::Counted { variable, .. } => self.bind(variable),
+                LoopHeader::Infinite | LoopHeader::While(_) => {}
+            },
+            LoweredStatement::Switch(plan) => {
+                if let SwitchKind::Type {
+                    binding: Some(name),
+                    ..
+                } = &plan.kind
+                {
+                    self.bind(name);
+                }
+            }
+            LoweredStatement::Select(plan) => {
+                for arm in &plan.arms {
+                    if let SelectArmPlan::Receive {
+                        receive_vars: Some(names),
+                        ..
+                    } = arm
+                    {
+                        for name in names.split(", ") {
+                            self.bind(name);
+                        }
+                    }
+                }
+            }
+            LoweredStatement::Assign(
+                AssignForm::Simple { target, .. } | AssignForm::Compound { target, .. },
+            ) => self.write_through(target),
+            LoweredStatement::AssignMany { targets, .. } => {
+                for target in targets {
+                    self.write_through(target);
+                }
+            }
+            LoweredStatement::BreakValue(BreakValuePlan::Transfer { action, .. }) => match action {
+                BreakValueAction::UnitCallIntoResult { result_var }
+                | BreakValueAction::AssignToResult { result_var } => {
+                    self.writes.insert(result_var.clone());
+                }
+                BreakValueAction::Discard => {}
+            },
+            _ => {}
+        }
+    }
+}
+
+fn inline_name_aliases(statements: &mut Vec<LoweredStatement>) {
+    let uses = NameUses::of(statements);
+    for_each_statements_mut(statements, &mut |list| {
+        let mut index = 0;
+        while index + 1 < list.len() {
+            if let Some((temp, source)) = alias_define(&list[index])
+                && uses.reads(&temp) == 1
+                && uses.bindings(&temp) == 1
+                && !uses.writes.contains(&temp)
+                && replace_only_read(&mut list[index + 1], &temp, &source)
+            {
+                list.remove(index);
+            } else {
+                index += 1;
+            }
+        }
+    });
+}
+
+fn alias_define(statement: &LoweredStatement) -> Option<(String, String)> {
+    match statement {
+        LoweredStatement::Directed { inner, .. } => alias_define(inner),
+        LoweredStatement::Define(Definition { names, value }) => {
+            match (names.as_slice(), value.node()) {
+                ([temp], GoExpressionNode::Identifier(source))
+                    if go_name::is_plain_identifier(source) =>
+                {
+                    Some((temp.clone(), source.clone()))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn replace_only_read(statement: &mut LoweredStatement, temp: &str, source: &str) -> bool {
+    match statement {
+        LoweredStatement::Directed { inner, .. } => replace_only_read(inner, temp, source),
+        LoweredStatement::Define(Definition { names, value }) => {
+            !names.iter().any(|name| name == source) && rename_in(vec![value], None, temp, source)
+        }
+        LoweredStatement::Assign(AssignForm::Simple {
+            target_capture,
+            target,
+            value,
+        }) if target_capture.is_empty() && value.setup.is_empty() => {
+            rename_in(vec![target, &mut value.expression], Some(0), temp, source)
+        }
+        LoweredStatement::Assign(AssignForm::Compound {
+            target_capture,
+            target,
+            kind: CompoundKind::OpAssign {
+                rhs, pinned_left, ..
+            },
+        }) if target_capture.is_empty() && rhs.setup.is_empty() => {
+            let mut siblings = vec![target, &mut rhs.expression];
+            siblings.extend(pinned_left.as_mut());
+            rename_in(siblings, Some(0), temp, source)
+        }
+        LoweredStatement::Return(ReturnForm::Plain { value }) if value.setup.is_empty() => {
+            rename_in(vec![&mut value.expression], None, temp, source)
+        }
+        LoweredStatement::Return(ReturnForm::Multi { values }) => {
+            rename_in(values.iter_mut().collect(), None, temp, source)
+        }
+        LoweredStatement::ExpressionStatement { expression, .. } => {
+            rename_in(vec![expression], None, temp, source)
+        }
+        LoweredStatement::If(plan)
+            if plan.condition_setup.is_empty() && plan.initializer.is_none() =>
+        {
+            rename_in(vec![&mut plan.condition], None, temp, source)
+        }
+        LoweredStatement::Switch(plan) => match &mut plan.kind {
+            SwitchKind::Value { subject } | SwitchKind::Type { subject, .. } => {
+                rename_in(vec![subject], None, temp, source)
+            }
+            SwitchKind::Conditional => false,
+        },
+        LoweredStatement::Select(plan) if plan.setup.is_empty() => {
+            let siblings = plan
+                .arms
+                .iter_mut()
+                .flat_map(|arm| match arm {
+                    SelectArmPlan::Receive { channel, .. } => vec![channel],
+                    SelectArmPlan::Send { channel, value, .. } => vec![channel, value],
+                    SelectArmPlan::Default { .. } => Vec::new(),
+                })
+                .collect();
+            rename_in(siblings, None, temp, source)
+        }
+        _ => false,
+    }
+}
+
+fn rename_in(
+    siblings: Vec<&mut GoExpression>,
+    written: Option<usize>,
+    temp: &str,
+    source: &str,
+) -> bool {
+    let analyses: Vec<Analysis> = siblings
+        .iter()
+        .map(|sibling| analyze(sibling.node(), temp))
+        .collect();
+    let reader = analyses.iter().position(|analysis| analysis.reads > 0);
+    let Some(reader) = reader else {
+        return false;
+    };
+    if written == Some(reader) || analyses[reader].reads != 1 || !analyses[reader].ordered {
+        return false;
+    }
+    let other_work = analyses
+        .iter()
+        .enumerate()
+        .any(|(index, analysis)| index != reader && analysis.works);
+    if other_work {
+        return false;
+    }
+    let mut siblings = siblings;
+    siblings[reader].rename_identifier(temp, source);
+    true
+}
+
+struct Analysis {
+    reads: usize,
+    works: bool,
+    ordered: bool,
+}
+
+fn analyze(node: &GoExpressionNode, temp: &str) -> Analysis {
+    if let GoExpressionNode::Identifier(name) = node {
+        return Analysis {
+            reads: usize::from(name == temp),
+            works: false,
+            ordered: true,
+        };
+    }
+    if let GoExpressionNode::FunctionLiteral { body, .. } = node {
+        let mut reads = 0;
+        body.visit_expressions(&mut |inner| {
+            if let GoExpressionNode::Identifier(name) = inner
+                && name == temp
+            {
+                reads += 1;
+            }
+        });
+        return Analysis {
+            reads,
+            works: false,
+            ordered: reads == 0,
+        };
+    }
+    if let GoExpressionNode::Verbatim(_) = node {
+        return Analysis {
+            reads: 0,
+            works: true,
+            ordered: true,
+        };
+    }
+    let identity_read = match node {
+        GoExpressionNode::AddressOf(operand) | GoExpressionNode::Slice { base: operand, .. } => {
+            mentions(operand, temp)
+        }
+        GoExpressionNode::Call { callee, .. } => {
+            matches!(callee.as_ref(), GoExpressionNode::Selector { base, .. } if mentions(base, temp))
+        }
+        _ => false,
+    };
+    let mut children = Vec::new();
+    node.visit_children(&mut |child| children.push(analyze(child, temp)));
+    let reads = children.iter().map(|child| child.reads).sum();
+    let reader = children.iter().position(|child| child.reads > 0);
+    let other_work = children
+        .iter()
+        .enumerate()
+        .any(|(index, child)| Some(index) != reader && child.works);
+    let ordered = children.iter().all(|child| child.ordered)
+        && !(reader.is_some() && other_work)
+        && !identity_read;
+    Analysis {
+        reads,
+        works: node.does_work() || children.iter().any(|child| child.works),
+        ordered,
+    }
+}
+
+fn mentions(node: &GoExpressionNode, name: &str) -> bool {
+    let mut found = false;
+    node.visit(&mut |inner| {
+        if let GoExpressionNode::Identifier(read) = inner
+            && read == name
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+fn drop_unread_temps(statements: &mut Vec<LoweredStatement>) {
+    loop {
+        let uses = NameUses::of(statements);
+        let mut discards: HashMap<String, usize> = HashMap::default();
+        for_each_statement(statements, &mut |statement| {
+            if let Some(name) = discarded_name(statement) {
+                *discards.entry(name.to_string()).or_default() += 1;
+            }
+        });
+        let mut dropped: Option<String> = None;
+        for_each_statement(statements, &mut |statement| {
+            if dropped.is_some() {
+                return;
+            }
+            let Some((name, value)) = pure_define(statement) else {
+                return;
+            };
+            let unread = uses.value_reads(name) == discards.get(name).copied().unwrap_or_default()
+                && uses.bindings(name) == 1
+                && !uses.writes.contains(name);
+            let mut sources = Vec::new();
+            value.node().visit(&mut |node| {
+                if let GoExpressionNode::Identifier(source) = node {
+                    sources.push(source.clone());
+                }
+            });
+            if unread && sources.iter().all(|source| uses.value_reads(source) > 1) {
+                dropped = Some(name.to_string());
+            }
+        });
+        let Some(name) = dropped else {
+            return;
+        };
+        for_each_statements_mut(statements, &mut |list| {
+            list.retain(|statement| {
+                pure_define(statement).is_none_or(|(defined, _)| defined != name)
+                    && discarded_name(statement) != Some(name.as_str())
+            });
+        });
+        for_each_statements_mut(statements, &mut |list| {
+            for statement in list {
+                drop_empty_else(statement);
+            }
+        });
+    }
+}
+
+fn drop_empty_else(statement: &mut LoweredStatement) {
+    let mut plan = match statement {
+        LoweredStatement::Directed { inner, .. } => return drop_empty_else(inner),
+        LoweredStatement::If(plan) => plan,
+        _ => return,
+    };
+    loop {
+        if matches!(&plan.else_arm, ElseArm::Else { body, .. } if body.renders_empty()) {
+            plan.else_arm = ElseArm::None;
+            return;
+        }
+        match &mut plan.else_arm {
+            ElseArm::ElseIf(inner) => plan = inner,
+            ElseArm::Else { .. } | ElseArm::None => return,
+        }
+    }
+}
+
+fn pure_define(statement: &LoweredStatement) -> Option<(&str, &GoExpression)> {
+    match statement {
+        LoweredStatement::Directed { inner, .. } => pure_define(inner),
+        LoweredStatement::Define(Definition { names, value }) => match names.as_slice() {
+            [name] if !value.does_work() => Some((name, value)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn discarded_name(statement: &LoweredStatement) -> Option<&str> {
+    match statement {
+        LoweredStatement::Directed { inner, .. } => discarded_name(inner),
+        LoweredStatement::Discard(expression) => match expression.node() {
+            GoExpressionNode::Identifier(name) => Some(name),
+            _ => None,
+        },
+        _ => None,
+    }
+}

--- a/crates/emit/src/plan/go_expression.rs
+++ b/crates/emit/src/plan/go_expression.rs
@@ -61,7 +61,6 @@ pub(crate) enum GoExpressionNode {
         left: Box<GoExpressionNode>,
         right: Box<GoExpressionNode>,
     },
-    Parenthesized(Box<GoExpressionNode>),
     Conversion {
         go_type: String,
         operand: Box<GoExpressionNode>,
@@ -146,7 +145,6 @@ impl GoExpressionNode {
             | Self::Conversion { operand, .. }
             | Self::AddressOf(operand)
             | Self::Dereference(operand)
-            | Self::Parenthesized(operand)
             | Self::Spread(operand) => operand.does_work(),
             Self::Binary { left, right, .. } => left.does_work() || right.does_work(),
         }
@@ -154,33 +152,49 @@ impl GoExpressionNode {
 
     pub(crate) fn visit(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
         visit(self);
+        if let Self::FunctionLiteral { body, .. } = self {
+            body.visit_expressions(visit);
+        } else {
+            self.visit_children(&mut |child| child.visit(visit));
+        }
+    }
+
+    pub(crate) fn rename_identifier(&mut self, from: &str, to: &str) {
+        match self {
+            Self::Identifier(name) if name == from => *name = to.to_string(),
+            _ => self.visit_children_mut(&mut |child| child.rename_identifier(from, to)),
+        }
+    }
+
+    pub(crate) fn visit_children(&self, visit: &mut impl FnMut(&GoExpressionNode)) {
         match self {
             Self::Identifier(_)
             | Self::Qualified { .. }
             | Self::Literal(_)
             | Self::Type(_)
             | Self::Empty
-            | Self::Verbatim(_) => {}
+            | Self::Verbatim(_)
+            | Self::FunctionLiteral { .. } => {}
             Self::CompositeLiteral { elements, .. } => {
                 for element in elements {
                     if let Some(key) = &element.key {
-                        key.visit(visit);
+                        visit(key);
                     }
-                    element.value.visit(visit);
+                    visit(&element.value);
                 }
             }
             Self::Call { callee, arguments } => {
-                callee.visit(visit);
+                visit(callee);
                 for argument in arguments {
-                    argument.visit(visit);
+                    visit(argument);
                 }
             }
             Self::Instantiation { base, .. }
             | Self::Selector { base, .. }
-            | Self::TypeAssertion { base, .. } => base.visit(visit),
+            | Self::TypeAssertion { base, .. } => visit(base),
             Self::Index { base, index } => {
-                base.visit(visit);
-                index.visit(visit);
+                visit(base);
+                visit(index);
             }
             Self::Slice {
                 base,
@@ -188,33 +202,158 @@ impl GoExpressionNode {
                 high,
                 max,
             } => {
-                base.visit(visit);
+                visit(base);
                 for bound in [low, high, max].into_iter().flatten() {
-                    bound.visit(visit);
+                    visit(bound);
                 }
             }
             Self::Unary { operand, .. }
             | Self::Conversion { operand, .. }
             | Self::AddressOf(operand)
             | Self::Dereference(operand)
-            | Self::Parenthesized(operand)
-            | Self::Spread(operand) => operand.visit(visit),
+            | Self::Spread(operand) => visit(operand),
             Self::Binary { left, right, .. } => {
-                left.visit(visit);
-                right.visit(visit);
+                visit(left);
+                visit(right);
             }
-            Self::FunctionLiteral { body, .. } => body.visit_expressions(visit),
         }
     }
 
-    /// Print the node token for token, since `gofmt` owns the spacing.
+    fn visit_children_mut(&mut self, visit: &mut impl FnMut(&mut GoExpressionNode)) {
+        match self {
+            Self::Identifier(_)
+            | Self::Qualified { .. }
+            | Self::Literal(_)
+            | Self::Type(_)
+            | Self::Empty
+            | Self::Verbatim(_)
+            | Self::FunctionLiteral { .. } => {}
+            Self::CompositeLiteral { elements, .. } => {
+                for element in elements {
+                    if let Some(key) = &mut element.key {
+                        visit(key);
+                    }
+                    visit(&mut element.value);
+                }
+            }
+            Self::Call { callee, arguments } => {
+                visit(callee);
+                for argument in arguments {
+                    visit(argument);
+                }
+            }
+            Self::Instantiation { base, .. }
+            | Self::Selector { base, .. }
+            | Self::TypeAssertion { base, .. } => visit(base),
+            Self::Index { base, index } => {
+                visit(base);
+                visit(index);
+            }
+            Self::Slice {
+                base,
+                low,
+                high,
+                max,
+            } => {
+                visit(base);
+                for bound in [low, high, max].into_iter().flatten() {
+                    visit(bound);
+                }
+            }
+            Self::Unary { operand, .. }
+            | Self::Conversion { operand, .. }
+            | Self::AddressOf(operand)
+            | Self::Dereference(operand)
+            | Self::Spread(operand) => visit(operand),
+            Self::Binary { left, right, .. } => {
+                visit(left);
+                visit(right);
+            }
+        }
+    }
+
     pub(crate) fn print(&self) -> String {
         let mut output = String::new();
-        self.write(&mut output);
+        self.write(&mut output, Slot::FREE);
         output
     }
 
-    fn write(&self, output: &mut String) {
+    pub(crate) fn print_header(&self) -> String {
+        let mut output = String::new();
+        self.write(&mut output, Slot::HEADER);
+        output
+    }
+
+    fn binding(&self) -> Binding {
+        match self {
+            Self::Literal(text) if text.starts_with(['-', '+']) => {
+                Binding::Prefix(text.chars().next().unwrap_or(' '))
+            }
+            Self::Identifier(_)
+            | Self::Qualified { .. }
+            | Self::Literal(_)
+            | Self::Type(_)
+            | Self::CompositeLiteral { .. }
+            | Self::Call { .. }
+            | Self::Instantiation { .. }
+            | Self::Selector { .. }
+            | Self::Index { .. }
+            | Self::Slice { .. }
+            | Self::TypeAssertion { .. }
+            | Self::Conversion { .. }
+            | Self::Spread(_)
+            | Self::FunctionLiteral { .. }
+            | Self::Empty => Binding::Primary,
+            Self::Unary { operator, .. } => Binding::Prefix(operator.chars().next().unwrap_or(' ')),
+            Self::AddressOf(_) => Binding::Prefix('&'),
+            Self::Dereference(_) => Binding::Prefix('*'),
+            Self::Binary { operator, .. } => Binding::Binary(binary_level(operator)),
+            Self::Verbatim(_) => Binding::Unknown,
+        }
+    }
+
+    fn needs_parens(&self, slot: Slot) -> bool {
+        if slot.header
+            && matches!(
+                self,
+                Self::CompositeLiteral {
+                    go_type: Some(_),
+                    ..
+                }
+            )
+        {
+            return true;
+        }
+        match (self.binding(), slot.kind) {
+            (Binding::Unknown, SlotKind::Free) => false,
+            (Binding::Unknown, _) => true,
+            (Binding::Primary, SlotKind::Postfix) => {
+                matches!(self, Self::Literal(_) | Self::FunctionLiteral { .. })
+            }
+            (Binding::Primary, _) => false,
+            (Binding::Prefix(sign), SlotKind::Prefix(operator)) => {
+                sign == operator && matches!(sign, '-' | '+' | '&')
+            }
+            (Binding::Prefix(_), SlotKind::Callee | SlotKind::Postfix) => true,
+            (Binding::Prefix(_), _) => false,
+            (Binding::Binary(level), SlotKind::Left(parent)) => level < parent,
+            (Binding::Binary(level), SlotKind::Right(parent)) => level <= parent,
+            (Binding::Binary(_), SlotKind::Free) => false,
+            (Binding::Binary(_), _) => true,
+        }
+    }
+
+    fn write_child(child: &Self, slot: Slot, output: &mut String) {
+        if child.needs_parens(slot) {
+            output.push('(');
+            child.write(output, Slot::FREE);
+            output.push(')');
+        } else {
+            child.write(output, slot);
+        }
+    }
+
+    fn write(&self, output: &mut String, slot: Slot) {
         match self {
             Self::Identifier(text)
             | Self::Literal(text)
@@ -263,13 +402,13 @@ impl GoExpressionNode {
                 }
             }
             Self::Call { callee, arguments } => {
-                callee.write(output);
+                Self::write_child(callee, slot.with(SlotKind::Callee), output);
                 output.push('(');
                 for (index, argument) in arguments.iter().enumerate() {
                     if index > 0 {
                         output.push_str(", ");
                     }
-                    argument.write(output);
+                    argument.write(output, Slot::FREE);
                 }
                 output.push(')');
             }
@@ -277,18 +416,18 @@ impl GoExpressionNode {
                 base,
                 type_arguments,
             } => {
-                base.write(output);
+                Self::write_child(base, slot.with(SlotKind::Postfix), output);
                 output.push_str(type_arguments);
             }
             Self::Selector { base, field } => {
-                base.write(output);
+                Self::write_child(base, slot.with(SlotKind::Postfix), output);
                 output.push('.');
                 output.push_str(field);
             }
             Self::Index { base, index } => {
-                base.write(output);
+                Self::write_child(base, slot.with(SlotKind::Postfix), output);
                 output.push('[');
-                index.write(output);
+                index.write(output, Slot::FREE);
                 output.push(']');
             }
             Self::Slice {
@@ -297,68 +436,57 @@ impl GoExpressionNode {
                 high,
                 max,
             } => {
-                base.write(output);
+                Self::write_child(base, slot.with(SlotKind::Postfix), output);
                 output.push('[');
                 if let Some(low) = low {
-                    low.write(output);
+                    low.write(output, Slot::FREE);
                 }
                 output.push(':');
                 if let Some(high) = high {
-                    high.write(output);
+                    high.write(output, Slot::FREE);
                 }
                 if let Some(max) = max {
                     output.push(':');
-                    max.write(output);
+                    max.write(output, Slot::FREE);
                 }
                 output.push(']');
             }
             Self::TypeAssertion { base, go_type } => {
-                base.write(output);
+                Self::write_child(base, slot.with(SlotKind::Postfix), output);
                 output.push_str(".(");
                 output.push_str(go_type);
                 output.push(')');
             }
             Self::Unary { operator, operand } => {
-                let operand = operand.print();
-                // Go reads `--x` as a decrement, so a negated negative keeps its parentheses.
-                if operator == "-" && operand.starts_with('-') {
-                    output.push_str("-(");
-                    output.push_str(&operand);
-                    output.push(')');
-                } else {
-                    output.push_str(operator);
-                    output.push_str(&operand);
-                }
+                output.push_str(operator);
+                let sign = operator.chars().next().unwrap_or(' ');
+                Self::write_child(operand, slot.with(SlotKind::Prefix(sign)), output);
             }
             Self::AddressOf(operand) => {
                 output.push('&');
-                operand.write(output);
+                Self::write_child(operand, slot.with(SlotKind::Prefix('&')), output);
             }
             Self::Dereference(operand) => {
                 output.push('*');
-                operand.write(output);
+                Self::write_child(operand, slot.with(SlotKind::Prefix('*')), output);
             }
             Self::Binary {
                 operator,
                 left,
                 right,
             } => {
-                left.write(output);
+                let level = binary_level(operator);
+                Self::write_child(left, slot.with(SlotKind::Left(level)), output);
                 output.push(' ');
                 output.push_str(operator);
                 output.push(' ');
-                right.write(output);
-            }
-            Self::Parenthesized(inner) => {
-                output.push('(');
-                inner.write(output);
-                output.push(')');
+                Self::write_child(right, slot.with(SlotKind::Right(level)), output);
             }
             Self::Conversion { go_type, operand } => {
                 output.push_str(&render_conversion(go_type, &operand.print()));
             }
             Self::Spread(operand) => {
-                operand.write(output);
+                Self::write_child(operand, slot.with(SlotKind::Postfix), output);
                 output.push_str("...");
             }
             Self::FunctionLiteral {
@@ -407,12 +535,149 @@ impl GoExpressionNode {
     }
 }
 
+#[derive(Clone, Copy)]
+struct Slot {
+    kind: SlotKind,
+    header: bool,
+}
+
+impl Slot {
+    const FREE: Self = Self {
+        kind: SlotKind::Free,
+        header: false,
+    };
+    const HEADER: Self = Self {
+        kind: SlotKind::Free,
+        header: true,
+    };
+
+    fn with(self, kind: SlotKind) -> Self {
+        Self {
+            kind,
+            header: self.header,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SlotKind {
+    Free,
+    Left(u8),
+    Right(u8),
+    Prefix(char),
+    Callee,
+    Postfix,
+}
+
+enum Binding {
+    Primary,
+    Prefix(char),
+    Binary(u8),
+    Unknown,
+}
+
+fn binary_level(operator: &str) -> u8 {
+    match operator {
+        "*" | "/" | "%" | "<<" | ">>" | "&" | "&^" => 5,
+        "+" | "-" | "|" | "^" => 4,
+        "==" | "!=" | "<" | "<=" | ">" | ">=" => 3,
+        "&&" => 2,
+        "||" => 1,
+        _ => 0,
+    }
+}
+
 impl CompositeElement {
     fn write(&self, output: &mut String) {
         if let Some(key) = &self.key {
-            key.write(output);
+            key.write(output, Slot::FREE);
             output.push_str(": ");
         }
-        self.value.write(output);
+        self.value.write(output, Slot::FREE);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn name(text: &str) -> GoExpressionNode {
+        GoExpressionNode::Identifier(text.to_string())
+    }
+
+    fn binary(left: GoExpressionNode, operator: &str, right: GoExpressionNode) -> GoExpressionNode {
+        GoExpressionNode::Binary {
+            operator: operator.to_string(),
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    fn literal_struct(go_type: &str) -> GoExpressionNode {
+        GoExpressionNode::CompositeLiteral {
+            go_type: Some(go_type.to_string()),
+            elements: Vec::new(),
+            layout: CompositeLayout::Inline { padded: true },
+        }
+    }
+
+    #[test]
+    fn looser_operand_takes_parentheses() {
+        let shifted = binary(binary(name("a"), "+", name("b")), "<<", name("c"));
+        assert_eq!(shifted.print(), "(a + b) << c");
+        let sum = binary(binary(name("a"), "*", name("b")), "+", name("c"));
+        assert_eq!(sum.print(), "a * b + c");
+    }
+
+    #[test]
+    fn equal_operand_on_the_right_takes_parentheses() {
+        let nested = binary(name("a"), "-", binary(name("b"), "-", name("c")));
+        assert_eq!(nested.print(), "a - (b - c)");
+        let flat = binary(binary(name("a"), "-", name("b")), "-", name("c"));
+        assert_eq!(flat.print(), "a - b - c");
+    }
+
+    #[test]
+    fn repeated_sign_takes_parentheses() {
+        let negate = |operand| GoExpressionNode::Unary {
+            operator: "-".to_string(),
+            operand: Box::new(operand),
+        };
+        assert_eq!(negate(negate(name("x"))).print(), "-(-x)");
+        assert_eq!(
+            negate(GoExpressionNode::Literal("-1".to_string())).print(),
+            "-(-1)"
+        );
+        let not = |operand| GoExpressionNode::Unary {
+            operator: "!".to_string(),
+            operand: Box::new(operand),
+        };
+        assert_eq!(not(not(name("x"))).print(), "!!x");
+    }
+
+    #[test]
+    fn postfix_on_prefix_takes_parentheses() {
+        let field = GoExpressionNode::Selector {
+            base: Box::new(GoExpressionNode::Dereference(Box::new(name("node")))),
+            field: "Child".to_string(),
+        };
+        assert_eq!(field.print(), "(*node).Child");
+        let call = GoExpressionNode::Call {
+            callee: Box::new(GoExpressionNode::Dereference(Box::new(name("f")))),
+            arguments: vec![name("x")],
+        };
+        assert_eq!(call.print(), "(*f)(x)");
+    }
+
+    #[test]
+    fn composite_literal_takes_parentheses_in_a_header() {
+        let compared = binary(name("x"), "==", literal_struct("Point"));
+        assert_eq!(compared.print(), "x == Point{}");
+        assert_eq!(compared.print_header(), "x == (Point{})");
+        let called = GoExpressionNode::Call {
+            callee: Box::new(name("f")),
+            arguments: vec![literal_struct("Point")],
+        };
+        assert_eq!(called.print_header(), "f(Point{})");
     }
 }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -16,7 +16,6 @@ use crate::plan::bodies::{
 use crate::plan::go_expression::CompositeLayout;
 use crate::plan::placement::{collapse_declared_temp, requires_temp_var, try_elide_tail_let};
 use crate::plan::values::{GoExpression, OperandForm, ValuePlan};
-use crate::utils::wrap_if_struct_literal;
 use std::slice;
 use syntax::ast::{
     BinaryOperator, Expression, IdentifierResolution, IfLetAlternative, Literal, MatchArm, Pattern,
@@ -87,7 +86,11 @@ impl Planner<'_> {
         );
         let mut setup = vec![declaration];
         setup.extend(block.statements);
-        collapse_declared_temp(&mut setup, &result_var);
+        collapse_declared_temp(
+            &mut setup,
+            &result_var,
+            self.short_declaration_keeps_type(ty),
+        );
         ValuePlan::captured(setup, result_var)
     }
 
@@ -499,7 +502,7 @@ impl Planner<'_> {
         AssertShape {
             failure_condition: match flipped {
                 Some(_) => condition,
-                None => negate_parenthesized(condition),
+                None => GoExpression::unary("!", condition),
             },
             kind: "relation",
             message: format!("expected {operator}"),
@@ -532,7 +535,7 @@ impl Planner<'_> {
         operand: &Expression,
         statements: &mut Vec<LoweredStatement>,
     ) -> AssertShape {
-        let ctx = ExpressionContext::value().condition();
+        let ctx = ExpressionContext::value();
         let failure_condition = if let Expression::Unary {
             operator: UnaryOperator::Not,
             expression: negated,
@@ -541,17 +544,15 @@ impl Planner<'_> {
         {
             let (setup, condition) = self.plan_operand(negated, ctx).into_parts();
             statements.extend(setup);
-            wrap_if_struct_literal(condition)
+            condition
         } else if matches!(operand, Expression::Binary { .. }) {
-            // `!` binds tighter than `&&` and `||`, so a binary predicate keeps
-            // its parentheses.
             let (setup, condition) = self.lower_condition(operand);
             statements.extend(setup);
-            negate_parenthesized(condition)
+            GoExpression::unary("!", condition)
         } else {
             let (setup, condition) = self.plan_unary_not(operand, ctx).into_parts();
             statements.extend(setup);
-            wrap_if_struct_literal(condition)
+            condition
         };
         AssertShape {
             failure_condition,
@@ -708,7 +709,7 @@ impl Planner<'_> {
     }
 
     fn lower_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, GoExpression) {
-        let plan = self.plan_operand(condition, ExpressionContext::value().condition());
+        let plan = self.plan_operand(condition, ExpressionContext::value());
         plan.into_parts()
     }
 
@@ -724,7 +725,7 @@ impl Planner<'_> {
             setup,
             PairCondition {
                 initializer: None,
-                condition: wrap_if_struct_literal(rendered),
+                condition: rendered,
             },
         )
     }
@@ -738,7 +739,7 @@ impl Planner<'_> {
             }
             let (setup, rendered) = this.lower_condition(condition);
             if !setup.is_empty() {
-                let exit = GoExpression::unary("!", GoExpression::parenthesized(rendered));
+                let exit = GoExpression::unary("!", rendered);
                 return this.lower_loop_with_exit_test(setup, exit, body);
             }
             let header = if matches!(
@@ -750,7 +751,7 @@ impl Planner<'_> {
             ) {
                 LoopHeader::Infinite
             } else {
-                LoopHeader::While(wrap_if_struct_literal(rendered))
+                LoopHeader::While(rendered)
             };
             this.lower_loop_with_header(header, body)
         })
@@ -1105,10 +1106,6 @@ struct AssertShape {
 struct AssertOperand {
     expression: Expression,
     rendered: GoExpression,
-}
-
-fn negate_parenthesized(condition: GoExpression) -> GoExpression {
-    GoExpression::unary("!", GoExpression::parenthesized(condition))
 }
 
 /// The equals lowering can read its left operand as a method receiver, where a

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bodies;
 pub(crate) mod calls;
+pub(crate) mod cleanup;
 pub(crate) mod go_expression;
 pub(crate) mod lower;
 pub(crate) mod placement;

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -5,14 +5,17 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::expressions::staging::SpreadSequenceOptions;
-use crate::names::go_name::{GeneratedPackage, is_plain_identifier};
+use crate::names::go_name::GeneratedPackage;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::plan::bodies::{
     AssignForm, BreakValueAction, BreakValuePlan, ElseArm, LoopHeader, LoopTransfer, LoweredBlock,
     LoweredStatement, PlacePlan, define, discard, expression_statement,
 };
 use crate::plan::calls::plan_variadic_spread;
-use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::plan::go_expression::GoExpressionNode;
+use crate::plan::values::{
+    CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, ValuePlan,
+};
 use crate::statements::assignments::is_lvalue_chain;
 use crate::types::native::NativeGoType;
 use std::slice;
@@ -74,7 +77,11 @@ pub(crate) fn rebind_trailing_temp(
 }
 
 /// Collapse `var x T` plus the one statement that fills it into `x := value`.
-pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, name: &str) {
+pub(crate) fn collapse_declared_temp(
+    statements: &mut Vec<LoweredStatement>,
+    name: &str,
+    value_has_declared_type: bool,
+) {
     let [
         LoweredStatement::VarDecl {
             name: declared,
@@ -95,7 +102,7 @@ pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, nam
             target,
             value,
         }) => {
-            if !matches!(go_type.as_str(), "int" | "string" | "bool")
+            if !infers_declared_type(go_type, &value.expression, value_has_declared_type)
                 || target.as_str() != name
                 || !target_capture.is_empty()
                 || !value.setup.is_empty()
@@ -133,6 +140,42 @@ pub(crate) fn collapse_declared_temp(statements: &mut Vec<LoweredStatement>, nam
     statements[0] = define(name.to_string(), value);
 }
 
+fn infers_declared_type(
+    go_type: &str,
+    value: &GoExpression,
+    value_has_declared_type: bool,
+) -> bool {
+    if let Some(kind) = value.constant_kind() {
+        return match kind {
+            ConstantKind::Int => go_type == "int",
+            ConstantKind::Rune => matches!(go_type, "rune" | "int32"),
+            ConstantKind::Float => go_type == "float64",
+            ConstantKind::Complex => go_type == "complex128",
+            ConstantKind::Bool => go_type == "bool",
+            ConstantKind::String => go_type == "string",
+        };
+    }
+    match value.node() {
+        GoExpressionNode::Literal(text) => {
+            matches!(go_type, "int" | "string" | "bool") && text != "nil"
+        }
+        GoExpressionNode::CompositeLiteral {
+            go_type: Some(literal_type),
+            ..
+        } => literal_type == go_type,
+        GoExpressionNode::CompositeLiteral { go_type: None, .. }
+        | GoExpressionNode::FunctionLiteral { .. }
+        | GoExpressionNode::Verbatim(_) => false,
+        GoExpressionNode::Binary { operator, .. } => match operator.as_str() {
+            "==" | "!=" | "<" | "<=" | ">" | ">=" | "&&" | "||" => go_type == "bool",
+            "<<" | ">>" => go_type == "int",
+            _ => value_has_declared_type,
+        },
+        GoExpressionNode::Unary { operator, .. } if operator == "!" => go_type == "bool",
+        _ => value_has_declared_type && !go_type.contains("chan"),
+    }
+}
+
 /// The value of a body that is exactly one plain `name = value`.
 fn single_simple_assign_value(body: &LoweredBlock, name: &str) -> Option<GoExpression> {
     let [LoweredStatement::Assign(assign)] = body.statements.as_slice() else {
@@ -160,34 +203,18 @@ fn join_boolean_branches(
 ) -> Option<GoExpression> {
     let and = |left: GoExpression, right: GoExpression| GoExpression::binary(left, "&&", right);
     let or = |left: GoExpression, right: GoExpression| GoExpression::binary(left, "||", right);
+    let not = |operand: &GoExpression| GoExpression::unary("!", operand.clone());
     Some(match (then_value.as_str(), else_value.as_str()) {
         ("true", "false") => condition.clone(),
-        ("false", "true") => negate_condition(condition),
+        ("false", "true") => not(condition),
         // Both-literal same-value arms would drop the condition's evaluation.
         ("true", "true") | ("false", "false") => return None,
-        (_, "false") => and(and_operand(condition), and_operand(then_value)),
+        (_, "false") => and(condition.clone(), then_value.clone()),
         ("true", _) => or(condition.clone(), else_value.clone()),
-        ("false", _) => and(negate_condition(condition), and_operand(else_value)),
-        (_, "true") => or(negate_condition(condition), then_value.clone()),
+        ("false", _) => and(not(condition), else_value.clone()),
+        (_, "true") => or(not(condition), then_value.clone()),
         _ => return None,
     })
-}
-
-fn negate_condition(condition: &GoExpression) -> GoExpression {
-    if is_plain_identifier(condition.as_str()) {
-        GoExpression::unary("!", condition.clone())
-    } else {
-        GoExpression::unary("!", GoExpression::parenthesized(condition.clone()))
-    }
-}
-
-/// Parenthesize a synthesized `&&` operand, keeping bare identifiers bare.
-fn and_operand(operand: &GoExpression) -> GoExpression {
-    if is_plain_identifier(operand.as_str()) {
-        operand.clone()
-    } else {
-        GoExpression::parenthesized(operand.clone())
-    }
 }
 
 pub(crate) fn requires_temp_var(expression: &Expression) -> bool {
@@ -297,6 +324,13 @@ pub(crate) fn expression_contains_binding(expression: &Expression, name: &str) -
 }
 
 impl Planner<'_> {
+    pub(crate) fn short_declaration_keeps_type(&self, ty: &Type) -> bool {
+        let peeled = self.facts.peel_alias(ty);
+        !self.facts.is_interface_or_unknown(&peeled)
+            && !(matches!(peeled, Type::Nominal { .. })
+                && self.facts.underlying_simple_kind(&peeled).is_some())
+    }
+
     /// Lower a discarded expression into structured statements: a bare
     /// side-effecting call (`f()`), a `_ = value` discard, or a propagate.
     pub(crate) fn lower_discard_value(&mut self, value: &Expression) -> Vec<LoweredStatement> {

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -295,11 +295,6 @@ impl GoExpression {
         Self::new(node)
     }
 
-    pub(crate) fn parenthesized(value: GoExpression) -> Self {
-        let constant = value.constant;
-        Self::new(GoExpressionNode::Parenthesized(Box::new(value.node))).with_constant(constant)
-    }
-
     pub(crate) fn unary(operator: &str, value: GoExpression) -> Self {
         let constant = unary_constant(operator, value.constant);
         let node = GoExpressionNode::Unary {
@@ -336,6 +331,15 @@ impl GoExpression {
 
     pub(crate) fn rendered(&self) -> String {
         self.rendered.clone()
+    }
+
+    pub(crate) fn print_header(&self) -> String {
+        self.node.print_header()
+    }
+
+    pub(crate) fn rename_identifier(&mut self, from: &str, to: &str) {
+        self.node.rename_identifier(from, to);
+        self.rendered = self.node.print();
     }
 
     pub(crate) fn as_str(&self) -> &str {
@@ -729,18 +733,6 @@ impl ValuePlan {
         (self.setup, self.expression)
     }
 
-    pub(crate) fn parenthesized(mut self) -> Self {
-        if matches!(self.evaluation.form, OperandForm::Call)
-            || (self.evaluation.stability.is_stable_across_calls()
-                && !matches!(self.evaluation.form, OperandForm::Name))
-        {
-            self.evaluation.stability = Stability::Observable;
-        }
-        self.evaluation.form = OperandForm::Other;
-        self.expression = GoExpression::parenthesized(self.expression);
-        self
-    }
-
     pub(crate) fn conversion(mut self, go_type: String) -> Self {
         self.expression = GoExpression::conversion(go_type, self.expression);
         self.evaluation.form = OperandForm::Other;
@@ -771,12 +763,7 @@ impl Planner<'_> {
             return ValuePlan::plain_call(setup, call, EvaluationEffect::EffectfulCall);
         }
         match expression {
-            Expression::Paren { expression, .. } if self.is_conversion_cast(expression) => {
-                self.plan_operand(expression, ctx)
-            }
-            Expression::Paren { expression, .. } => {
-                self.plan_operand(expression, ctx).parenthesized()
-            }
+            Expression::Paren { expression, .. } => self.plan_operand(expression, ctx),
             Expression::Cast { expression, ty, .. } => self.plan_cast(expression, ty, ctx),
             Expression::IndexedAccess {
                 expression, index, ..
@@ -806,7 +793,7 @@ impl Planner<'_> {
                 spread,
                 ty,
                 ..
-            } => self.plan_struct_call(name, field_assignments, spread, ty, ctx),
+            } => self.plan_struct_call(name, field_assignments, spread, ty),
             Expression::Reference {
                 expression: inner,
                 ty,

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -62,15 +62,22 @@ impl Renderer {
     fn render_switch(&self, output: &mut String, plan: &SwitchStatementPlan) {
         match &plan.kind {
             SwitchKind::Conditional => output.push_str("switch {\n"),
-            SwitchKind::Value { subject } => write_line!(output, "switch {} {{", subject),
+            SwitchKind::Value { subject } => {
+                write_line!(output, "switch {} {{", subject.print_header())
+            }
             SwitchKind::Type {
                 subject,
                 binding: Some(binding),
-            } => write_line!(output, "switch {} := {}.(type) {{", binding, subject),
+            } => write_line!(
+                output,
+                "switch {} := {}.(type) {{",
+                binding,
+                subject.print_header()
+            ),
             SwitchKind::Type {
                 subject,
                 binding: None,
-            } => write_line!(output, "switch {}.(type) {{", subject),
+            } => write_line!(output, "switch {}.(type) {{", subject.print_header()),
         }
         for case in &plan.cases {
             write_line!(output, "case {}:", join_expressions(&case.labels));
@@ -207,20 +214,20 @@ impl Renderer {
                         rhs,
                         pinned_left,
                     } => {
-                        let rhs_text = self.render_value(output, rhs);
+                        for statement in &rhs.setup {
+                            self.render_statement(output, statement);
+                        }
                         match pinned_left {
                             Some(left) => {
-                                write_line!(
-                                    output,
-                                    "{} = {} {} {}",
-                                    target,
-                                    left,
-                                    op_text,
-                                    rhs_text
-                                )
+                                let value = GoExpression::binary(
+                                    left.clone(),
+                                    op_text.as_str(),
+                                    rhs.expression.clone(),
+                                );
+                                write_line!(output, "{} = {}", target, value)
                             }
                             None => {
-                                write_line!(output, "{} {}= {}", target, op_text, rhs_text)
+                                write_line!(output, "{} {}= {}", target, op_text, rhs.expression)
                             }
                         }
                     }
@@ -340,20 +347,27 @@ impl Renderer {
         }
         match &plan.header {
             LoopHeader::Infinite => output.push_str("for {\n"),
-            LoopHeader::While(condition) => write_line!(output, "for {} {{", condition),
+            LoopHeader::While(condition) => {
+                write_line!(output, "for {} {{", condition.print_header())
+            }
             LoopHeader::Range {
                 key,
                 value,
                 iterable,
             } => match (key, value) {
-                (None, None) => write_line!(output, "for range {} {{", iterable),
-                (Some(key), None) => write_line!(output, "for {} := range {} {{", key, iterable),
+                (None, None) => write_line!(output, "for range {} {{", iterable.print_header()),
+                (Some(key), None) => write_line!(
+                    output,
+                    "for {} := range {} {{",
+                    key,
+                    iterable.print_header()
+                ),
                 (key, Some(value)) => write_line!(
                     output,
                     "for {}, {} := range {} {{",
                     key.as_deref().unwrap_or("_"),
                     value,
-                    iterable
+                    iterable.print_header()
                 ),
             },
             LoopHeader::Counted {
@@ -364,8 +378,10 @@ impl Renderer {
                 output,
                 "for {} := {}; {}; {}++ {{",
                 variable,
-                start,
-                condition.as_ref().map_or("", GoExpression::as_str),
+                start.print_header(),
+                condition
+                    .as_ref()
+                    .map_or(String::new(), GoExpression::print_header),
                 variable
             ),
         }
@@ -377,10 +393,12 @@ impl Renderer {
         debug_assert!(!plan.condition.is_empty(), "if condition must not be empty");
         output.push_str("if ");
         if let Some(initializer) = &plan.initializer {
-            self.render_definition(output, initializer);
+            output.push_str(&initializer.names.join(", "));
+            output.push_str(" := ");
+            output.push_str(&initializer.value.print_header());
             output.push_str("; ");
         }
-        output.push_str(plan.condition.as_str());
+        output.push_str(&plan.condition.print_header());
         output.push_str(" {\n");
     }
 

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -121,23 +121,11 @@ impl Planner<'_> {
             let tmp = self.fresh_var(Some("left"));
             self.declare(&tmp);
             target_capture.push(define(tmp.clone(), target_place.clone()));
-            tmp
+            GoExpression::name(tmp)
         });
-        let parenthesize_rhs =
-            pinned_left.is_some() && matches!(rhs.unwrap_parens(), Expression::Binary { .. });
-        let mut right_hand_side = right_hand_side.map_expression(|_, staged_value| {
-            if parenthesize_rhs {
-                GoExpression::parenthesized(staged_value)
-            } else {
-                staged_value
-            }
-        });
-        if parenthesize_rhs {
-            right_hand_side.make_observable_computed();
-        }
         let kind = CompoundKind::OpAssign {
             op_text: format!("{}", op),
-            rhs: right_hand_side,
+            rhs: Box::new(right_hand_side),
             pinned_left,
         };
         AssignForm::Compound {
@@ -203,7 +191,7 @@ impl Planner<'_> {
             } => {
                 let base = if let Some(inner) = expression.deref_inner() {
                     let inner = self.capture_operand_into(setup, inner);
-                    GoExpression::parenthesized(GoExpression::dereference(inner))
+                    GoExpression::dereference(inner)
                 } else {
                     self.capture_operand_into(setup, expression)
                 };
@@ -349,7 +337,7 @@ impl Planner<'_> {
     ) -> GoExpression {
         if let Some(inner) = base.deref_inner() {
             let inner = self.capture_assignment_operand(setup, inner, "base", right_hand_side);
-            GoExpression::parenthesized(GoExpression::dereference(inner))
+            GoExpression::dereference(inner)
         } else {
             self.capture_assignment_operand(setup, base, "base", right_hand_side)
         }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -327,7 +327,11 @@ impl Planner<'_> {
             &GoExpression::name(name.to_string()),
             Some(binding_ty),
         ));
-        collapse_declared_temp(&mut statements, name);
+        collapse_declared_temp(
+            &mut statements,
+            name,
+            self.short_declaration_keeps_type(binding_ty),
+        );
         statements
     }
 

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::plan::values::GoExpression;
 use syntax::ast::{Expression, Literal};
 use syntax::program::{DotAccessKind, ReceiverCoercion};
 use syntax::types::Type;
@@ -9,14 +8,6 @@ macro_rules! write_line {
     };
 }
 pub(crate) use write_line;
-
-pub(crate) fn wrap_if_struct_literal(condition: GoExpression) -> GoExpression {
-    if condition.as_str().contains('{') {
-        GoExpression::parenthesized(condition)
-    } else {
-        condition
-    }
-}
 
 pub(crate) fn receiver_name(type_name: &str) -> String {
     type_name

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -9012,7 +9012,7 @@ fn assert_bare_predicate_parenthesizes_a_struct_literal() {
     );
 
     assert!(
-        go.contains("if (!Point{"),
+        go.contains("if !(Point{"),
         "a condition opening with a composite literal must be parenthesized, got:\n{go}"
     );
 }

--- a/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
+++ b/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
@@ -33,9 +33,7 @@ func primeCache(bar Bar[int]) {
 }
 
 func cachedCollision(bar Bar[int]) {
-	_lisAdapter_Bar_Box_1 := 1
 	consume(_lisAdapter_Bar_Box_2{inner: bar})
-	_ = _lisAdapter_Bar_Box_1
 }
 
 func main() {

--- a/tests/spec/build/snapshots/generated_import_qualifier_locals_renamed.snap
+++ b/tests/spec/build/snapshots/generated_import_qualifier_locals_renamed.snap
@@ -14,9 +14,7 @@ func show(fmt_ int) string {
 }
 
 func main() {
-	strings_ := 1
 	ok := strings.Contains("abc", "a")
-	_ = strings_
 	_ = ok
 	_ = show(2)
 }

--- a/tests/spec/build/snapshots/go_option_unwrap_temp_var_no_collision.snap
+++ b/tests/spec/build/snapshots/go_option_unwrap_temp_var_no_collision.snap
@@ -23,7 +23,5 @@ func main() {
 	} else {
 		req = lisette.MakeResultOk[*http.Request, error](ret_1)
 	}
-	unwrap_2 := 7
-	_ = unwrap_2
 	fmt.Println(req)
 }

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -476,9 +476,8 @@ fn third_party_go_import_path_emitted_in_full() {
     let input = r#"
 import "go:github.com/bwmarrin/discordgo"
 
-fn test() {
-  let s = discordgo.Session{}
-  let _ = s
+fn session() -> discordgo.Session {
+  discordgo.Session{}
 }
 "#;
     let typedef = r#"

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -888,9 +888,9 @@ fn main() {
 #[test]
 fn interop_slice_literal_option_import() {
     let input = r#"
-fn main() {
+fn empty() -> Slice<Option<int>> {
   let xs: Slice<Option<int>> = []
-  let _ = xs
+  xs
 }
 "#;
     assert_emit_snapshot!(input);
@@ -918,9 +918,8 @@ fn interop_package_const_aliased_import() {
     let input = r#"
 import t "go:time"
 
-fn main() {
-  let d = t.Second
-  let _ = d
+fn second() -> t.Duration {
+  t.Second
 }
 "#;
     assert_emit_snapshot!(input);
@@ -944,9 +943,8 @@ fn interop_package_const_nested_package() {
     let input = r#"
 import "go:debug/dwarf"
 
-fn main() {
-  let t = dwarf.TagArrayType
-  let _ = t
+fn tag() -> dwarf.Tag {
+  dwarf.TagArrayType
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -1882,3 +1882,18 @@ fn classify(n: int) -> string {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn match_one_arm_float_result_declares_with_short_form() {
+    let input = r#"
+struct Pair(float64, float64)
+
+fn area(p: Pair) -> float64 {
+  let a = match p {
+    Pair(x, y) => x * y,
+  };
+  a
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/auto_address_parenthesized_function_call_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_parenthesized_function_call_receiver.snap
@@ -33,6 +33,6 @@ func makeFoo() Foo {
 }
 
 func test() {
-	ref_1 := (makeFoo())
+	ref_1 := makeFoo()
 	ref_1.increment()
 }

--- a/tests/spec/emit/snapshots/auto_address_parenthesized_struct_literal_receiver.snap
+++ b/tests/spec/emit/snapshots/auto_address_parenthesized_struct_literal_receiver.snap
@@ -25,5 +25,5 @@ func (f *Foo) increment() {
 }
 
 func test() {
-	(&(Foo{value: 42})).increment()
+	(&Foo{value: 42}).increment()
 }

--- a/tests/spec/emit/snapshots/auto_address_receiver_ref_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/auto_address_receiver_ref_temp_var_no_collision.snap
@@ -40,7 +40,5 @@ func makeBox() Box {
 func main() {
 	ref_1 := makeBox()
 	v := ref_1.inc()
-	ref_1_2 := 7
 	_ = v
-	_ = ref_1_2
 }

--- a/tests/spec/emit/snapshots/boolean_branch_assign_collapses_to_condition.snap
+++ b/tests/spec/emit/snapshots/boolean_branch_assign_collapses_to_condition.snap
@@ -14,7 +14,7 @@ package main
 
 func test(a, b int) bool {
 	direct := a > 0
-	and_arm := (a > 0) && (b > 1)
+	and_arm := a > 0 && b > 1
 	or_arm := a > 0 || b > 1
 	negated := !(a > 0)
 	return direct && and_arm && or_arm && negated

--- a/tests/spec/emit/snapshots/boolean_match_assign_collapses_to_condition.snap
+++ b/tests/spec/emit/snapshots/boolean_match_assign_collapses_to_condition.snap
@@ -38,6 +38,6 @@ type Node struct {
 }
 
 func test(node Node) bool {
-	matched := (node.Tag == NodeNumber) && (node.Number == 42)
+	matched := node.Tag == NodeNumber && node.Number == 42
 	return matched
 }

--- a/tests/spec/emit/snapshots/cast_nested_shift_to_float_pins_integer_type.snap
+++ b/tests/spec/emit/snapshots/cast_nested_shift_to_float_pins_integer_type.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func scale(level int) float64 {
-	return float64(int((2 << level) + 3))
+	return float64(int(2<<level + 3))
 }

--- a/tests/spec/emit/snapshots/complex_pattern_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/complex_pattern_temp_no_collision.snap
@@ -17,12 +17,6 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func main() {
 	tmp_1 := lisette.MakeTuple2[int, lisette.Tuple2[int, int]](1, lisette.MakeTuple2[int, int](2, 3))
-	a := tmp_1.First
-	b := tmp_1.Second.First
 	c := tmp_1.Second.Second
-	tmp_1_2 := 7
-	_ = a
-	_ = b
 	_ = c
-	_ = tmp_1_2
 }

--- a/tests/spec/emit/snapshots/declare_result_var_tracked_as_declared.snap
+++ b/tests/spec/emit/snapshots/declare_result_var_tracked_as_declared.snap
@@ -18,6 +18,4 @@ func main() {
 		tmp_1 = 2
 	}
 	_ = tmp_1
-	tmp_1_2 := 3
-	_ = tmp_1_2
 }

--- a/tests/spec/emit/snapshots/deref_then_slice.snap
+++ b/tests/spec/emit/snapshots/deref_then_slice.snap
@@ -9,6 +9,6 @@ description: |
 package main
 
 func rest(items *[]int) []int {
-	len_1 := len((*items))
+	len_1 := len(*items)
 	return (*items)[1:len_1:len_1]
 }

--- a/tests/spec/emit/snapshots/diverging_if_shadowed_else_binding_does_not_leak.snap
+++ b/tests/spec/emit/snapshots/diverging_if_shadowed_else_binding_does_not_leak.snap
@@ -20,7 +20,5 @@ func test(c bool) int {
 	if c {
 		return 0
 	}
-	count_1 := 5
-	_ = count_1
 	return count
 }

--- a/tests/spec/emit/snapshots/emit_or_capture_no_collision_with_user_vars.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_no_collision_with_user_vars.snap
@@ -18,7 +18,7 @@ import "fmt"
 
 func main() {
 	bound_0 := 10
-	bound_1 := (1 + 2)
+	bound_1 := 1 + 2
 	for i := range bound_1 {
 		fmt.Println(i)
 	}

--- a/tests/spec/emit/snapshots/emit_or_capture_range_loop_bound_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_loop_bound_temp_no_collision.snap
@@ -26,7 +26,5 @@ func main() {
 	for i := range bound_1 {
 		sum += i
 	}
-	bound_1_2 := 7
 	_ = sum
-	_ = bound_1_2
 }

--- a/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
@@ -27,7 +27,5 @@ func main() {
 	s := []int{1, 2, 3}
 	range_1 := makeRange()
 	sub := s[range_1.Start:range_1.End:range_1.End]
-	range_1_2 := 7
 	_ = sub
-	_ = range_1_2
 }

--- a/tests/spec/emit/snapshots/enum_layout_keeps_value_function_and_recursive_fields_distinct.snap
+++ b/tests/spec/emit/snapshots/enum_layout_keeps_value_function_and_recursive_fields_distinct.snap
@@ -57,7 +57,7 @@ func read(node Node) int {
 	case NodeCallback:
 		return node.Callback()
 	default:
-		return read((*node.Child))
+		return read(*node.Child)
 	}
 }
 

--- a/tests/spec/emit/snapshots/equality_indirect_recursive_enum_through_struct.snap
+++ b/tests/spec/emit/snapshots/equality_indirect_recursive_enum_through_struct.snap
@@ -42,7 +42,7 @@ func (t Tree) equals(other Tree) bool {
 	}
 	switch t.Tag {
 	case TreeNode:
-		return (*t.Node).equals((*other.Node))
+		return (*t.Node).equals(*other.Node)
 	default:
 		return true
 	}

--- a/tests/spec/emit/snapshots/equality_mutually_recursive_enums_deref_pointer_payloads.snap
+++ b/tests/spec/emit/snapshots/equality_mutually_recursive_enums_deref_pointer_payloads.snap
@@ -45,7 +45,7 @@ func (a A) equals(other A) bool {
 	}
 	switch a.Tag {
 	case AX:
-		return (*a.X).equals((*other.X))
+		return (*a.X).equals(*other.X)
 	default:
 		return true
 	}
@@ -68,7 +68,7 @@ func (b B) equals(other B) bool {
 	}
 	switch b.Tag {
 	case BY:
-		return (*b.Y).equals((*other.Y))
+		return (*b.Y).equals(*other.Y)
 	default:
 		return true
 	}

--- a/tests/spec/emit/snapshots/equality_recursive_enum_derefs_pointer_payload.snap
+++ b/tests/spec/emit/snapshots/equality_recursive_enum_derefs_pointer_payload.snap
@@ -37,7 +37,7 @@ func (l List) equals(other List) bool {
 	}
 	switch l.Tag {
 	case ListCons:
-		return l.Cons0 == other.Cons0 && (*l.Cons1).equals((*other.Cons1))
+		return l.Cons0 == other.Cons0 && (*l.Cons1).equals(*other.Cons1)
 	default:
 		return true
 	}

--- a/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
+++ b/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
@@ -22,10 +22,8 @@ func main() {
 	count := 0
 	s_1 := s
 	for i_2 := 0; i_2 < len(s_1); i_2++ {
-		b := s_1[i_2]
 		count++
 		s = ""
-		_ = b
 	}
 	if count != 2 {
 		panic("expected count 2 — bytes loop must iterate over the original string")

--- a/tests/spec/emit/snapshots/for_enumerate_complex_value_unused.snap
+++ b/tests/spec/emit/snapshots/for_enumerate_complex_value_unused.snap
@@ -23,8 +23,7 @@ func test() int {
 	sum := 0
 	for key_1, value_2 := range items {
 		_ = value_2
-		i := key_1
-		sum += i
+		sum += key_1
 	}
 	return sum
 }

--- a/tests/spec/emit/snapshots/generic_call_types_a_negated_literal.snap
+++ b/tests/spec/emit/snapshots/generic_call_types_a_negated_literal.snap
@@ -17,7 +17,7 @@ func ident[T any](v T) T {
 }
 
 func test() float64 {
-	var parenthesized float64 = -(1)
-	negated := ident(float64(-(1)))
+	var parenthesized float64 = -1
+	negated := ident(float64(-1))
 	return parenthesized/2.0 + negated/2.0
 }

--- a/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	f := (strconv.Atoi)
+	f := strconv.Atoi
 	ret_1, ret_2 := f("1")
 	var r lisette.Result[int, error]
 	if ret_2 != nil {

--- a/tests/spec/emit/snapshots/go_multi_return_tuple_destructuring_shadow.snap
+++ b/tests/spec/emit/snapshots/go_multi_return_tuple_destructuring_shadow.snap
@@ -19,8 +19,6 @@ import (
 )
 
 func main() {
-	x := "hi"
-	_ = x
 	x_1, y := math.Modf(1.25)
 	_ = lisette.MakeTuple2[float64, float64](x_1, y)
 }

--- a/tests/spec/emit/snapshots/if_let_header_parenthesizes_a_nested_generic_receiver.snap
+++ b/tests/spec/emit/snapshots/if_let_header_parenthesizes_a_nested_generic_receiver.snap
@@ -23,7 +23,7 @@ func (b Box[T]) parse() (int, bool) {
 }
 
 func eight() int {
-	if v, ok := (Box[[]int]{v: []int{1}}.parse()); ok {
+	if v, ok := (Box[[]int]{v: []int{1}}).parse(); ok {
 		return v
 	} else {
 		return 0

--- a/tests/spec/emit/snapshots/if_struct_literal_in_condition.snap
+++ b/tests/spec/emit/snapshots/if_struct_literal_in_condition.snap
@@ -31,7 +31,7 @@ func test() int {
 	if (Point{
 		x: 1,
 		y: 2,
-	}.sum() > 0) {
+	}).sum() > 0 {
 		return 1
 	}
 	return 0

--- a/tests/spec/emit/snapshots/interop_array_of_pointer_options_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_array_of_pointer_options_bridges_go_field_round_trip.snap
@@ -38,6 +38,4 @@ func main() {
 			wrapped_5[i_6] = lisette.MakeOptionNone[int]()
 		}
 	}
-	roundtrip := wrapped_5
-	_ = roundtrip
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_tuple_nested_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_tuple_nested_option_slot.snap
@@ -54,8 +54,6 @@ func main() {
 	})
 	tup_11 := lisette.MakeTuple2(ret_9, ret_10)
 	xs := tup_11.First
-	n := tup_11.Second
-	_ = n
 	if xs.Tag == lisette.OptionSome {
 		for _, x := range xs.SomeVal {
 			_ = x

--- a/tests/spec/emit/snapshots/interop_lisette_tuple_nested_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_tuple_nested_option_slot.snap
@@ -31,8 +31,6 @@ func main() {
 	ret_1, ret_2 := make_()
 	t := lisette.MakeTuple2(ret_1, ret_2)
 	xs := t.First
-	n := t.Second
-	_ = n
 	if xs.Tag == lisette.OptionSome {
 		for _, x := range xs.SomeVal {
 			_ = x

--- a/tests/spec/emit/snapshots/interop_map_with_pointer_option_keys_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_map_with_pointer_option_keys_bridges_go_field_round_trip.snap
@@ -39,6 +39,4 @@ func main() {
 		option_9 := lisette.OptionFromPointer[int](i_7)
 		wrapped_6[option_9] = v_8
 	}
-	roundtrip := wrapped_6
-	_ = roundtrip
 }

--- a/tests/spec/emit/snapshots/interop_nested_option_collections_bridge_go_returns.snap
+++ b/tests/spec/emit/snapshots/interop_nested_option_collections_bridge_go_returns.snap
@@ -28,7 +28,6 @@ func main() {
 			wrapped_2[i_3] = lisette.MakeOptionNone[int]()
 		}
 	}
-	values := wrapped_2
 	ret_5, ret_6 := nested.MaybeValues()
 	var maybe_values lisette.Option[[]lisette.Option[int]]
 	if ret_6 {
@@ -44,6 +43,5 @@ func main() {
 	} else {
 		maybe_values = lisette.MakeOptionNone[[]lisette.Option[int]]()
 	}
-	_ = values
 	_ = maybe_values
 }

--- a/tests/spec/emit/snapshots/interop_package_const_aliased_import.snap
+++ b/tests/spec/emit/snapshots/interop_package_const_aliased_import.snap
@@ -4,16 +4,14 @@ description: |
   
   import t "go:time"
   
-  fn main() {
-    let d = t.Second
-    let _ = d
+  fn second() -> t.Duration {
+    t.Second
   }
 ---
 package main
 
 import t "time"
 
-func main() {
-	d := t.Second
-	_ = d
+func second() t.Duration {
+	return t.Second
 }

--- a/tests/spec/emit/snapshots/interop_package_const_nested_package.snap
+++ b/tests/spec/emit/snapshots/interop_package_const_nested_package.snap
@@ -4,16 +4,14 @@ description: |
   
   import "go:debug/dwarf"
   
-  fn main() {
-    let t = dwarf.TagArrayType
-    let _ = t
+  fn tag() -> dwarf.Tag {
+    dwarf.TagArrayType
   }
 ---
 package main
 
 import "debug/dwarf"
 
-func main() {
-	t := dwarf.TagArrayType
-	_ = t
+func tag() dwarf.Tag {
+	return dwarf.TagArrayType
 }

--- a/tests/spec/emit/snapshots/interop_slice_literal_option_import.snap
+++ b/tests/spec/emit/snapshots/interop_slice_literal_option_import.snap
@@ -2,16 +2,16 @@
 source: tests/spec/emit/interop_matrix.rs
 description: |
   
-  fn main() {
+  fn empty() -> Slice<Option<int>> {
     let xs: Slice<Option<int>> = []
-    let _ = xs
+    xs
   }
 ---
 package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-func main() {
+func empty() []lisette.Option[int] {
 	xs := []lisette.Option[int]{}
-	_ = xs
+	return xs
 }

--- a/tests/spec/emit/snapshots/let_bind_unit_returning_call.snap
+++ b/tests/spec/emit/snapshots/let_bind_unit_returning_call.snap
@@ -15,6 +15,4 @@ func doNothing() {}
 
 func test() {
 	doNothing()
-	r := struct{}{}
-	_ = r
 }

--- a/tests/spec/emit/snapshots/let_binding_parenthesized_unit_call.snap
+++ b/tests/spec/emit/snapshots/let_binding_parenthesized_unit_call.snap
@@ -14,7 +14,5 @@ package main
 func noop() {}
 
 func main() {
-	(noop())
-	x := struct{}{}
-	_ = x
+	noop()
 }

--- a/tests/spec/emit/snapshots/let_discard_parenthesized_unit_call.snap
+++ b/tests/spec/emit/snapshots/let_discard_parenthesized_unit_call.snap
@@ -13,5 +13,5 @@ package main
 func noop() {}
 
 func main() {
-	(noop())
+	noop()
 }

--- a/tests/spec/emit/snapshots/let_else_subject_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/let_else_subject_temp_no_collision.snap
@@ -19,8 +19,4 @@ func main() {
 	if opt.Tag != lisette.OptionSome {
 		return
 	}
-	x := opt.SomeVal
-	subject_1 := 7
-	_ = x
-	_ = subject_1
 }

--- a/tests/spec/emit/snapshots/let_else_with_break.snap
+++ b/tests/spec/emit/snapshots/let_else_with_break.snap
@@ -18,7 +18,5 @@ func test(opt lisette.Option[int]) {
 		if opt.Tag != lisette.OptionSome {
 			break
 		}
-		x := opt.SomeVal
-		_ = x
 	}
 }

--- a/tests/spec/emit/snapshots/let_else_with_continue.snap
+++ b/tests/spec/emit/snapshots/let_else_with_continue.snap
@@ -18,7 +18,5 @@ func test(items []lisette.Option[int]) {
 		if item.Tag != lisette.OptionSome {
 			continue
 		}
-		x := item.SomeVal
-		_ = x
 	}
 }

--- a/tests/spec/emit/snapshots/let_unit_call_shadow.snap
+++ b/tests/spec/emit/snapshots/let_unit_call_shadow.snap
@@ -17,9 +17,5 @@ func foo() {}
 
 func main() {
 	foo()
-	x := struct{}{}
-	_ = x
 	foo()
-	x_1 := struct{}{}
-	_ = x_1
 }

--- a/tests/spec/emit/snapshots/match_guard_struct_literal.snap
+++ b/tests/spec/emit/snapshots/match_guard_struct_literal.snap
@@ -26,7 +26,7 @@ func main() {
 	}
 match_1:
 	for {
-		if (p == Point{
+		if p == (Point{
 			x: 1,
 			y: 2,
 		}) {

--- a/tests/spec/emit/snapshots/match_one_arm_float_result_declares_with_short_form.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_float_result_declares_with_short_form.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Pair(float64, float64)
+  
+  fn area(p: Pair) -> float64 {
+    let a = match p {
+      Pair(x, y) => x * y,
+    };
+    a
+  }
+---
+package main
+
+type Pair struct {
+	F0 float64
+	F1 float64
+}
+
+func area(p Pair) float64 {
+	a := p.F0 * p.F1
+	return a
+}

--- a/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
@@ -21,6 +21,4 @@ func main() {
 	if opt.Tag == lisette.OptionSome {
 		_ = opt.SomeVal
 	}
-	subject_1 := 7
-	_ = subject_1
 }

--- a/tests/spec/emit/snapshots/mutable_subslice_cloned.snap
+++ b/tests/spec/emit/snapshots/mutable_subslice_cloned.snap
@@ -14,8 +14,6 @@ package main
 import "slices"
 
 func test(arr []int) {
-	view := arr[1:4:4]
 	owned := slices.Clone(arr[1:4:4])
 	owned[0] = 99
-	_ = view
 }

--- a/tests/spec/emit/snapshots/negated_float_equality_flips.snap
+++ b/tests/spec/emit/snapshots/negated_float_equality_flips.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test(a, b float64) bool {
-	return (a != b)
+	return a != b
 }

--- a/tests/spec/emit/snapshots/negated_int_comparison_flips.snap
+++ b/tests/spec/emit/snapshots/negated_int_comparison_flips.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test(a, b int, s, t string) bool {
-	return (a >= b) && (s >= t)
+	return a >= b && s >= t
 }

--- a/tests/spec/emit/snapshots/nested_block_return_in_assignment_rhs.snap
+++ b/tests/spec/emit/snapshots/nested_block_return_in_assignment_rhs.snap
@@ -12,12 +12,10 @@ description: |
 package main
 
 func test() int {
-	x := 0
 	{
 		{
 			return 1
 		}
 	}
-	_ = x
 	return 2
 }

--- a/tests/spec/emit/snapshots/or_pattern_booleans.snap
+++ b/tests/spec/emit/snapshots/or_pattern_booleans.snap
@@ -12,7 +12,7 @@ description: |
 package main
 
 func test(a, b bool) string {
-	if (a && b) || (!a && !b) {
+	if a && b || !a && !b {
 		return "same"
 	}
 	return "different"

--- a/tests/spec/emit/snapshots/or_pattern_in_while_let.snap
+++ b/tests/spec/emit/snapshots/or_pattern_in_while_let.snap
@@ -20,7 +20,7 @@ func test(opt lisette.Option[int]) int {
 	current := opt
 	sum := 0
 	for {
-		if (current.Tag == lisette.OptionSome && current.SomeVal == 1) || (current.Tag == lisette.OptionSome && current.SomeVal == 2) || (current.Tag == lisette.OptionSome && current.SomeVal == 3) {
+		if current.Tag == lisette.OptionSome && current.SomeVal == 1 || current.Tag == lisette.OptionSome && current.SomeVal == 2 || current.Tag == lisette.OptionSome && current.SomeVal == 3 {
 			sum++
 			current = lisette.MakeOptionNone[int]()
 		} else {

--- a/tests/spec/emit/snapshots/or_pattern_let_else_binding_shadowing.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_binding_shadowing.snap
@@ -30,6 +30,4 @@ func main() {
 		return
 	}
 	_ = x
-	x_2 := 2
-	_ = x_2
 }

--- a/tests/spec/emit/snapshots/propagation_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/propagation_result_temp_var_no_collision.snap
@@ -23,8 +23,6 @@ func foo() lisette.Result[int, string] {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
 	y := check_1.OkVal + 1
-	result_2 := 7
-	_ = result_2
 	return lisette.MakeResultOk[int, string](y)
 }
 

--- a/tests/spec/emit/snapshots/recover_block_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recover_block_result_temp_var_no_collision.snap
@@ -17,7 +17,5 @@ func main() {
 	result := lisette.RecoverBlock(func() int {
 		return 1
 	})
-	recoverResult_1_2 := 7
-	_ = recoverResult_1_2
 	_ = result
 }

--- a/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
@@ -39,7 +39,7 @@ type List struct {
 
 func listSum(l List) int {
 	if l.Tag == ListCons {
-		return l.Cons0 + listSum((*l.Cons1))
+		return l.Cons0 + listSum(*l.Cons1)
 	}
 	return 0
 }

--- a/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
@@ -43,5 +43,5 @@ func countLeaves[T any](tree Tree[T]) int {
 		return 1
 	}
 	right := *tree.Right
-	return countLeaves((*tree.Left)) + countLeaves(right)
+	return countLeaves(*tree.Left) + countLeaves(right)
 }

--- a/tests/spec/emit/snapshots/reference_nested_parens_no_hoist.snap
+++ b/tests/spec/emit/snapshots/reference_nested_parens_no_hoist.snap
@@ -26,6 +26,6 @@ func (s *S) inc() {
 
 func main() {
 	s := S{x: 1}
-	r := &(s)
+	r := &s
 	r.inc()
 }

--- a/tests/spec/emit/snapshots/select_send_hoisted_temp_no_redeclare.snap
+++ b/tests/spec/emit/snapshots/select_send_hoisted_temp_no_redeclare.snap
@@ -31,6 +31,4 @@ func main() {
 	case ref_1 <- 1:
 	default:
 	}
-	ref_1_2 := 2
-	_ = ref_1_2
 }

--- a/tests/spec/emit/snapshots/slice_append_parenthesized_receiver.snap
+++ b/tests/spec/emit/snapshots/slice_append_parenthesized_receiver.snap
@@ -12,6 +12,6 @@ package main
 
 func main() {
 	s := []int{1}
-	s = append((s), 2)
+	s = append(s, 2)
 	_ = s
 }

--- a/tests/spec/emit/snapshots/struct_literal_receiver_in_an_if_header.snap
+++ b/tests/spec/emit/snapshots/struct_literal_receiver_in_an_if_header.snap
@@ -30,7 +30,7 @@ func (p Parser) parse() (int, error) {
 }
 
 func main() {
-	if n, err := (Parser{src: "ab"}.parse()); err == nil {
+	if n, err := (Parser{src: "ab"}).parse(); err == nil {
 		fmt.Println(n)
 	} else {
 		fmt.Println(err)

--- a/tests/spec/emit/snapshots/third_party_go_import_path_emitted_in_full.snap
+++ b/tests/spec/emit/snapshots/third_party_go_import_path_emitted_in_full.snap
@@ -4,16 +4,14 @@ description: |
   
   import "go:github.com/bwmarrin/discordgo"
   
-  fn test() {
-    let s = discordgo.Session{}
-    let _ = s
+  fn session() -> discordgo.Session {
+    discordgo.Session{}
   }
 ---
 package main
 
 import "github.com/bwmarrin/discordgo"
 
-func test() {
-	s := discordgo.Session{}
-	_ = s
+func session() discordgo.Session {
+	return discordgo.Session{}
 }

--- a/tests/spec/emit/snapshots/try_block_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/try_block_result_temp_var_no_collision.snap
@@ -28,8 +28,6 @@ func foo() lisette.Result[int, string] {
 		return lisette.MakeResultOk[int, any](check_2.OkVal)
 	}()
 	_ = tryResult_1
-	tryResult_1_3 := 7
-	_ = tryResult_1_3
 	return lisette.MakeResultOk[int, string](0)
 }
 

--- a/tests/spec/emit/snapshots/unary_not_skips_operator_text_inside_string_literal.snap
+++ b/tests/spec/emit/snapshots/unary_not_skips_operator_text_inside_string_literal.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test(s string) bool {
-	return ("x == y" != s)
+	return "x == y" != s
 }

--- a/tests/spec/emit/snapshots/underscore_prefixed_let_binding.snap
+++ b/tests/spec/emit/snapshots/underscore_prefixed_let_binding.snap
@@ -15,7 +15,5 @@ package main
 import "fmt"
 
 func test() {
-	s := "hello, world"
-	_ = s
 	fmt.Print("Done\n")
 }

--- a/tests/spec/emit/snapshots/unit_call_in_binary_equality.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_binary_equality.snap
@@ -15,6 +15,4 @@ func noop() {}
 
 func test() {
 	noop()
-	b := struct{}{} == struct{}{}
-	_ = b
 }

--- a/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
+++ b/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
@@ -26,7 +26,7 @@ func test() {
 	i := 0
 	for {
 		v_1 := i < 3
-		if !(lisette.MakeTuple2[bool, int](v_1, bump(&i)).First) {
+		if !lisette.MakeTuple2[bool, int](v_1, bump(&i)).First {
 			break
 		}
 		_ = i

--- a/tests/spec/emit/snapshots/while_let_basic.snap
+++ b/tests/spec/emit/snapshots/while_let_basic.snap
@@ -18,9 +18,7 @@ func test(opt lisette.Option[int]) {
 	current := opt
 	for {
 		if current.Tag == lisette.OptionSome {
-			x := current.SomeVal
 			current = lisette.MakeOptionNone[int]()
-			_ = x
 		} else {
 			break
 		}

--- a/tests/spec/emit/snapshots/while_let_result_pattern.snap
+++ b/tests/spec/emit/snapshots/while_let_result_pattern.snap
@@ -18,9 +18,7 @@ func test(res lisette.Result[int, string]) {
 	current := res
 	for {
 		if current.Tag == lisette.ResultOk {
-			value := current.OkVal
 			current = lisette.MakeResultErr[int, string]("done")
-			_ = value
 		} else {
 			break
 		}

--- a/tests/spec/emit/snapshots/while_struct_literal_condition_parenthesized.snap
+++ b/tests/spec/emit/snapshots/while_struct_literal_condition_parenthesized.snap
@@ -21,7 +21,7 @@ func test() {
 	for (Point{
 		x: 1,
 		y: 2,
-	}.x > 0) {
+	}).x > 0 {
 		break
 	}
 }

--- a/tests/spec/emit/snapshots/wrapped_return_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/wrapped_return_temp_no_collision.snap
@@ -15,8 +15,6 @@ description: |
 package main
 
 func foo() (int, bool) {
-	tmp_1 := 7
-	_ = tmp_1
 	if true {
 		return 1, true
 	}


### PR DESCRIPTION
Emitted Go now keeps parens only where Go needs them, and a temp that one statement fills is declared with `:=` in place of `var x T` plus an assignment, while a temp that no statement reads is omitted.

```rs
struct Pair(float64, float64)

fn area(p: Pair) -> float64 {
  let a = match p {
    Pair(x, y) => x * y,
  }
  a
}

fn ready(a: int, b: int) -> bool {
  let both = (a > 0) && (b > 1)
  both
}

fn main() {
  let _ = area(Pair(2.0, 3.0))
  let _ = ready(1, 2)
}
```

Before:

```go
func area(p Pair) float64 {
	var a float64
	a = p.F0 * p.F1
	return a
}

func ready(a, b int) bool {
	both := (a > 0) && (b > 1)
	return both
}
```

After:

```go
func area(p Pair) float64 {
	a := p.F0 * p.F1 // one declaration
	return a
}

func ready(a, b int) bool {
	both := a > 0 && b > 1 // no parens
	return both
}
```
